### PR TITLE
add options to TransactionCreate

### DIFF
--- a/src/endpoints/transactions/entities/transaction.create.ts
+++ b/src/endpoints/transactions/entities/transaction.create.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty } from '@nestjs/swagger';
 
 export class TransactionCreate {
   constructor(init?: Partial<TransactionCreate>) {
@@ -34,4 +34,7 @@ export class TransactionCreate {
 
   @ApiProperty()
   version: number = 0;
+
+  @ApiProperty()
+  options?: number = undefined;
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
While debugging the XOXNO API we discovered that the people using Web Wallet and Ledger were not able to send the signed TX to the blockchain via the API endpoint.

The issue we discovered was that the options field required at the protocol level in order to validate the signature of the Ledger was not sent to the Elrond Proxy. 
  
## Proposed Changes
Add the options field so in case the TX body sent has the options value set this one will be included in the final body.

## How to test
Try to send a TX made via Web Wallet + Ledger and console log the body before is sent to the Elrond Gateway/Proxy
