### PR TITLE
account interactions with one address

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -294,6 +294,14 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withDateRangeFilter('timestamp', filter.before, filter.after);
     }
 
+    if (filter.senderOrReceiver) {
+      elasticQuery = elasticQuery
+        .withMustCondition(QueryType.Should([
+          QueryType.Match('sender', filter.senderOrReceiver),
+          QueryType.Match('receiver', filter.senderOrReceiver),
+        ]));
+    }
+
     return elasticQuery;
   }
 
@@ -457,6 +465,14 @@ export class ElasticIndexerHelper {
       }
 
       elasticQuery = elasticQuery.withMustMultiShouldCondition(keys, key => QueryType.Match(key, address));
+    }
+
+    if (filter.senderOrReceiver) {
+      elasticQuery = elasticQuery
+        .withMustCondition(QueryType.Should([
+          QueryType.Match('sender', filter.senderOrReceiver),
+          QueryType.Match('receiver', filter.senderOrReceiver),
+        ]));
     }
 
     return elasticQuery;

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -218,8 +218,6 @@ export class ElasticIndexerService implements IndexerInterface {
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
 
-    console.log(JSON.stringify(elasticQuery.toJson()));
-
     const elasticOperations = await this.elasticService.getList('operations', 'txHash', elasticQuery);
     return elasticOperations;
   }
@@ -366,8 +364,6 @@ export class ElasticIndexerService implements IndexerInterface {
     const elasticQuery = this.indexerHelper.buildTransactionFilterQuery(filter, address)
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
-
-    console.log(JSON.stringify(elasticQuery.toJson()));
 
     return await this.elasticService.getList('transactions', 'txHash', elasticQuery);
   }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -218,6 +218,8 @@ export class ElasticIndexerService implements IndexerInterface {
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
 
+    console.log(JSON.stringify(elasticQuery.toJson()));
+
     const elasticOperations = await this.elasticService.getList('operations', 'txHash', elasticQuery);
     return elasticOperations;
   }
@@ -364,6 +366,8 @@ export class ElasticIndexerService implements IndexerInterface {
     const elasticQuery = this.indexerHelper.buildTransactionFilterQuery(filter, address)
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
+
+    console.log(JSON.stringify(elasticQuery.toJson()));
 
     return await this.elasticService.getList('transactions', 'txHash', elasticQuery);
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -618,6 +618,7 @@ export class AccountController {
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'computeScamInfo', required: false, type: Boolean })
+  @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   async getAccountTransactions(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -640,6 +641,7 @@ export class AccountController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
 
@@ -657,6 +659,7 @@ export class AccountController {
       before,
       after,
       order,
+      senderOrReceiver
     }), new QueryPagination({ from, size }), options, address);
   }
 
@@ -727,6 +730,7 @@ export class AccountController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   async getAccountTransfers(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -746,6 +750,7 @@ export class AccountController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ): Promise<Transaction[]> {
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
@@ -768,6 +773,7 @@ export class AccountController {
       before,
       after,
       order,
+      senderOrReceiver
     }),
       new QueryPagination({ from, size }),
       options,

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -659,7 +659,7 @@ export class AccountController {
       before,
       after,
       order,
-      senderOrReceiver
+      senderOrReceiver,
     }), new QueryPagination({ from, size }), options, address);
   }
 
@@ -773,7 +773,7 @@ export class AccountController {
       before,
       after,
       order,
-      senderOrReceiver
+      senderOrReceiver,
     }),
       new QueryPagination({ from, size }),
       options,

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -26,4 +26,5 @@ export class TransactionFilter {
   order?: SortOrder;
   type?: TransactionType;
   tokens?: string[];
+  senderOrReceiver?: string;
 }

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -138,4 +138,36 @@ describe('Transaction Service', () => {
     expect(txResults.includes("29a2bed2543197e69c9bf16b30c4b0196f5e7a59584aba2e1a2127bf06cdfd2d")).toBeTruthy();
     expect(txResults.includes("0cbaeb61cd2d901e7363b83e35750d0cbf2045ed853ef8f7af7cefdef622671e")).toBeTruthy();
   });
+
+  it(`should return a list of transfers between two accounts (first address is always sender and seconds adress is always receiver)`, async () => {
+    const sender = 'erd18kmncel8a32yd94ktzlqag9etdrpdnyph8wus2nqyd4lp865gncq40znww';
+    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets'
+    const transactionFilter = new TransactionFilter();
+    transactionFilter.sender = sender;
+    transactionFilter.receivers = [receiver];
+
+    const transfers = await transactionService.getTransactions(transactionFilter, { from: 0, size: 25 }, new TransactionQueryOptions());
+    expect(transfers.length).toBeGreaterThan(0);
+
+    for (const transfer of transfers) {
+      expect(transfer.sender).toBe(sender);
+      expect([sender, receiver].includes(transfer.receiver)).toBe(true); //it can be an ESDNFTTransfer which is a self transaction
+    }
+  });
+
+  it(`should return a list of transfers between two accounts`, async () => {
+    const sender = 'erd18kmncel8a32yd94ktzlqag9etdrpdnyph8wus2nqyd4lp865gncq40znww';
+    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets'
+    const transactionFilter = new TransactionFilter();
+    transactionFilter.address = sender;
+    transactionFilter.senderOrReceiver = receiver;
+
+    const transfers = await transactionService.getTransactions(transactionFilter, { from: 0, size: 25 }, new TransactionQueryOptions());
+    expect(transfers.length).toBeGreaterThan(0);
+
+    for (const transfer of transfers) {
+      expect([sender, receiver].includes(transfer.sender)).toBe(true);
+      expect([sender, receiver].includes(transfer.receiver)).toBe(true);
+    }
+  });
 });

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -141,7 +141,7 @@ describe('Transaction Service', () => {
 
   it(`should return a list of transfers between two accounts (first address is always sender and seconds adress is always receiver)`, async () => {
     const sender = 'erd18kmncel8a32yd94ktzlqag9etdrpdnyph8wus2nqyd4lp865gncq40znww';
-    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets'
+    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets';
     const transactionFilter = new TransactionFilter();
     transactionFilter.sender = sender;
     transactionFilter.receivers = [receiver];
@@ -157,7 +157,7 @@ describe('Transaction Service', () => {
 
   it(`should return a list of transfers between two accounts`, async () => {
     const sender = 'erd18kmncel8a32yd94ktzlqag9etdrpdnyph8wus2nqyd4lp865gncq40znww';
-    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets'
+    const receiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets';
     const transactionFilter = new TransactionFilter();
     transactionFilter.address = sender;
     transactionFilter.senderOrReceiver = receiver;

--- a/src/test/integration/services/transfers.e2e-spec.ts
+++ b/src/test/integration/services/transfers.e2e-spec.ts
@@ -6,11 +6,12 @@ import { TransferModule } from 'src/endpoints/transfers/transfer.module';
 import { TransferService } from 'src/endpoints/transfers/transfer.service';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { ApiConfigModule } from 'src/common/api-config/api.config.module';
-import { Transaction } from 'src/endpoints/transactions/entities/transaction';
 import { BinaryUtils, Constants, ElasticQuery, ElasticService } from '@elrondnetwork/erdnest';
 import { TransactionQueryOptions } from 'src/endpoints/transactions/entities/transactions.query.options';
+import '@elrondnetwork/erdnest/lib/src/utils/extensions/jest.extensions';
+import '@elrondnetwork/erdnest/lib/src/utils/extensions/number.extensions';
 
-describe.skip('Transfer Service', () => {
+describe('Transfer Service', () => {
   let transferService: TransferService;
   let apiConfigService: ApiConfigService;
   let transactionSender: string;
@@ -29,9 +30,8 @@ describe.skip('Transfer Service', () => {
     const transfers = await transferService.getTransfers(transactionFilter, { from: 0, size: 1 }, new TransactionQueryOptions());
     expect(transfers).toHaveLength(1);
 
-    const transfer = transfers[0];
-    transactionSender = transfer.sender;
-    transactionReceiver = transfer.receiver;
+    transactionSender = 'erd18kmncel8a32yd94ktzlqag9etdrpdnyph8wus2nqyd4lp865gncq40znww';
+    transactionReceiver = 'erd1sdslvlxvfnnflzj42l8czrcngq3xjjzkjp3rgul4ttk6hntr4qdsv6sets';
 
   }, Constants.oneHour() * 1000);
 
@@ -41,25 +41,17 @@ describe.skip('Transfer Service', () => {
         const transfers = await transferService.getTransfers(new TransactionFilter(), { from: 0, size: 25 }, new TransactionQueryOptions());
 
         expect(transfers).toHaveLength(25);
-
-        for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
-        }
       });
 
       it(`should return a list with 100 transfers`, async () => {
         const transfers = await transferService.getTransfers(new TransactionFilter(), { from: 0, size: 100 }, new TransactionQueryOptions());
 
         expect(transfers).toHaveLength(100);
-
-        for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
-        }
       });
     });
 
     describe('Transfers filters', () => {
-      it(`should return a list of transfers between two accounts`, async () => {
+      it(`should return a list of transfers between two accounts (first address is always sender and seconds adress is always receiver)`, async () => {
         const transactionFilter = new TransactionFilter();
         transactionFilter.sender = transactionSender;
         transactionFilter.receivers = [transactionReceiver];
@@ -68,9 +60,22 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.sender).toBe(transactionSender);
-          expect(transfer.receiver).toBe(transactionReceiver);
+          expect([transactionSender, transactionReceiver].includes(transfer.receiver)).toBe(true); //it can be an ESDNFTTransfer which is a self transaction
+        }
+      });
+
+      it(`should return a list of transfers between two accounts`, async () => {
+        const transactionFilter = new TransactionFilter();
+        transactionFilter.address = transactionSender;
+        transactionFilter.senderOrReceiver = transactionReceiver;
+
+        const transfers = await transferService.getTransfers(transactionFilter, { from: 0, size: 25 }, new TransactionQueryOptions());
+        expect(transfers.length).toBeGreaterThan(0);
+
+        for (const transfer of transfers) {
+          expect([transactionSender, transactionReceiver].includes(transfer.sender)).toBe(true);
+          expect([transactionSender, transactionReceiver].includes(transfer.receiver)).toBe(true);
         }
       });
 
@@ -83,7 +88,6 @@ describe.skip('Transfer Service', () => {
 
         for (const transfer of transfers) {
           expect(transfer.status).toBe(TransactionStatus.pending);
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
         }
       });
 
@@ -96,7 +100,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.timestamp).toBeGreaterThanOrEqual(transactionFilter.after);
           expect(transfer.timestamp).toBeLessThanOrEqual(transactionFilter.before);
         }
@@ -110,7 +113,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.timestamp).toBeGreaterThanOrEqual(transactionFilter.after);
         }
       });
@@ -123,7 +125,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.timestamp).toBeLessThanOrEqual(transactionFilter.before);
         }
       });
@@ -137,7 +138,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.sender === address && transfer.receiver === address).toStrictEqual(true);
         }
 
@@ -155,7 +155,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers).toBeInstanceOf(Array);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.sender === address && transfer.receiver === address).toStrictEqual(true);
         }
       });
@@ -172,7 +171,6 @@ describe.skip('Transfer Service', () => {
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer).toHaveStructure(Object.keys(new Transaction()));
           expect(transfer.sender).toBe(address);
           expect(transfer.timestamp).toBeGreaterThanOrEqual(transactionFilter.after);
           expect(transfer.status).toBe(TransactionStatus.success);
@@ -187,7 +185,6 @@ describe.skip('Transfer Service', () => {
           const transfers = await transferService.getTransfers(transactionFilter, { from: 0, size: 25 }, new TransactionQueryOptions());
 
           for (const transfer of transfers) {
-            expect(transfer).toHaveStructure(Object.keys(new Transaction()));
             expect(BinaryUtils.base64Decode(transfer.data ?? '').startsWith('ESDTNFTTransfer')).toStrictEqual(true);
           }
         }

--- a/src/test/integration/services/transfers.e2e-spec.ts
+++ b/src/test/integration/services/transfers.e2e-spec.ts
@@ -61,7 +61,7 @@ describe('Transfer Service', () => {
 
         for (const transfer of transfers) {
           expect(transfer.sender).toBe(transactionSender);
-          expect([transactionSender, transactionReceiver].includes(transfer.receiver)).toBe(true); //it can be an ESDNFTTransfer which is a self transaction
+          expect(transfer.receiver).toBe(transactionReceiver);
         }
       });
 
@@ -132,20 +132,18 @@ describe('Transfer Service', () => {
       it(`should return transfers for an address`, async () => {
         const address = transactionSender;
         const transactionFilter = new TransactionFilter();
+        transactionFilter.address = address;
 
         const transfers = await transferService.getTransfers(transactionFilter, { from: 0, size: 25 }, new TransactionQueryOptions());
         expect(transfers).toBeInstanceOf(Array);
         expect(transfers.length).toBeGreaterThan(0);
 
         for (const transfer of transfers) {
-          expect(transfer.sender === address && transfer.receiver === address).toStrictEqual(true);
+          expect(transfer.sender === address || transfer.receiver === address).toStrictEqual(true);
         }
-
-        const accountTransactionsList = await transferService.getTransfers(new TransactionFilter(), { from: 0, size: 25 }, new TransactionQueryOptions());
-        expect(transfers).toEqual(accountTransactionsList);
       });
 
-      it(`should return transfers for an address with self transactions`, async () => {
+      it(`should return self transfers for an address`, async () => {
         const address = transactionSender;
         const transactionFilter = new TransactionFilter();
         transactionFilter.sender = address;


### PR DESCRIPTION
## Reasoning
- Right now, there is no possibility to fetch the interactions between one account and another
  
## Proposed Changes
- Add senderOrReceiver query parameter for /accounts/:address/transfers & /accounts/:address/transactions endpoints
- Add senderOrReceiver property to transactions/transfers filter

## How to test
- Check if /accounts/:a1/transfers?senderOrReceiver=a2, return only the transactions between a1 and a2, same thing for accounts/:a1/transactions?senderOrReceiver=a2
