### PR TITLE
Auth setting allow native auth tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,12 +2471,13 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.13.tgz",
-      "integrity": "sha512-eT9/pxI17NFj2NbNoSoIVwSLpDDaSSGfDMM5qQsbYfhlxFpjWs2r2SSV/dH+udLiT2DeGfodwJG3kkpreLQh/g==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.19.tgz",
+      "integrity": "sha512-Hf/IfWyEBYSfy420gLnR61IlheeoxXSetcGgQkxSeMtVA64rH3anFlRmYHTJ+CPsb2VgqOdgcBFhR5O0piCwXA==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-nestjs. Use @multiversx/sdk-nestjs instead.",
       "dependencies": {
-        "@elrondnetwork/native-auth-client": "^0.1.0",
-        "@elrondnetwork/native-auth-server": "^0.1.1",
+        "@elrondnetwork/native-auth-client": "^0.1.4",
+        "@elrondnetwork/native-auth-server": "^0.1.9",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@types/redis": "^2.8.32",
         "agentkeepalive": "^4.2.1",
@@ -2603,9 +2604,10 @@
       }
     },
     "node_modules/@elrondnetwork/native-auth-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-client/-/native-auth-client-0.1.0.tgz",
-      "integrity": "sha512-LWHpn9SFmiLGBQZ2dqXHCJu5ZHJ/PU87nxG4BokrdcW/Vu6kZq1joNk1kUfGGzr56IIE1kuJjfvh8F0Vmtynxw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-client/-/native-auth-client-0.1.5.tgz",
+      "integrity": "sha512-9CmJj3XSd/nWwdGOasFhk8ttPfQlb0UKZVLL2S8xvs7x550mFOh4MNsvI3IuqTDsf1/bUhhSIfv7jyX/ztLy0g==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-native-auth-client. Use @multiversx/sdk-native-auth-client instead.",
       "dependencies": {
         "axios": "^0.27.2"
       }
@@ -2633,9 +2635,10 @@
       }
     },
     "node_modules/@elrondnetwork/native-auth-server": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-server/-/native-auth-server-0.1.1.tgz",
-      "integrity": "sha512-mv2elF7lO/Lr8FlGS2DvRtsqDr3APqOWtPxQgEGIVVUPUUpFnycWaQUAQmPuaGl1P8u8GBmPkhoFAoCD8lMn/w==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-server/-/native-auth-server-0.1.10.tgz",
+      "integrity": "sha512-DS5jtzf+h9Nemin76fQUBu+9C6UGSPhJUjp0oViPMbT6FAu0w0cFFEOtI0ZG4u2IJ2vnaZ1TSHs2iqknP/uLDQ==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-native-auth-server. Use @multiversx/sdk-native-auth-server instead.",
       "dependencies": {
         "@elrondnetwork/erdjs": "^10.2.7",
         "@elrondnetwork/erdjs-walletcore": "^1.0.0",
@@ -2647,6 +2650,7 @@
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs/-/erdjs-10.2.8.tgz",
       "integrity": "sha512-WOT8J8jhodIiDcjnQjrzsB/2cCq1qigoGp+CloYqOeweL50SWMNN+9QTB2GzoqwAPRBGuZONSs7SYBVNElnhTA==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-core. Use @multiversx/sdk-core instead.",
       "dependencies": {
         "@elrondnetwork/transaction-decoder": "0.1.0",
         "bech32": "1.1.4",
@@ -2662,6 +2666,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-walletcore/-/erdjs-walletcore-1.0.0.tgz",
       "integrity": "sha512-I+N7rwBs4p9bX6d2Rd9Ck6uwCOsgafDzL9aAaFqwh3NnmEI7JGrXPvFoZxDTOQ9pyd2J9jk4dXS6GAImjd3R8g==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-wallet. Use @multiversx/sdk-wallet instead.",
       "dependencies": {
         "@elrondnetwork/bls-wasm": "0.3.3",
         "bech32": "1.1.4",
@@ -2701,6 +2706,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-0.1.0.tgz",
       "integrity": "sha512-R9YSiJCAgdlSzTKBy7/KjohFghmUhZIGDqWt6NGXrf33EN24QB15Q0LgHEW7lXsqsDSF5GpRYetsS7V3jYZQOg==",
+      "deprecated": "WARNING: This project has been moved to @multiversx/sdk-transaction-decoder. Use @multiversx/sdk-transaction-decoder instead.",
       "dependencies": {
         "bech32": "^2.0.0"
       }
@@ -2741,9 +2747,9 @@
       }
     },
     "node_modules/@elrondnetwork/native-auth-server/node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -17382,12 +17388,12 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.13.tgz",
-      "integrity": "sha512-eT9/pxI17NFj2NbNoSoIVwSLpDDaSSGfDMM5qQsbYfhlxFpjWs2r2SSV/dH+udLiT2DeGfodwJG3kkpreLQh/g==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.19.tgz",
+      "integrity": "sha512-Hf/IfWyEBYSfy420gLnR61IlheeoxXSetcGgQkxSeMtVA64rH3anFlRmYHTJ+CPsb2VgqOdgcBFhR5O0piCwXA==",
       "requires": {
-        "@elrondnetwork/native-auth-client": "^0.1.0",
-        "@elrondnetwork/native-auth-server": "^0.1.1",
+        "@elrondnetwork/native-auth-client": "^0.1.4",
+        "@elrondnetwork/native-auth-server": "^0.1.9",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@types/redis": "^2.8.32",
         "agentkeepalive": "^4.2.1",
@@ -17579,9 +17585,9 @@
       }
     },
     "@elrondnetwork/native-auth-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-client/-/native-auth-client-0.1.0.tgz",
-      "integrity": "sha512-LWHpn9SFmiLGBQZ2dqXHCJu5ZHJ/PU87nxG4BokrdcW/Vu6kZq1joNk1kUfGGzr56IIE1kuJjfvh8F0Vmtynxw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-client/-/native-auth-client-0.1.5.tgz",
+      "integrity": "sha512-9CmJj3XSd/nWwdGOasFhk8ttPfQlb0UKZVLL2S8xvs7x550mFOh4MNsvI3IuqTDsf1/bUhhSIfv7jyX/ztLy0g==",
       "requires": {
         "axios": "^0.27.2"
       },
@@ -17608,9 +17614,9 @@
       }
     },
     "@elrondnetwork/native-auth-server": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-server/-/native-auth-server-0.1.1.tgz",
-      "integrity": "sha512-mv2elF7lO/Lr8FlGS2DvRtsqDr3APqOWtPxQgEGIVVUPUUpFnycWaQUAQmPuaGl1P8u8GBmPkhoFAoCD8lMn/w==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/native-auth-server/-/native-auth-server-0.1.10.tgz",
+      "integrity": "sha512-DS5jtzf+h9Nemin76fQUBu+9C6UGSPhJUjp0oViPMbT6FAu0w0cFFEOtI0ZG4u2IJ2vnaZ1TSHs2iqknP/uLDQ==",
       "requires": {
         "@elrondnetwork/erdjs": "^10.2.7",
         "@elrondnetwork/erdjs-walletcore": "^1.0.0",
@@ -17710,9 +17716,9 @@
           }
         },
         "node-gyp-build": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-          "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+          "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
         }
       }
     },

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3517,20 +3517,26 @@ type TokenWithBalanceAccountFlat {
   """Token burnt details."""
   burnt: String!
 
+  """Token canAddSpecialRoles property in case of type MetaESDT."""
+  canAddSpecialRoles: Boolean
+
   """Token canBurn property."""
-  canBurn: Boolean!
+  canBurn: Boolean
 
   """Token canChangeOwner property."""
-  canChangeOwner: Boolean!
+  canChangeOwner: Boolean
 
   """Token canFreeze property."""
-  canFreeze: Boolean!
+  canFreeze: Boolean
 
   """Token canMint property."""
-  canMint: Boolean!
+  canMint: Boolean
 
   """Token canPause property."""
   canPause: Boolean!
+
+  """Token canFreeze property."""
+  canTransferNftCreateRole: Boolean
 
   """Token canUpgrade property."""
   canUpgrade: Boolean!
@@ -3571,8 +3577,14 @@ type TokenWithBalanceAccountFlat {
   """Token ticker."""
   ticker: String!
 
+  """Creation timestamp."""
+  timestamp: Float!
+
   """Tokens transactions."""
   transactions: Float
+
+  """Token type."""
+  type: TokenType!
 
   """ValueUsd token for the given token account."""
   valueUsd: Float

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { PluginService } from './common/plugins/plugin.service';
 import { TransactionCompletedModule } from './crons/transaction.processor/transaction.completed.module';
 import { SocketAdapter } from './common/websockets/socket-adapter';
 import { ApiConfigModule } from './common/api-config/api.config.module';
-import { CachingService, LoggerInitializer, LoggingInterceptor, MetricsService, CachingInterceptor, LogRequestsInterceptor, FieldsInterceptor, ExtractInterceptor, CleanupInterceptor, PaginationInterceptor, QueryCheckInterceptor, ComplexityInterceptor, OriginInterceptor, RequestCpuTimeInterceptor, JwtOrNativeAuthGuard } from '@elrondnetwork/erdnest';
+import { CachingService, LoggerInitializer, LoggingInterceptor, MetricsService, CachingInterceptor, LogRequestsInterceptor, FieldsInterceptor, ExtractInterceptor, CleanupInterceptor, PaginationInterceptor, QueryCheckInterceptor, ComplexityInterceptor, OriginInterceptor, RequestCpuTimeInterceptor } from '@elrondnetwork/erdnest';
 import { ErdnestConfigServiceImpl } from './common/api-config/erdnest.config.service.impl';
 import { RabbitMqModule } from './common/rabbitmq/rabbitmq.module';
 import { TransactionLoggingInterceptor } from './interceptors/transaction.logging.interceptor';
@@ -30,6 +30,7 @@ import { GraphqlComplexityInterceptor } from './graphql/interceptors/graphql.com
 import { GraphQLMetricsInterceptor } from './graphql/interceptors/graphql.metrics.interceptor';
 import { ApiMetricsService } from './common/metrics/api.metrics.service';
 import { StatusCheckerModule } from './crons/status.checker/status.checker.module';
+import { JwtOrNativeAuthGuard } from './utils/jwt.or.native.auth.guard';
 
 async function bootstrap() {
   const apiConfigApp = await NestFactory.create(ApiConfigModule);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { PluginService } from './common/plugins/plugin.service';
 import { TransactionCompletedModule } from './crons/transaction.processor/transaction.completed.module';
 import { SocketAdapter } from './common/websockets/socket-adapter';
 import { ApiConfigModule } from './common/api-config/api.config.module';
-import { JwtAuthenticateGlobalGuard, CachingService, LoggerInitializer, LoggingInterceptor, MetricsService, CachingInterceptor, LogRequestsInterceptor, FieldsInterceptor, ExtractInterceptor, CleanupInterceptor, PaginationInterceptor, QueryCheckInterceptor, ComplexityInterceptor, OriginInterceptor, RequestCpuTimeInterceptor } from '@elrondnetwork/erdnest';
+import { CachingService, LoggerInitializer, LoggingInterceptor, MetricsService, CachingInterceptor, LogRequestsInterceptor, FieldsInterceptor, ExtractInterceptor, CleanupInterceptor, PaginationInterceptor, QueryCheckInterceptor, ComplexityInterceptor, OriginInterceptor, RequestCpuTimeInterceptor, JwtOrNativeAuthGuard } from '@elrondnetwork/erdnest';
 import { ErdnestConfigServiceImpl } from './common/api-config/erdnest.config.service.impl';
 import { RabbitMqModule } from './common/rabbitmq/rabbitmq.module';
 import { TransactionLoggingInterceptor } from './interceptors/transaction.logging.interceptor';
@@ -163,9 +163,10 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   const apiMetricsService = publicApp.get<ApiMetricsService>(ApiMetricsService);
   const pluginService = publicApp.get<PluginService>(PluginService);
   const httpAdapterHostService = publicApp.get<HttpAdapterHost>(HttpAdapterHost);
+  const cachingService = publicApp.get<CachingService>(CachingService);
 
   if (apiConfigService.getIsAuthActive()) {
-    publicApp.useGlobalGuards(new JwtAuthenticateGlobalGuard(new ErdnestConfigServiceImpl(apiConfigService)));
+    publicApp.useGlobalGuards(new JwtOrNativeAuthGuard(new ErdnestConfigServiceImpl(apiConfigService), cachingService));
   }
 
   const httpServer = httpAdapterHostService.httpAdapter.getHttpServer();
@@ -185,7 +186,6 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   globalInterceptors.push(new LoggingInterceptor(metricsService));
 
   if (apiConfigService.getUseRequestCachingFlag()) {
-    const cachingService = publicApp.get<CachingService>(CachingService);
 
     const cachingInterceptor = new CachingInterceptor(
       cachingService,

--- a/src/utils/jwt.or.native.auth.guard.ts
+++ b/src/utils/jwt.or.native.auth.guard.ts
@@ -1,0 +1,31 @@
+import { CachingService, ErdnestConfigService, ERDNEST_CONFIG_SERVICE, JwtAuthenticateGuard, NativeAuthGuard } from '@elrondnetwork/erdnest';
+import { Injectable, CanActivate, ExecutionContext, Inject } from '@nestjs/common';
+
+@Injectable()
+export class JwtOrNativeAuthGuard implements CanActivate {
+  constructor(
+    @Inject(ERDNEST_CONFIG_SERVICE)
+    private readonly erdnestConfigService: ErdnestConfigService,
+    private readonly cachingService: CachingService
+  ) { }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const jwtGuard = new JwtAuthenticateGuard(this.erdnestConfigService);
+    const nativeAuthGuard = new NativeAuthGuard(this.cachingService);
+
+    try {
+      const result = await jwtGuard.canActivate(context);
+      if (result) {
+        return true;
+      }
+    } catch (error) {
+      // do nothing
+    }
+
+    try {
+      return await nativeAuthGuard.canActivate(context);
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/src/utils/jwt.or.native.auth.guard.ts
+++ b/src/utils/jwt.or.native.auth.guard.ts
@@ -1,4 +1,4 @@
-import { CachingService, ErdnestConfigService, ERDNEST_CONFIG_SERVICE, JwtAuthenticateGuard, NativeAuthGuard } from '@elrondnetwork/erdnest';
+import { CachingService, DecoratorUtils, ErdnestConfigService, ERDNEST_CONFIG_SERVICE, JwtAuthenticateGuard, NativeAuthGuard, NoAuthOptions } from '@elrondnetwork/erdnest';
 import { Injectable, CanActivate, ExecutionContext, Inject } from '@nestjs/common';
 
 @Injectable()
@@ -10,6 +10,11 @@ export class JwtOrNativeAuthGuard implements CanActivate {
   ) { }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const noAuthMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getHandler());
+    if (noAuthMetadata) {
+      return true;
+    }
+
     const jwtGuard = new JwtAuthenticateGuard(this.erdnestConfigService);
     const nativeAuthGuard = new NativeAuthGuard(this.cachingService);
 


### PR DESCRIPTION
## Reasoning
- When activating global auth, only legacy jwts were allowed
  
## Proposed Changes
- Allow dual validation of tokens, both jwt and also native auth 

## How to test
- Activate auth flag (`api.auth: true` in config), then perform request e.g. on the `/accounts` route with Authorization header using a native auth token
