### PR TITLE
 add owner attribute for providers

### DIFF
--- a/src/endpoints/providers/entities/delegation.data.ts
+++ b/src/endpoints/providers/entities/delegation.data.ts
@@ -6,4 +6,5 @@ export class DelegationData {
   aprValue: number | undefined = undefined;
   featured: boolean = false;
   contract: string | null = null;
+  owner: string | null = null;
 }

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -92,6 +92,10 @@ export class ProviderService {
         if (delegationData.featured) {
           element.featured = delegationData.featured;
         }
+
+        if (delegationData.owner) {
+          element.owner = delegationData.owner;
+        }
       }
 
       // Add Nodes details for provider
@@ -101,9 +105,6 @@ export class ProviderService {
       element.stake = nodesInfos.stake;
       element.topUp = nodesInfos.topUp;
       element.locked = nodesInfos.locked;
-
-      // @ts-ignore
-      delete element.owner;
     });
 
     providers.sort((a, b) => {

--- a/src/test/integration/services/providers.e2e-spec.ts
+++ b/src/test/integration/services/providers.e2e-spec.ts
@@ -41,6 +41,7 @@ describe('Provider Service', () => {
       }
 
       expect(result.hasOwnProperty("provider")).toBeTruthy();
+      expect(result.hasOwnProperty("owner")).toBeTruthy();
       expect(result.hasOwnProperty("serviceFee")).toBeTruthy();
       expect(result.hasOwnProperty("delegationCap")).toBeTruthy();
       expect(result.hasOwnProperty("apr")).toBeTruthy();
@@ -65,6 +66,7 @@ describe('Provider Service', () => {
       expect(result.identity).toBeDefined();
       expect(result.identity).toStrictEqual("meria");
       expect(result.provider).toStrictEqual("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85");
+      expect(result.owner).toStrictEqual("erd1fx5t2nwq4fh9jws5xqfl85hr0l8tuqks9sr7ut9wrpkp7dugzxnqyksfyg");
     });
 
     it("should return provider addresses", async () => {
@@ -111,6 +113,7 @@ describe('Provider Service', () => {
 
       for (const result of results) {
         expect(result.hasOwnProperty("provider")).toBeTruthy();
+        expect(result.hasOwnProperty("owner")).toBeTruthy();
         expect(result.hasOwnProperty("serviceFee")).toBeTruthy();
         expect(result.hasOwnProperty("delegationCap")).toBeTruthy();
         expect(result.hasOwnProperty("apr")).toBeTruthy();
@@ -138,6 +141,7 @@ describe('Provider Service', () => {
 
       for (const result of results) {
         expect(result.hasOwnProperty("provider")).toBeTruthy();
+        expect(result.hasOwnProperty("owner")).toBeTruthy();
         expect(result.hasOwnProperty("serviceFee")).toBeTruthy();
         expect(result.hasOwnProperty("delegationCap")).toBeTruthy();
         expect(result.hasOwnProperty("apr")).toBeTruthy();


### PR DESCRIPTION
## Reasoning
-  on providers route /providers, owner attributes is missing
  
## Proposed Changes
-  add "owner" attribute

## How to test
- /providers -> should return all providers details + owner attribute defined
- /prividers/:address -> should return all provider details + owner attribute defined
