### PR TITLE
Allow herotags for smart contracts as well

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -109,9 +109,7 @@ export class AccountService {
         }
       }
 
-      if (!AddressUtils.isSmartContractAddress(address)) {
-        account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
-      }
+      account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
 
       await this.pluginService.processAccount(account);
       return account;


### PR DESCRIPTION
## Reasoning
- In order to optimize performance, herotags were not fetched for smart contract, although the protocol allows it
  
## Proposed Changes
- since the number of smart contracts is relatively finite, we can allow fetching herotags for these as well

## How to test
- verify whether herotags are loaded for smart contracts
