### PR TITLE
Fix XMEX / LKMEX decoding error

### DIFF
--- a/src/common/locked-asset/locked-asset.service.ts
+++ b/src/common/locked-asset/locked-asset.service.ts
@@ -27,7 +27,7 @@ export class LockedAssetService {
       return undefined;
     }
 
-    if (!identifier.startsWith(lockedTokenIds.lkmex)) {
+    if (!lockedTokenIds.lkmex || !identifier.startsWith(lockedTokenIds.lkmex)) {
       return undefined;
     }
 
@@ -48,7 +48,7 @@ export class LockedAssetService {
       return undefined;
     }
 
-    if (!identifier.startsWith(lockedTokenIds.xmex)) {
+    if (!lockedTokenIds.xmex || !identifier.startsWith(lockedTokenIds.xmex)) {
       return undefined;
     }
 
@@ -117,22 +117,12 @@ export class LockedAssetService {
     return parseInt(epoch, 16);
   }
 
-  private lockedTokenIds: LockedTokensInterface | undefined;
-
   private async getLockedTokens(): Promise<LockedTokensInterface | undefined> {
-    if (this.lockedTokenIds) {
-      return this.lockedTokenIds;
-    }
-
-    const lockedTokenIds = await this.cachingService.getOrSetCache(
+    return await this.cachingService.getOrSetCache(
       CacheInfo.LockedTokenIDs.key,
       async () => await this.getLockedTokensRaw(),
       CacheInfo.LockedTokenIDs.ttl,
     );
-
-    this.lockedTokenIds = lockedTokenIds;
-
-    return lockedTokenIds;
   }
 
   private async getLockedTokensRaw(): Promise<LockedTokensInterface> {

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -109,9 +109,7 @@ export class AccountService {
         }
       }
 
-      if (!AddressUtils.isSmartContractAddress(address)) {
-        account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
-      }
+      account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
 
       await this.pluginService.processAccount(account);
       return account;

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -109,7 +109,9 @@ export class AccountService {
         }
       }
 
-      account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
+      if (!AddressUtils.isSmartContractAddress(address)) {
+        account.username = await this.usernameService.getUsernameForAddress(address) ?? undefined;
+      }
 
       await this.pluginService.processAccount(account);
       return account;


### PR DESCRIPTION
## Reasoning
- If xmex / lkmex ticker are empty for whatever reason, decoding is always attempted
  
## Proposed Changes
- Add an extra check whether the ticker really exists before decoding

## How to test
- Make sure mex settings are not loaded, then any token should not be attempted to be decoded as lkmex
