### PR TITLE
Refresh token & account assets every 10 minutes

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -230,9 +230,9 @@ export class CacheWarmerService {
     }, true);
   }
 
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_10_MINUTES)
   async handleTokenAssetsInvalidations() {
-    await Locker.lock('Token assets invalidations', async () => {
+    await Locker.lock('Token / Account assets invalidations', async () => {
       await this.assetsService.checkout();
       const assets = this.assetsService.getAllTokenAssetsRaw();
       await this.invalidateKey(CacheInfo.TokenAssets.key, assets, CacheInfo.TokenAssets.ttl);


### PR DESCRIPTION
## Reasoning
- Assets repository has > 125MB total, meaning it takes longer and longer to checkout
  
## Proposed Changes
- Refresh token & account assets every 10 minutes

## How to test
- Less network traffic overall should be performed by the cache warmer instance
