### PR TITLE
Fix account NFTs type filter

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -137,7 +137,9 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.type !== undefined) {
-      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('type', filter.type));
+      const types = (filter.type ?? '').split(',');
+
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(types, type => QueryType.Match('type', type));
     }
 
     if (identifier !== undefined) {


### PR DESCRIPTION
## Proposed Changes
- Fix account nfts route filter by multiple types if the address is smart contract

## How to test (devnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqqt3yvus3er8jd2knhfxcnhfhzpjx7m8w46lqd4cncw/nfts?type=NonFungibleESDT,MetaESDT` should return multiple nfts and not an empty array
