### PR TITLE
Integrate new indexer mappings

### DIFF
--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -358,6 +358,10 @@ export class ApiConfigService {
     return this.configService.get<boolean>('flags.indexer-v3') ?? false;
   }
 
+  getIsIndexerV5FlagActive(): boolean {
+    return this.configService.get<boolean>('flags.indexer-v5') ?? false;
+  }
+
   isGraphQlActive(): boolean {
     return this.configService.get<boolean>('api.graphql') ?? false;
   }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -615,7 +615,7 @@ export class ElasticIndexerService implements IndexerInterface {
                 {
                   collection: {
                     terms: {
-                      field: 'token.keyword',
+                      field: this.apiConfigService.getIsIndexerV5FlagActive() ? 'token' : 'token.keyword',
                     },
                   },
                 },


### PR DESCRIPTION
## Reasoning
- Elasticsearch had an update where the mappings were improved, mainly `text` types were converted to `keyword`, which impacted the functioning of the API
  
## Proposed Changes
- create a config flag to specify whether to target the new and upcoming ES information, starting with the account collections query which did not need to use the `.keyword` specification

## How to test
- when targeting an updated indexer, such as `devnet-index.multiversx.com`, after setting the activation flag, account collections should start to be returned
