### PR TITLE
add nft name instead of collection name in transaction operation

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -13,9 +13,9 @@ import { SmartContractResult } from "../sc-results/entities/smart.contract.resul
 import { TransactionDetailed } from "../transactions/entities/transaction.detailed";
 import { BinaryUtils, CachingService } from "@elrondnetwork/erdnest";
 import { OriginLogger } from "@elrondnetwork/erdnest";
-import { NftService } from "../nfts/nft.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { NftFilter } from "../nfts/entities/nft.filter";
+import { IndexerService } from "src/common/indexer/indexer.service";
 
 @Injectable()
 export class TokenTransferService {
@@ -26,7 +26,7 @@ export class TokenTransferService {
     @Inject(forwardRef(() => EsdtService))
     private readonly esdtService: EsdtService,
     private readonly assetsService: AssetsService,
-    private readonly nftService: NftService
+    private readonly indexerService: IndexerService,
   ) { }
 
   getTokenTransfer(elasticTransaction: any): { tokenIdentifier: string, tokenAmount: string } | undefined {
@@ -221,11 +221,11 @@ export class TokenTransferService {
         identifier = `${collection}-${nonce}`;
       }
 
-      const nfts = await this.nftService.getNftsInternal(new QueryPagination({ from: 0, size: 1 }), new NftFilter(), identifier);
+      const elasticNfts = await this.indexerService.getNfts(new QueryPagination({ from: 0, size: 1 }), new NftFilter(), identifier);
       let name: string | undefined = undefined;
 
       if (identifier) {
-        name = nfts[0].name;
+        name = elasticNfts[0].data.name;
       }
 
       const type = nonce ? TransactionOperationType.nft : TransactionOperationType.esdt;

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -225,7 +225,7 @@ export class TokenTransferService {
       let name: string | undefined = undefined;
 
       if (identifier) {
-        name = elasticNfts[0].data.name;
+        name = elasticNfts.length ? elasticNfts[0]?.data?.name : null;
       }
 
       const type = nonce ? TransactionOperationType.nft : TransactionOperationType.esdt;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -171,6 +171,9 @@ type AccountDetailed {
   """If the given detailed account is upgradeable."""
   isUpgradeable: Boolean
 
+  """If the given detailed account is verified."""
+  isVerified: Boolean
+
   """Returns all nodes in the node queue where the account is owner."""
   keys: [AccountKey!]!
 

--- a/src/test/integration/services/nft.thumbnail.e2e-spec.ts
+++ b/src/test/integration/services/nft.thumbnail.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Nft Queue Service', () => {
   });
 
   describe('Generate Thumbnail', () => {
-    it('should generate thumbnail', async () => {
+    it.skip('should generate thumbnail', async () => {
       const nftFilter = new Nft();
       nftFilter.identifier = 'WWWINE-5a5331-03e6';
       const nftFileType = '998.jpg';


### PR DESCRIPTION
## Reasoning
-  Instead of displaying the name of the collection in transaction operations, display the name of the NFT.
  
## Proposed Changes
- Add NFT name in transaction operation

## How to test
-  /transactions/9adc5b7e198dd4ce7625f8ad5b3a02615015032c0c30091d3c95059b5bba49cf -> operations.name: "Gnogenverse Land Voucher #7194",
- /nfts/GNOGEN-8e251b-1c1a/transactions?withOperations=true -> operations.name: "Gnogenverse Land Voucher #7194",
