### PR TITLE
Collection extra fields

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -242,7 +242,10 @@ export class ElasticIndexerService implements IndexerInterface {
   async getNftCollections(pagination: QueryPagination, filter: CollectionFilter, address?: string): Promise<any[]> {
     const elasticQuery = this.indexerHelper.buildCollectionRolesFilter(filter, address)
       .withPagination(pagination)
-      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+      .withSort([
+        { name: 'api_isVerified', order: ElasticSortOrder.descending },
+        { name: 'api_holderCount', order: ElasticSortOrder.descending },
+      ]);
 
     return await this.elasticService.getList('tokens', 'identifier', elasticQuery);
   }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -665,4 +665,16 @@ export class ElasticIndexerService implements IndexerInterface {
   async setMetadataForToken(identifier: string, value: any): Promise<void> {
     return await this.elasticService.setCustomValue('tokens', identifier, 'metadata', value);
   }
+
+  async setIsVerifiedForToken(identifier: string, isVerified: boolean): Promise<void> {
+    return await this.elasticService.setCustomValue('tokens', identifier, 'isVerified', isVerified);
+  }
+
+  async setHolderCountForToken(identifier: string, holderCount: number): Promise<void> {
+    return await this.elasticService.setCustomValue('tokens', identifier, 'holderCount', holderCount);
+  }
+
+  async setNftCountForToken(identifier: string, nftCount: number): Promise<void> {
+    return await this.elasticService.setCustomValue('tokens', identifier, 'nftCount', nftCount);
+  }
 }

--- a/src/common/indexer/entities/collection.ts
+++ b/src/common/indexer/entities/collection.ts
@@ -1,4 +1,5 @@
 export interface Collection {
+  _id: string;
   name: string;
   ticker: string;
   token: string;
@@ -7,4 +8,7 @@ export interface Collection {
   type: string;
   timestamp: number;
   ownersHistory: { address: string, timestamp: number }[];
+  api_isVerified?: boolean;
+  api_nftCount?: number;
+  api_holderCount?: number;
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -141,4 +141,10 @@ export interface IndexerInterface {
   setMediaForToken(identifier: string, value: NftMedia[]): Promise<void>
 
   setMetadataForToken(identifier: string, value: any): Promise<void>
+
+  setIsVerifiedForToken(identifier: string, isVerified: boolean): Promise<void>
+
+  setHolderCountForToken(identifier: string, holderCount: number): Promise<void>
+
+  setNftCountForToken(identifier: string, nftCount: number): Promise<void>
 }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -284,6 +284,18 @@ export class IndexerService implements IndexerInterface {
     return await this.execute('setMetadataForToken', this.indexerInterface.setMetadataForToken(identifier, value));
   }
 
+  async setIsVerifiedForToken(identifier: string, isVerified: boolean): Promise<void> {
+    return await this.execute('setIsVerifiedForToken', this.indexerInterface.setIsVerifiedForToken(identifier, isVerified));
+  }
+
+  async setHolderCountForToken(identifier: string, holderCount: number): Promise<void> {
+    return await this.execute('setHolderCountForToken', this.indexerInterface.setHolderCountForToken(identifier, holderCount));
+  }
+
+  async setNftCountForToken(identifier: string, nftCount: number): Promise<void> {
+    return await this.execute('setNftCountForToken', this.indexerInterface.setNftCountForToken(identifier, nftCount));
+  }
+
   async getNftCollectionsByIds(identifiers: string[]): Promise<Collection[]> {
     return await this.execute('getNftCollectionsByIds', this.indexerInterface.getNftCollectionsByIds(identifiers));
   }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -609,4 +609,16 @@ export class PostgresIndexerService implements IndexerInterface {
   async setMetadataForToken(_identifier: string, _value: any): Promise<void> {
     // TODO custom columns cannot be added
   }
+
+  async setIsVerifiedForToken(_identifier: string, _isVerified: boolean): Promise<void> {
+    // TODO custom columns cannot be added
+  }
+
+  async setHolderCountForToken(_identifier: string, _holderCount: number): Promise<void> {
+    // TODO custom columns cannot be added
+  }
+
+  async setNftCountForToken(_identifier: string, _nftCount: number): Promise<void> {
+    // TODO custom columns cannot be added
+  }
 }

--- a/src/crons/elastic.updater/elastic.updater.module.ts
+++ b/src/crons/elastic.updater/elastic.updater.module.ts
@@ -1,5 +1,7 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
+import { AssetsModule } from 'src/common/assets/assets.module';
+import { PersistenceModule } from 'src/common/persistence/persistence.module';
 import { EndpointsServicesModule } from 'src/endpoints/endpoints.services.module';
 import { ElasticUpdaterService } from './elastic.updater.service';
 
@@ -7,6 +9,8 @@ import { ElasticUpdaterService } from './elastic.updater.service';
   imports: [
     ScheduleModule.forRoot(),
     EndpointsServicesModule,
+    AssetsModule,
+    forwardRef(() => PersistenceModule),
   ],
   providers: [
     ElasticUpdaterService,

--- a/src/endpoints/collections/entities/nft.collection.ts
+++ b/src/endpoints/collections/entities/nft.collection.ts
@@ -79,4 +79,16 @@ export class NftCollection {
   @Field(() => [CollectionTrait], { description: 'Trait list for the given NFT collection.', nullable: true })
   @ApiProperty({ type: CollectionTrait, isArray: true })
   traits: CollectionTrait[] = [];
+
+  @Field(() => Boolean, { description: 'Returns true if the collection is verified.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  isVerified: boolean | undefined = undefined;
+
+  @Field(() => Number, { description: 'Number of holders. Will be returned only if the collection is verified.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  holderCount: boolean | undefined = undefined;
+
+  @Field(() => Number, { description: 'Number of NFTs for this collection. Will be returned only if the collection is verified.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  nftCount: boolean | undefined = undefined;
 }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -171,6 +171,9 @@ type AccountDetailed {
   """If the given detailed account is upgradeable."""
   isUpgradeable: Boolean
 
+  """If the given detailed account is verified."""
+  isVerified: Boolean
+
   """Returns all nodes in the node queue where the account is owner."""
   keys: [AccountKey!]!
 


### PR DESCRIPTION
## Reasoning
- Extra KPIs needed to be attached to NFT collections
  
## Proposed Changes
- attach `isVerified`, `nftCount`, `holderCount` fields in ES which are periodically cache warmed
- default sorting for collections: verified collections first, then sorted by holder count descending
- map these 3 fields in the response body for the collections

## How to test (mainnet)
- `/collections` endpoint should return verified collections first, then sorted by holder count descending
