### PR TITLE
change default nft rarity algorithm to openRarity

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -592,7 +592,7 @@ export class NftService {
   }
 
   private getNftRankAlgorithmFromAssets(assets?: TokenAssets): NftRankAlgorithm {
-    return assets?.preferredRankAlgorithm ?? NftRankAlgorithm.jaccardDistances;
+    return assets?.preferredRankAlgorithm ?? NftRankAlgorithm.openRarity;
   }
 
   private getNftRankElasticKey(algorithm: NftRankAlgorithm) {


### PR DESCRIPTION
## Reasoning
- The default rarity sort algorithm should be OpenRarity

## Proposed Changes
- Change default nft rarity algorithm to openRarity

## How to test
- https://api.multiversx.com/collections/ZOIDSTERS-9121a9/nfts?sort=rank
