### PR TITLE
Stats endpoint real transactions

### DIFF
--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -225,7 +225,7 @@ export class NetworkService {
       shards,
       blocks,
       accounts,
-      transactions,
+      transactions: transactions + scResults,
       scResults,
       refreshRate,
       epoch,


### PR DESCRIPTION
## Reasoning
- The stats endpoint returns only standard transaction count but excludes smart contract results
  
## Proposed Changes
- add tx + scr in `transactions` attribute

## How to test (mainnet)
- `/stats` endpoint should return `transactions` as 291+ mil.
