### PR TITLE
Public api url for NativeAuth

### DIFF
--- a/src/common/api-config/erdnest.config.service.impl.ts
+++ b/src/common/api-config/erdnest.config.service.impl.ts
@@ -17,6 +17,8 @@ export class ErdnestConfigServiceImpl implements ErdnestConfigService {
   }
 
   getApiUrl(): string {
-    return this.apiConfigService.getSelfUrl();
+    const network = this.apiConfigService.getNetwork();
+    const prefix = network !== 'mainnet' ? `${network}-` : '';
+    return `https://${prefix}api.multiversx.com`;
   }
 }


### PR DESCRIPTION
## Reasoning
- Public api url for NativeAuth instead of self
- Using self url could lead to circular requests
  
