### PR TITLE
update simple-git version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "rimraf": "^3.0.2",
         "rxjs": "^7.1.0",
         "sharp": "^0.30.7",
-        "simple-git": "^2.48.0",
+        "simple-git": "^3.16.0",
         "swagger-ui-express": "^4.3.0",
         "tiny-async-pool": "^1.2.0",
         "typeorm": "^0.3.6",
@@ -13532,17 +13532,17 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.4"
       },
       "funding": {
         "type": "github",
-        "url": "https://github.com/sponsors/steveukx/"
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/simple-swizzle": {
@@ -25938,13 +25938,13 @@
       }
     },
     "simple-git": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.48.0.tgz",
-      "integrity": "sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.2"
+        "debug": "^4.3.4"
       }
     },
     "simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^7.1.0",
     "sharp": "^0.30.7",
-    "simple-git": "^2.48.0",
+    "simple-git": "^3.16.0",
     "swagger-ui-express": "^4.3.0",
     "tiny-async-pool": "^1.2.0",
     "typeorm": "^0.3.6",


### PR DESCRIPTION
## Reasoning
- Version of simple-git  used in package.json was critical vulnerable
  
## Proposed Changes
-  Update simple-git to ^3.16.0