### PR TITLE
fix provider extra fields

### DIFF
--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -38,11 +38,14 @@ export class ProviderService {
         return undefined;
       }
 
-      provider.automaticActivation = delegationData.automaticActivation;
-      provider.initialOwnerFunds = delegationData.initialOwnerFunds;
-      provider.checkCapOnRedelegate = delegationData.checkCapOnRedelegate;
-      provider.totalUnStaked = delegationData.totalUnStaked;
-      provider.createdNonce = delegationData.createdNonce;
+      const modifiedProvider = { ...provider };
+      modifiedProvider.automaticActivation = delegationData.automaticActivation;
+      modifiedProvider.initialOwnerFunds = delegationData.initialOwnerFunds;
+      modifiedProvider.checkCapOnRedelegate = delegationData.checkCapOnRedelegate;
+      modifiedProvider.totalUnStaked = delegationData.totalUnStaked;
+      modifiedProvider.createdNonce = delegationData.createdNonce;
+
+      return modifiedProvider;
     }
 
     return provider;


### PR DESCRIPTION
## Reasoning
-  When getProviders() methods was called, and after getProvider() method was called, extra fields from getProvider() were applied to geProviders() object
  
## Proposed Changes
- copy the provider object before applying the extra fields

## How to test
- first call /providers
- second call /providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu
- call /providers again and see if the extra fields have not been applied
