### PR TITLE
Handle transaction not found in gateway

### DIFF
--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -109,7 +109,7 @@ export class GatewayService {
     return new NftData(result.tokenData);
   }
 
-  async getTransaction(txHash: string): Promise<Transaction> {
+  async getTransaction(txHash: string): Promise<Transaction | undefined> {
     // eslint-disable-next-line require-await
     const result = await this.get(`transaction/${txHash}?withResults=true`, GatewayComponentRequest.transactionDetails, async (error) => {
       if (error.response.data.error === 'transaction not found') {
@@ -119,7 +119,7 @@ export class GatewayService {
       return false;
     });
 
-    return result.transaction;
+    return result?.transaction;
   }
 
   @LogPerformanceAsync(MetricsEvents.SetGatewayDuration, { argIndex: 1 })


### PR DESCRIPTION
## Proposed Changes
- Handle case where the transaction fetch api call from gateway returns undefined

## How to test (mainnet)
- `/transactions/b02a40735ccacac778333476a514589aca1cfe5dc13f744192935b1f1c5b5917` should not log any error message
