### PR TITLE
 nft marketplace auctions endpoint refactoring

### DIFF
--- a/src/common/entities/query.pagination.ts
+++ b/src/common/entities/query.pagination.ts
@@ -5,4 +5,7 @@ export class QueryPagination {
 
   from: number = 0;
   size: number = 25;
+
+  before?: number;
+  after?: number;
 }

--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -109,7 +109,7 @@ export class GatewayService {
     return new NftData(result.tokenData);
   }
 
-  async getTransaction(txHash: string): Promise<Transaction> {
+  async getTransaction(txHash: string): Promise<Transaction | undefined> {
     // eslint-disable-next-line require-await
     const result = await this.get(`transaction/${txHash}?withResults=true`, GatewayComponentRequest.transactionDetails, async (error) => {
       if (error.response.data.error === 'transaction not found') {
@@ -119,7 +119,7 @@ export class GatewayService {
       return false;
     });
 
-    return result.transaction;
+    return result?.transaction;
   }
 
   @LogPerformanceAsync(MetricsEvents.SetGatewayDuration, { argIndex: 1 })

--- a/src/endpoints/marketplace/entities/account.auctions.ts
+++ b/src/endpoints/marketplace/entities/account.auctions.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { AuctionStatus } from "./auction.status";
+import { Bids } from "./bids";
 
 export class Auction {
   constructor(init?: Partial<Auction>) {
@@ -7,13 +8,10 @@ export class Auction {
   }
 
   @ApiProperty({ type: String })
-  creator?: string = '';
-
-  @ApiProperty({ type: String })
   owner?: string = '';
 
-  @ApiProperty({ type: String })
-  auctionId?: string = '';
+  @ApiProperty({ type: Number })
+  auctionId?: number = 0;
 
   @ApiProperty({ type: String })
   identifier: string = '';
@@ -39,6 +37,9 @@ export class Auction {
   @ApiProperty({ type: String })
   marketplace: string = '';
 
-  @ApiProperty({ type: [String] })
-  tags: string[] = [];
+  @ApiProperty({ type: Bids })
+  minBid: Bids = new Bids();
+
+  @ApiProperty({ type: Bids })
+  maxBid: Bids = new Bids();
 }

--- a/src/endpoints/marketplace/entities/account.auctions.ts
+++ b/src/endpoints/marketplace/entities/account.auctions.ts
@@ -7,7 +7,7 @@ export class Auction {
   }
 
   @ApiProperty({ type: String })
-  auctionId: string = '';
+  auctionId?: string = '';
 
   @ApiProperty({ type: String })
   identifier: string = '';
@@ -22,13 +22,13 @@ export class Auction {
   createdAt: number = 0;
 
   @ApiProperty({ type: Number })
-  endsAt: number = 0;
-
-  @ApiProperty({ type: String })
-  marketplace: string = '';
+  endsAt?: number = 0;
 
   @ApiProperty({ type: String })
   marketplaceAuctionId: string = '';
+
+  @ApiProperty({ type: String })
+  marketplace: string = '';
 
   @ApiProperty({ type: [String] })
   tags: string[] = [];

--- a/src/endpoints/marketplace/entities/account.auctions.ts
+++ b/src/endpoints/marketplace/entities/account.auctions.ts
@@ -7,6 +7,12 @@ export class Auction {
   }
 
   @ApiProperty({ type: String })
+  creator?: string = '';
+
+  @ApiProperty({ type: String })
+  owner?: string = '';
+
+  @ApiProperty({ type: String })
   auctionId?: string = '';
 
   @ApiProperty({ type: String })
@@ -17,6 +23,9 @@ export class Auction {
 
   @ApiProperty({ enum: AuctionStatus })
   status: AuctionStatus = AuctionStatus.unknown;
+
+  @ApiProperty({ type: String })
+  auctionType?: string = '';
 
   @ApiProperty({ type: Number })
   createdAt: number = 0;

--- a/src/endpoints/marketplace/entities/auctions.ts
+++ b/src/endpoints/marketplace/entities/auctions.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { AuctionStatus } from "./auction.status";
 import { Bids } from "./bids";
 
 export class Auctions {
@@ -9,26 +10,32 @@ export class Auctions {
   @ApiProperty({ type: String })
   owner: string = '';
 
+  @ApiProperty({ type: Number })
+  auctionId?: number = 0;
+
   @ApiProperty({ type: String })
   identifier: string = '';
 
   @ApiProperty({ type: String })
   collection: string = '';
 
-  @ApiProperty({ type: Number })
-  nonce: number = 0;
+  @ApiProperty({ enum: AuctionStatus })
+  status: AuctionStatus = AuctionStatus.unknown;
 
   @ApiProperty({ type: String })
-  id: string = '';
-
-  @ApiProperty({ type: Number })
-  marketPlaceId: number = 0;
-
-  @ApiProperty({ type: String })
-  marketplace: string = '';
+  auctionType?: string = '';
 
   @ApiProperty({ type: Number })
   createdAt: number = 0;
+
+  @ApiProperty({ type: Number })
+  endsAt?: number = 0;
+
+  @ApiProperty({ type: Number })
+  marketplaceAuctionId: number = 0;
+
+  @ApiProperty({ type: String })
+  marketplace: string = '';
 
   @ApiProperty({ type: Bids })
   minBid: Bids = new Bids();

--- a/src/endpoints/marketplace/entities/auctions.ts
+++ b/src/endpoints/marketplace/entities/auctions.ts
@@ -7,6 +7,9 @@ export class Auctions {
   }
 
   @ApiProperty({ type: String })
+  owner: string = '';
+
+  @ApiProperty({ type: String })
   identifier: string = '';
 
   @ApiProperty({ type: String })
@@ -24,15 +27,12 @@ export class Auctions {
   @ApiProperty({ type: String })
   marketplace: string = '';
 
+  @ApiProperty({ type: Number })
+  createdAt: number = 0;
+
   @ApiProperty({ type: Bids })
   minBid: Bids = new Bids();
 
   @ApiProperty({ type: Bids })
   maxBid: Bids = new Bids();
-
-  @ApiProperty({ type: Number })
-  createdAt: number = 0;
-
-  @ApiProperty({ type: String })
-  owner: string = '';
 }

--- a/src/endpoints/marketplace/entities/auctions.ts
+++ b/src/endpoints/marketplace/entities/auctions.ts
@@ -31,8 +31,8 @@ export class Auctions {
   maxBid: Bids = new Bids();
 
   @ApiProperty({ type: Number })
-  timestamp: number = 0;
+  createdAt: number = 0;
 
   @ApiProperty({ type: String })
-  ownerAddress: string = '';
+  owner: string = '';
 }

--- a/src/endpoints/marketplace/graphql/account.auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/account.auctions.query.ts
@@ -33,7 +33,14 @@ export const accountAuctionsQuery = (address: string, status?: AuctionStatus) =>
           marketplace{
             key
           }
-          tags
+          minBid {
+            amount
+            token
+          }
+          maxBid {
+            amount
+            token
+          }
           marketplaceAuctionId
           startDate
           __typename

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-request";
 
-export const auctionId = (id: string) => {
+export const auctionId = (id: number) => {
   return gql`
   query {
     auctions(filters:{

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -19,9 +19,12 @@ export const auctionId = (id: string) => {
           identifier
           collection
           status
+          type
           creationDate
           endDate
           marketplace{key}
+          asset{creatorAddress}
+          ownerAddress
           tags
           marketplaceAuctionId
           startDate

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -1,0 +1,34 @@
+import { gql } from "graphql-request";
+
+export const auctionId = (id: string) => {
+  return gql`
+  query {
+    auctions(filters:{
+      operator: AND,
+      filters:[
+        {
+          field: "id",
+          op: EQ,
+          values: ["${id}"]
+        }
+      ]
+    }){
+      edges{
+        node{
+          id
+          identifier
+          collection
+          status
+          creationDate
+          endDate
+          marketplace{key}
+          tags
+          marketplaceAuctionId
+          startDate
+          __typename
+        }
+      }
+    }
+  }
+`;
+};

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -24,6 +24,14 @@ export const auctionId = (id: string) => {
           endDate
           marketplace{key}
           asset{creatorAddress}
+          minBid {
+            amount
+            token
+          }
+          maxBid {
+            amount
+            token
+          }
           ownerAddress
           tags
           marketplaceAuctionId

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -33,7 +33,6 @@ export const auctionIdQuery = (id: number) => {
             token
           }
           ownerAddress
-          tags
           marketplaceAuctionId
           startDate
           __typename

--- a/src/endpoints/marketplace/graphql/auctionId.query.ts
+++ b/src/endpoints/marketplace/graphql/auctionId.query.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-request";
 
-export const auctionId = (id: number) => {
+export const auctionIdQuery = (id: number) => {
   return gql`
   query {
     auctions(filters:{

--- a/src/endpoints/marketplace/graphql/auctions.count.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.count.query.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-request";
 
-export const auctionsCount = gql`
+export const auctionsCountQuery = gql`
 query selectedAuction($filters: FiltersExpression) {
   auctions(
     filters: $filters

--- a/src/endpoints/marketplace/graphql/auctions.count.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.count.query.ts
@@ -1,0 +1,12 @@
+import { gql } from "graphql-request";
+
+export const auctionsCount = gql`
+query selectedAuction($filters: FiltersExpression) {
+  auctions(
+    filters: $filters
+  ) {
+    pageData {
+      count
+    }
+  }
+}`;

--- a/src/endpoints/marketplace/graphql/auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.query.ts
@@ -1,41 +1,45 @@
 import { gql } from "graphql-request";
 
 export const auctionsQuery = gql`
-query($first: Int){
-  auctions(pagination:{
-    first: $first,
-  },
-  grouping:{
-    groupBy: IDENTIFIER
-  },
-  filters:{
-    operator: AND,
-    filters:[
-      {
-        field: "status",
-        op: EQ
-        values: ["Running"]
-      }
-    ]
-  }
-  sorting: {
-    direction: DESC,
-    field: "creationDate"
-  }
-  ){
-    edges{
-      node{
+query GetAuctions($first: Int, $after: String, $before: String) {
+  auctions(
+    pagination: {
+      first: $first,
+      after: $after,
+      before: $before
+    },
+    grouping:{
+      groupBy: IDENTIFIER
+    },
+    filters:{
+      operator: AND,
+      filters:[
+        {
+          field: "status",
+          op: EQ,
+          values: ["Running"]
+        }
+      ]
+    }
+    sorting: {
+      direction: DESC,
+      field: "creationDate"
+    }
+  ) {
+    edges {
+      cursor
+      node {
         identifier
         collection
         nonce
         id
         marketplaceAuctionId
         marketplaceKey
-        minBid{
+        minBid {
           amount
           token
         }
-        maxBid{
+        maxBid {
           amount
           token
         }
@@ -43,5 +47,12 @@ query($first: Int){
         ownerAddress
       }
     }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
   }
-}`;
+}
+`;

--- a/src/endpoints/marketplace/graphql/auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.query.ts
@@ -31,6 +31,8 @@ query GetAuctions($first: Int, $after: String, $before: String) {
       node {
         identifier
         collection
+        status
+        type
         nonce
         id
         marketplaceAuctionId

--- a/src/endpoints/marketplace/graphql/auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.query.ts
@@ -8,9 +8,6 @@ query GetAuctions($first: Int, $after: String, $before: String) {
       after: $after,
       before: $before
     },
-    grouping:{
-      groupBy: IDENTIFIER
-    },
     filters:{
       operator: AND,
       filters:[

--- a/src/endpoints/marketplace/graphql/collection.auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/collection.auctions.query.ts
@@ -1,0 +1,62 @@
+import { gql } from "graphql-request";
+
+export const collectionAuctionsQuery = gql`
+query GetAuctions($first: Int, $after: String, $before: String, $collection: [String]!) {
+  auctions(
+    pagination: {
+      first: $first,
+      after: $after,
+      before: $before
+    },
+    filters:{
+      filters:[
+        {
+          field: "status",
+          op: EQ,
+          values: ["Running"]
+        },
+        {
+          field: "collection",
+          op: EQ,
+          values: $collection
+        }
+      ],
+      operator: AND,
+    }
+    sorting: {
+      direction: DESC,
+      field: "creationDate"
+    }
+  ) {
+    edges {
+      cursor
+      node {
+        identifier
+        collection
+        status
+        type
+        nonce
+        id
+        marketplaceAuctionId
+        marketplaceKey
+        minBid {
+          amount
+          token
+        }
+        maxBid {
+          amount
+          token
+        }
+        creationDate
+        ownerAddress
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+}
+`;

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -54,7 +54,7 @@ export class NftMarketplaceController {
   @ApiOkResponse({ type: Auctions })
   @ApiQuery({ name: 'auctionId', description: 'Auction identifier', required: true })
   getAuctionId(
-    @Param('id') id: string,
+    @Param('id') id: number,
   ): Promise<Auction> {
     return this.nftMarketplaceService.getAuctionId(id);
   }

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -1,12 +1,11 @@
 import { ParseAddressPipe, ParseEnumPipe } from "@multiversx/sdk-nestjs";
 import { Controller, DefaultValuePipe, Get, NotFoundException, Param, ParseIntPipe, Query } from "@nestjs/common";
-import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { AccountAuctionStats } from "./entities/account.auction.stats";
 import { Auction } from "./entities/account.auctions";
 import { AuctionStatus } from "./entities/auction.status";
 import { Auctions } from "./entities/auctions";
-import { AuctionsFilter } from "./entities/auctions.filter";
 import { CollectionAuctionStats } from "./entities/collection.auction.stats";
 import { NftMarketplaceService } from "./nft.marketplace.service";
 
@@ -24,40 +23,9 @@ export class NftMarketplaceController {
   getAuctions(
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<Auctions[]> {
-    return this.nftMarketplaceService.getAuctionsRaw(
+    return this.nftMarketplaceService.getAuctions(
       new QueryPagination({ size }),
     );
-  }
-
-  @Get("/auctions/count")
-  @ApiOperation({ summary: 'Auctions count', description: 'Return total number of available auctions' })
-  @ApiOkResponse({ type: Number })
-  @ApiQuery({ name: 'marketplace', description: 'Search by marketplace name', required: false })
-  async getTokenCount(
-    @Query('marketplace') marketplace?: string,
-  ): Promise<number> {
-    return await this.nftMarketplaceService.getAuctionsCount(new AuctionsFilter({ marketplace }));
-  }
-
-  @Get("/auctions/c")
-  @ApiExcludeEndpoint()
-  async getTokenCountAlternative(
-    @Query('marketplace') marketplace?: string,
-  ): Promise<number> {
-    return await this.nftMarketplaceService.getAuctionsCount(new AuctionsFilter({ marketplace }));
-  }
-
-  @Get("/auctions/:id")
-  @ApiOperation({ summary: 'Explore auction details', description: 'Returns a specific auction ' })
-  @ApiOkResponse({ type: Auctions })
-  async getAuctionById(
-    @Param("id") id: string,
-  ): Promise<Auctions> {
-    const auction = await this.nftMarketplaceService.getAuctionById(id);
-    if (auction === undefined) {
-      throw new NotFoundException('Auction not found');
-    }
-    return auction;
   }
 
   @Get("/accounts/:address/auction/stats")

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -1,4 +1,4 @@
-import { ParseAddressPipe, ParseEnumPipe } from "@multiversx/sdk-nestjs";
+import { ParseAddressPipe, ParseCollectionPipe, ParseEnumPipe } from "@multiversx/sdk-nestjs";
 import { Controller, DefaultValuePipe, Get, NotFoundException, Param, ParseIntPipe, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -20,10 +20,10 @@ export class NftMarketplaceController {
   @ApiOperation({ summary: 'Explore auctions', description: 'Returns auctions available in marketplaces ' })
   @ApiOkResponse({ type: [Auctions] })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
-  getAuctions(
+  async getAuctions(
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<Auctions[]> {
-    return this.nftMarketplaceService.getAuctions(
+    return await this.nftMarketplaceService.getAuctions(
       new QueryPagination({ size }),
     );
   }
@@ -32,10 +32,10 @@ export class NftMarketplaceController {
   @ApiOperation({ summary: 'Auctions count', description: 'Returns all auctions count available on marketplaces ' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
-  getAuctionsCount(
-    @Query('status') status: AuctionStatus,
+  async getAuctionsCount(
+    @Query('status', new ParseEnumPipe(AuctionStatus)) status?: AuctionStatus,
   ): Promise<number> {
-    return this.nftMarketplaceService.getAuctionsCount(status);
+    return await this.nftMarketplaceService.getAuctionsCount(status);
   }
 
   @Get("/auctions/c")
@@ -43,20 +43,20 @@ export class NftMarketplaceController {
   @ApiOperation({ summary: 'Auctions count', description: 'Returns all auctions count available on marketplaces ' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
-  getAuctionsCountAlternative(
-    @Query('status') status: AuctionStatus,
+  async getAuctionsCountAlternative(
+    @Query('status', new ParseEnumPipe(AuctionStatus)) status?: AuctionStatus,
   ): Promise<number> {
-    return this.nftMarketplaceService.getAuctionsCount(status);
+    return await this.nftMarketplaceService.getAuctionsCount(status);
   }
 
   @Get("/auctions/:id")
   @ApiOperation({ summary: 'Auction details', description: 'Returns auction details for a specific auction identifier ' })
   @ApiOkResponse({ type: Auctions })
   @ApiQuery({ name: 'auctionId', description: 'Auction identifier', required: true })
-  getAuctionId(
+  async getAuctionId(
     @Param('id') id: number,
   ): Promise<Auction> {
-    return this.nftMarketplaceService.getAuctionId(id);
+    return await this.nftMarketplaceService.getAuctionId(id);
   }
 
   @Get("/accounts/:address/auction/stats")
@@ -80,7 +80,7 @@ export class NftMarketplaceController {
   @ApiQuery({ name: 'status', description: 'Returns auctions with specified status', required: false })
   @ApiOkResponse({ type: Auction })
   async getAccountAuctions(
-    @Param('address') address: string,
+    @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('status', new ParseEnumPipe(AuctionStatus)) status?: AuctionStatus,
@@ -97,27 +97,20 @@ export class NftMarketplaceController {
   @ApiOperation({ summary: 'Collection stats', description: 'Returns collection status details from nft marketplace for a given collection identifier' })
   @ApiOkResponse({ type: CollectionAuctionStats })
   async getCollectionStats(
-    @Param('collection') collection: string,
+    @Param('collection', ParseCollectionPipe) collection: string,
   ): Promise<CollectionAuctionStats> {
-    const collectionStats = await this.nftMarketplaceService.getCollectionStats({ identifier: collection });
-    if (!collectionStats) {
-      throw new NotFoundException('Could not fetch collection stats');
-    }
-
-    return collectionStats;
+    return await this.nftMarketplaceService.getCollectionStats({ identifier: collection });
   }
 
-  @Get('/collection/:collection/auctions')
+  @Get('/collections/:collection/auctions')
   @ApiOperation({ summary: 'Collection auctions', description: 'Returns all auctions for a specific collection ' })
   @ApiOkResponse({ type: [Auctions] })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'collection', description: 'Collection identifier', required: true })
-  getCollectionAuctions(
-    @Param('collection') collection: string,
+  async getCollectionAuctions(
+    @Param('collection', ParseCollectionPipe) collection: string,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<Auctions[]> {
-    return this.nftMarketplaceService.getCollectionAuctions(
-      new QueryPagination({ size }), collection,
-    );
+    return await this.nftMarketplaceService.getCollectionAuctions(new QueryPagination({ size }), collection);
   }
 }

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -106,4 +106,18 @@ export class NftMarketplaceController {
 
     return collectionStats;
   }
+
+  @Get('/collection/:collection/auctions')
+  @ApiOperation({ summary: 'Collection auctions', description: 'Returns all auctions for a specific collection ' })
+  @ApiOkResponse({ type: [Auctions] })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'collection', description: 'Collection identifier', required: true })
+  getCollectionAuctions(
+    @Param('collection') collection: string,
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+  ): Promise<Auctions[]> {
+    return this.nftMarketplaceService.getCollectionAuctions(
+      new QueryPagination({ size }), collection,
+    );
+  }
 }

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -23,11 +23,10 @@ export class NftMarketplaceController {
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   getAuctions(
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query("marketplace") marketplace: string,
   ): Promise<Auctions[]> {
-    return this.nftMarketplaceService.getAuctions(
+    return this.nftMarketplaceService.getAuctionsRaw(
       new QueryPagination({ size }),
-      new AuctionsFilter({ marketplace }));
+    );
   }
 
   @Get("/auctions/count")

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -29,7 +29,7 @@ export class NftMarketplaceController {
   }
 
   @Get("/auctions/count")
-  @ApiOperation({ summary: 'Auction count', description: 'Returns all auctions count available on marketplaces ' })
+  @ApiOperation({ summary: 'Auctions count', description: 'Returns all auctions count available on marketplaces ' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
   getAuctionsCount(
@@ -40,7 +40,7 @@ export class NftMarketplaceController {
 
   @Get("/auctions/c")
   @ApiExcludeEndpoint()
-  @ApiOperation({ summary: 'Auction count', description: 'Returns all auctions count available on marketplaces ' })
+  @ApiOperation({ summary: 'Auctions count', description: 'Returns all auctions count available on marketplaces ' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
   getAuctionsCountAlternative(

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -93,6 +93,16 @@ export class NftMarketplaceController {
     return account;
   }
 
+  @Get('/accounts/:address/auctions/count')
+  @ApiOperation({ summary: 'Address auctions count', description: 'Returns total running auctions count for a specific address ' })
+  @ApiOkResponse({ type: Number })
+  @ApiQuery({ name: 'address', description: 'Account address', required: true })
+  async getAccountAuctionsCount(
+    @Param('address', ParseAddressPipe) address: string,
+  ): Promise<number> {
+    return await this.nftMarketplaceService.getAccountAuctionsCount(address);
+  }
+
   @Get("/collections/:collection/auction/stats")
   @ApiOperation({ summary: 'Collection stats', description: 'Returns collection status details from nft marketplace for a given collection identifier' })
   @ApiOkResponse({ type: CollectionAuctionStats })

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -113,4 +113,14 @@ export class NftMarketplaceController {
   ): Promise<Auctions[]> {
     return await this.nftMarketplaceService.getCollectionAuctions(new QueryPagination({ size }), collection);
   }
+
+  @Get('/collections/:collection/auctions/count')
+  @ApiOperation({ summary: 'Collection auctions count', description: 'Returns total running auctions count for a specific collection ' })
+  @ApiOkResponse({ type: Number })
+  @ApiQuery({ name: 'collection', description: 'Collection identifier', required: true })
+  async getCollectionAuctionsCount(
+    @Param('collection', ParseCollectionPipe) collection: string,
+  ): Promise<number> {
+    return await this.nftMarketplaceService.getCollectionAuctionsCount(collection);
+  }
 }

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -75,4 +75,14 @@ export class NftMarketplaceController {
 
     return collectionStats;
   }
+
+  @Get("/auctions/:id")
+  @ApiOperation({ summary: 'Auction ID', description: 'Returns auction details for a specific auction ID ' })
+  @ApiOkResponse({ type: Auctions })
+  @ApiQuery({ name: 'id', description: 'Auction ID', required: false })
+  getAuctionId(
+    @Param('id') id: string,
+  ): Promise<Auction> {
+    return this.nftMarketplaceService.getAuctionId(id);
+  }
 }

--- a/src/endpoints/marketplace/nft.marketplace.controller.ts
+++ b/src/endpoints/marketplace/nft.marketplace.controller.ts
@@ -1,6 +1,6 @@
 import { ParseAddressPipe, ParseEnumPipe } from "@multiversx/sdk-nestjs";
 import { Controller, DefaultValuePipe, Get, NotFoundException, Param, ParseIntPipe, Query } from "@nestjs/common";
-import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { AccountAuctionStats } from "./entities/account.auction.stats";
 import { Auction } from "./entities/account.auctions";
@@ -26,6 +26,37 @@ export class NftMarketplaceController {
     return this.nftMarketplaceService.getAuctions(
       new QueryPagination({ size }),
     );
+  }
+
+  @Get("/auctions/count")
+  @ApiOperation({ summary: 'Auction count', description: 'Returns all auctions count available on marketplaces ' })
+  @ApiOkResponse({ type: Number })
+  @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
+  getAuctionsCount(
+    @Query('status') status: AuctionStatus,
+  ): Promise<number> {
+    return this.nftMarketplaceService.getAuctionsCount(status);
+  }
+
+  @Get("/auctions/c")
+  @ApiExcludeEndpoint()
+  @ApiOperation({ summary: 'Auction count', description: 'Returns all auctions count available on marketplaces ' })
+  @ApiOkResponse({ type: Number })
+  @ApiQuery({ name: 'status', description: 'Returns auctions count with specified status', required: false })
+  getAuctionsCountAlternative(
+    @Query('status') status: AuctionStatus,
+  ): Promise<number> {
+    return this.nftMarketplaceService.getAuctionsCount(status);
+  }
+
+  @Get("/auctions/:id")
+  @ApiOperation({ summary: 'Auction details', description: 'Returns auction details for a specific auction identifier ' })
+  @ApiOkResponse({ type: Auctions })
+  @ApiQuery({ name: 'auctionId', description: 'Auction identifier', required: true })
+  getAuctionId(
+    @Param('id') id: string,
+  ): Promise<Auction> {
+    return this.nftMarketplaceService.getAuctionId(id);
   }
 
   @Get("/accounts/:address/auction/stats")
@@ -74,15 +105,5 @@ export class NftMarketplaceController {
     }
 
     return collectionStats;
-  }
-
-  @Get("/auctions/:id")
-  @ApiOperation({ summary: 'Auction ID', description: 'Returns auction details for a specific auction ID ' })
-  @ApiOkResponse({ type: Auctions })
-  @ApiQuery({ name: 'id', description: 'Auction ID', required: false })
-  getAuctionId(
-    @Param('id') id: string,
-  ): Promise<Auction> {
-    return this.nftMarketplaceService.getAuctionId(id);
   }
 }

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -249,7 +249,7 @@ export class NftMarketplaceService {
       };
 
       const result: any = await this.graphQlService.getNftServiceData(collectionAuctionsQuery, variables);
-      console.log(result);
+
       if (!result) {
         return auctions;
       }

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -107,12 +107,15 @@ export class NftMarketplaceService {
     const auction = result.auctions.edges[0].node;
 
     const auctionData: Auction = {
+      owner: auction.ownerAddress,
+      creator: auction.asset.creatorAddress,
       identifier: auction.identifier,
       collection: auction.collection,
       status: auction.status,
+      auctionType: auction.type,
       createdAt: auction.creationDate,
       marketplaceAuctionId: auction.marketplaceAuctionId,
-      marketplace: auction.marketplace,
+      marketplace: auction.marketplace.key,
       tags: auction.tags,
     };
 

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -86,10 +86,9 @@ export class NftMarketplaceService {
       accountAuction.collection = auction.node.collection;
       accountAuction.status = auction.node.status.toLowerCase();
       accountAuction.createdAt = auction.node.creationDate;
-      accountAuction.endsAt = auction.node.endDate;
+      accountAuction.endsAt = auction.node.endDate !== 0 ? auction.endDate : undefined;
       accountAuction.marketplace = auction.node.marketplace.key;
       accountAuction.marketplaceAuctionId = auction.node.marketplaceAuctionId;
-      accountAuction.tags = auction.node.tags;
 
       return accountAuction;
     });
@@ -108,20 +107,23 @@ export class NftMarketplaceService {
 
     const auctionData: Auction = {
       owner: auction.ownerAddress,
-      creator: auction.asset.creatorAddress,
       identifier: auction.identifier,
       collection: auction.collection,
       status: auction.status,
       auctionType: auction.type,
       createdAt: auction.creationDate,
+      endsAt: auction.endDate !== 0 ? auction.endDate : undefined,
       marketplaceAuctionId: auction.marketplaceAuctionId,
       marketplace: auction.marketplace.key,
-      tags: auction.tags,
+      minBid: {
+        amount: auction.minBid.amount,
+        token: auction.minBid.token,
+      },
+      maxBid: {
+        amount: auction.maxBid.amount,
+        token: auction.maxBid.token,
+      },
     };
-
-    if (auction.endDate !== 0) {
-      auctionData.endsAt = auction.endDate;
-    }
 
     return auctionData;
   }
@@ -163,11 +165,13 @@ export class NftMarketplaceService {
           currentAuction.owner = auction.node.ownerAddress;
           currentAuction.identifier = auction.node.identifier;
           currentAuction.collection = auction.node.collection;
-          currentAuction.nonce = auction.node.nonce;
-          currentAuction.id = auction.node.id;
-          currentAuction.marketPlaceId = auction.node.marketplaceAuctionId;
+          currentAuction.status = auction.node.status;
+          currentAuction.auctionType = auction.node.type;
+          currentAuction.auctionId = parseInt(auction.node.id);
+          currentAuction.marketplaceAuctionId = auction.node.marketplaceAuctionId;
           currentAuction.marketplace = auction.node.marketplaceKey;
           currentAuction.createdAt = auction.node.creationDate;
+          currentAuction.endsAt = auction.node.endDate !== 0 ? auction.endDate : undefined;
           currentAuction.minBid.amount = auction.node.minBid.amount;
           currentAuction.minBid.token = auction.node.minBid.token;
           currentAuction.maxBid.amount = auction.node.maxBid.amount;

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -97,7 +97,7 @@ export class NftMarketplaceService {
     return auctions.slice(from, from + size);
   }
 
-  async getAuctionId(id: string): Promise<Auction> {
+  async getAuctionId(id: number): Promise<Auction> {
     const result = await this.graphQlService.getNftServiceData(auctionId(id), {});
 
     if (!result) {

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -14,6 +14,7 @@ import { auctionsQuery } from "./graphql/auctions.query";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { AuctionStatus } from "./entities/auction.status";
 import BigNumber from "bignumber.js";
+import { auctionId } from "./graphql/auctionId.query";
 
 @Injectable()
 export class NftMarketplaceService {
@@ -25,7 +26,7 @@ export class NftMarketplaceService {
     const variables = { filters: { address } };
     const result: any = await this.graphQlService.getNftServiceData(accountStatsQuery, variables);
     if (!result) {
-      throw new BadRequestException('Count not fetch accountsStats data from Nft Marketplace');
+      throw new BadRequestException('Count not fetch data from nft service');
     }
 
     return {
@@ -44,7 +45,7 @@ export class NftMarketplaceService {
     const result: any = await this.graphQlService.getNftServiceData(collectionStatsQuery, variables);
 
     if (!result) {
-      throw new BadRequestException('Count not fetch collectionStats data from Nft Marketplace');
+      throw new BadRequestException('Count not fetch data from nft service');
     }
 
     return {
@@ -61,7 +62,7 @@ export class NftMarketplaceService {
     const result: any = await this.graphQlService.getNftServiceData(collectionsStatsQuery, {});
 
     if (!result) {
-      throw new BadRequestException('Count not fetch exploreCollectionsStats data from Nft Marketplace');
+      throw new BadRequestException('Count not fetch data from nft service');
     }
 
     return {
@@ -94,6 +95,32 @@ export class NftMarketplaceService {
     });
 
     return auctions.slice(from, from + size);
+  }
+
+  async getAuctionId(id: string): Promise<Auction> {
+    const result = await this.graphQlService.getNftServiceData(auctionId(id), {});
+
+    if (!result) {
+      throw new BadRequestException('Count not fetch data from nft service');
+    }
+
+    const auction = result.auctions.edges[0].node;
+
+    const auctionData: Auction = {
+      identifier: auction.identifier,
+      collection: auction.collection,
+      status: auction.status,
+      createdAt: auction.creationDate,
+      marketplaceAuctionId: auction.marketplaceAuctionId,
+      marketplace: auction.marketplace,
+      tags: auction.tags,
+    };
+
+    if (auction.endDate !== 0) {
+      auctionData.endsAt = auction.endDate;
+    }
+
+    return auctionData;
   }
 
   async getAuctions(pagination: QueryPagination): Promise<Auctions[]> {

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -14,8 +14,8 @@ import { auctionsQuery } from "./graphql/auctions.query";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { AuctionStatus } from "./entities/auction.status";
 import BigNumber from "bignumber.js";
-import { auctionId } from "./graphql/auctionId.query";
-import { auctionsCount } from "./graphql/auctions.count.query";
+import { auctionIdQuery } from "./graphql/auctionId.query";
+import { auctionsCountQuery } from "./graphql/auctions.count.query";
 import { collectionAuctionsQuery } from "./graphql/collection.auctions.query";
 
 @Injectable()
@@ -99,7 +99,7 @@ export class NftMarketplaceService {
   }
 
   async getAuctionId(id: number): Promise<Auction> {
-    const result = await this.graphQlService.getNftServiceData(auctionId(id), {});
+    const result = await this.graphQlService.getNftServiceData(auctionIdQuery(id), {});
 
     if (!result) {
       throw new BadRequestException('Count not fetch data from nft service');
@@ -217,7 +217,7 @@ export class NftMarketplaceService {
       },
     };
 
-    const result: any = await this.graphQlService.getNftServiceData(auctionsCount, variables);
+    const result: any = await this.graphQlService.getNftServiceData(auctionsCountQuery, variables);
 
     if (!result) {
       throw new BadRequestException('Count not fetch data from nft service');

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -248,8 +248,6 @@ export class NftMarketplaceService {
         "collection": collection,
       };
 
-      console.log(collection);
-
       const result: any = await this.graphQlService.getNftServiceData(collectionAuctionsQuery, variables);
       console.log(result);
       if (!result) {

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -68,7 +68,7 @@ export class NftMarketplaceService {
     const auctions = result.auctions.edges.map((auction: any) => {
       const accountAuction = new Auction();
 
-      accountAuction.auctionId = auction.node.id;
+      accountAuction.auctionId = parseInt(auction.node.id);
       accountAuction.identifier = auction.node.identifier;
       accountAuction.collection = auction.node.collection;
       accountAuction.status = auction.node.status.toLowerCase();

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -215,6 +215,34 @@ export class NftMarketplaceService {
     return result.auctions.pageData.count;
   }
 
+  async getCollectionAuctionsCount(collection: string): Promise<number> {
+    const variables = {
+      filters: {
+        filters: [
+          {
+            field: "status",
+            op: "EQ",
+            values: ["Running"],
+          },
+          {
+            field: 'collection',
+            op: 'EQ',
+            values: [collection],
+          },
+        ],
+        operator: 'AND',
+      },
+    };
+
+    const result: any = await this.graphQlService.getNftServiceData(auctionsCountQuery, variables);
+
+    if (!result) {
+      throw new BadRequestException('Count not fetch data from nft service');
+    }
+
+    return result.auctions.pageData.count;
+  }
+
   async getCollectionAuctions(pagination: QueryPagination, collection: string): Promise<Auctions[]> {
     let hasNextPage = true;
     let after = null;

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -15,6 +15,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { AuctionStatus } from "./entities/auction.status";
 import BigNumber from "bignumber.js";
 import { auctionId } from "./graphql/auctionId.query";
+import { auctionsCount } from "./graphql/auctions.count.query";
 
 @Injectable()
 export class NftMarketplaceService {
@@ -109,7 +110,7 @@ export class NftMarketplaceService {
       owner: auction.ownerAddress,
       identifier: auction.identifier,
       collection: auction.collection,
-      status: auction.status,
+      status: auction.status.toLowerCase(),
       auctionType: auction.type,
       createdAt: auction.creationDate,
       endsAt: auction.endDate !== 0 ? auction.endDate : undefined,
@@ -165,7 +166,7 @@ export class NftMarketplaceService {
           currentAuction.owner = auction.node.ownerAddress;
           currentAuction.identifier = auction.node.identifier;
           currentAuction.collection = auction.node.collection;
-          currentAuction.status = auction.node.status;
+          currentAuction.status = auction.node.status.toLowerCase();
           currentAuction.auctionType = auction.node.type;
           currentAuction.auctionId = parseInt(auction.node.id);
           currentAuction.marketplaceAuctionId = auction.node.marketplaceAuctionId;
@@ -199,5 +200,28 @@ export class NftMarketplaceService {
     }
 
     return auctions;
+  }
+
+  async getAuctionsCount(status?: AuctionStatus): Promise<number> {
+    const variables = {
+      filters: {
+        filters: [
+          {
+            field: 'status',
+            op: 'IN',
+            values: [status],
+          },
+        ],
+        operator: 'AND',
+      },
+    };
+
+    const result: any = await this.graphQlService.getNftServiceData(auctionsCount, variables);
+
+    if (!result) {
+      throw new BadRequestException('Count not fetch data from nft service');
+    }
+
+    return result.auctions.pageData.count;
   }
 }

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -243,6 +243,34 @@ export class NftMarketplaceService {
     return result.auctions.pageData.count;
   }
 
+  async getAccountAuctionsCount(address: string): Promise<number> {
+    const variables = {
+      filters: {
+        filters: [
+          {
+            field: "status",
+            op: "EQ",
+            values: ["Running"],
+          },
+          {
+            field: 'ownerAddress',
+            op: 'EQ',
+            values: [address],
+          },
+        ],
+        operator: 'AND',
+      },
+    };
+
+    const result: any = await this.graphQlService.getNftServiceData(auctionsCountQuery, variables);
+
+    if (!result) {
+      throw new BadRequestException('Count not fetch data from nft service');
+    }
+
+    return result.auctions.pageData.count;
+  }
+
   async getCollectionAuctions(pagination: QueryPagination, collection: string): Promise<Auctions[]> {
     let hasNextPage = true;
     let after = null;

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -4,11 +4,9 @@ import { AccountAuctionStats } from "./entities/account.auction.stats";
 import { Auction } from "./entities/account.auctions";
 import { CollectionAuctionStats } from "./entities/collection.auction.stats";
 import { CollectionStatsFilters } from "./entities/collection.stats.filter";
-import { ExploreCollectionsStats } from "./entities/explore.collections.stats";
 import { accountAuctionsQuery } from "./graphql/account.auctions.query";
 import { accountStatsQuery } from "./graphql/account.stats.query";
 import { collectionStatsQuery } from "./graphql/collection.stats.query";
-import { collectionsStatsQuery } from "./graphql/explore.query";
 import { Auctions } from "./entities/auctions";
 import { auctionsQuery } from "./graphql/auctions.query";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -60,19 +58,6 @@ export class NftMarketplaceService {
     };
   }
 
-  async getExploreCollectionsStats(): Promise<ExploreCollectionsStats> {
-    const result: any = await this.graphQlService.getNftServiceData(collectionsStatsQuery, {});
-
-    if (!result) {
-      throw new BadRequestException('Count not fetch data from nft service');
-    }
-
-    return {
-      verifiedCount: result.exploreCollectionsStats.verifiedCount,
-      activeLast30DaysCount: result.exploreCollectionsStats.activeLast30DaysCount,
-    };
-  }
-
   async getAccountAuctions(queryPagination: QueryPagination, address: string, state?: AuctionStatus): Promise<Auction[]> {
     const { from, size } = queryPagination;
     const result: any = await this.graphQlService.getNftServiceData(accountAuctionsQuery(address, state), {});
@@ -91,6 +76,10 @@ export class NftMarketplaceService {
       accountAuction.endsAt = auction.node.endDate !== 0 ? auction.endDate : undefined;
       accountAuction.marketplace = auction.node.marketplace.key;
       accountAuction.marketplaceAuctionId = auction.node.marketplaceAuctionId;
+      accountAuction.minBid.amount = auction.node.minBid.amount;
+      accountAuction.minBid.token = auction.node.minBid.token;
+      accountAuction.maxBid.amount = auction.node.maxBid.amount;
+      accountAuction.maxBid.token = auction.node.maxBid.token;
 
       return accountAuction;
     });

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -361,7 +361,7 @@ describe('Marketplace Service', () => {
       },
     };
 
-    it('should return the count of running auctions for a specific collections', async () => {
+    it('should return the count of running auctions for a specific collection', async () => {
       jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(mockResult);
 
       const result = await service.getCollectionAuctionsCount(collection);

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -374,4 +374,28 @@ describe('Marketplace Service', () => {
       await expect(service.getCollectionAuctionsCount(collection)).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('getAccountAuctionsCount', () => {
+    const collection: string = 'erd14wxx9p9kld06w66n6lcxcchv976n7crzma8w7s3tkaqcme8hr7fqdhhfdg';
+    const mockResult = {
+      auctions: {
+        pageData: {
+          count: 48,
+        },
+      },
+    };
+
+    it('should return the count of running auctions for a specific address', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(mockResult);
+
+      const result = await service.getAccountAuctionsCount(collection);
+      expect(result).toStrictEqual(48);
+    });
+
+    it('should throw a BadRequestException if the GraphQL query returns no results', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(Promise.resolve(null));
+
+      await expect(service.getAccountAuctionsCount(collection)).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -262,4 +262,62 @@ describe('Marketplace Service', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('getAuctionId', () => {
+    it('should return an auction details for a specific auctionId', async () => {
+      const auctionId: number = 847035;
+
+      const auction = {
+        auctions: {
+          edges: [
+            {
+              node: {
+                id: '847035',
+                identifier: 'Test-2d29f9-01',
+                collection: 'Test-2d29f9',
+                status: 'Running',
+                type: 'Nft',
+                creationDate: 1676576533,
+                endDate: 1676585733,
+                marketplace: { key: 'xoxno' },
+                asset: {
+                  creatorAddress: 'erd14wxx9p9kld06w66n6lcxcchv976n7crzma8w7s3tkaqcme8hr7fqdhhfdg',
+                },
+                minBid: { amount: '1900000000000000000', token: 'EGLD' },
+                maxBid: { amount: '1900000000000000000', token: 'EGLD' },
+                ownerAddress: 'erd14wxx9p9kld06w66n6lcxcchv976n7crzma8w7s3tkaqcme8hr7fqdhhfdg',
+                marketplaceAuctionId: 586854,
+                startDate: 1676576532,
+              },
+            },
+          ],
+        },
+      };
+
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(auction);
+
+      const result = await service.getAuctionId(auctionId);
+
+      expect(result).toEqual(expect.objectContaining({
+        owner: 'erd14wxx9p9kld06w66n6lcxcchv976n7crzma8w7s3tkaqcme8hr7fqdhhfdg',
+        identifier: 'Test-2d29f9-01',
+        collection: 'Test-2d29f9',
+        status: 'running',
+        auctionType: 'Nft',
+        createdAt: 1676576533,
+        endsAt: 1676585733,
+        marketplaceAuctionId: 586854,
+        marketplace: 'xoxno',
+        minBid: { amount: '1900000000000000000', token: 'EGLD' },
+        maxBid: { amount: '1900000000000000000', token: 'EGLD' },
+      }));
+    });
+
+    it('should throw a BadRequestException if result cannot be fetched', async () => {
+      const auctionId = 1111;
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(null);
+
+      await expect(service.getAuctionId(auctionId)).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -234,7 +234,7 @@ describe('Marketplace Service', () => {
 
       expect(actual).toEqual(expect.arrayContaining([
         expect.objectContaining({
-          auctionId: '1',
+          auctionId: 1,
           identifier: 'Test-2d29f9-1',
           collection: 'Test-2d29f9',
           status: 'running',

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -1,0 +1,73 @@
+import { Test } from "@nestjs/testing";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { NftMarketplaceService } from "src/endpoints/marketplace/nft.marketplace.service";
+import { RootTestModule } from "src/test/root-test.module";
+
+describe('Marketplace Service', () => {
+  let service: NftMarketplaceService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [RootTestModule],
+      providers: [NftMarketplaceService],
+    }).compile();
+
+    service = moduleRef.get<NftMarketplaceService>(NftMarketplaceService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getAuctions', () => {
+    it('should return an array of auctions', async () => {
+      const pagination = { size: 1 };
+
+      jest.spyOn(service['graphQlService'], 'getNftServiceData').mockResolvedValue({
+        auctions: {
+          edges: [
+            {
+              node: {
+                ownerAddress: 'erd1rwzt4gcqk9e6xqgzgvssdhad3l3pgzsqf08fqhzjrkkmp2kllgpsgppy4j',
+                identifier: 'Test-2d29f9-0103',
+                collection: 'Test-2d29f9',
+                status: 'running',
+                type: 'Nft',
+                id: '842843',
+                marketplaceAuctionId: '584150',
+                marketplaceKey: 'xoxno',
+                creationDate: '1676563203',
+                endDate: 0,
+                minBid: { amount: '1', token: '390000000000000000' },
+                maxBid: { amount: '2', token: 'EGLD' },
+              },
+            },
+          ],
+          pageInfo: {
+            endCursor: '123',
+            hasNextPage: true,
+          },
+        },
+      });
+
+      const result = await service.getAuctions(new QueryPagination(pagination));
+
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          owner: 'erd1rwzt4gcqk9e6xqgzgvssdhad3l3pgzsqf08fqhzjrkkmp2kllgpsgppy4j',
+          auctionId: 842843,
+          identifier: 'Test-2d29f9-0103',
+          collection: 'Test-2d29f9',
+          status: 'running',
+          auctionType: 'Nft',
+          createdAt: '1676563203',
+          endsAt: undefined,
+          marketplaceAuctionId: '584150',
+          marketplace: 'xoxno',
+          minBid: { amount: '1', token: '390000000000000000' },
+          maxBid: { amount: '2', token: 'EGLD' },
+        }),
+      ]));
+    });
+  });
+});

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -350,4 +350,28 @@ describe('Marketplace Service', () => {
       await expect(service.getAuctionsCount()).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('getCollectionAuctionsCount', () => {
+    const collection: string = 'Test-2d29f9';
+    const mockResult = {
+      auctions: {
+        pageData: {
+          count: 2109,
+        },
+      },
+    };
+
+    it('should return the count of running auctions for a specific collections', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(mockResult);
+
+      const result = await service.getCollectionAuctionsCount(collection);
+      expect(result).toStrictEqual(2109);
+    });
+
+    it('should throw a BadRequestException if the GraphQL query returns no results', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(Promise.resolve(null));
+
+      await expect(service.getCollectionAuctionsCount(collection)).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/src/test/integration/services/marketplace.e2e-spec.ts
+++ b/src/test/integration/services/marketplace.e2e-spec.ts
@@ -320,4 +320,34 @@ describe('Marketplace Service', () => {
       await expect(service.getAuctionId(auctionId)).rejects.toThrow(BadRequestException);
     });
   });
+
+  describe('getAuctionsCount', () => {
+    const mockResult = {
+      auctions: {
+        pageData: {
+          count: 10,
+        },
+      },
+    };
+
+    it('should return the count of all auctions if no status is provided', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(mockResult);
+
+      const result = await service.getAuctionsCount();
+      expect(result).toStrictEqual(10);
+    });
+
+    it('should return the count of auctions with the specified status', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(mockResult);
+
+      const result = await service.getAuctionsCount(AuctionStatus.running);
+      expect(result).toStrictEqual(10);
+    });
+
+    it('should throw a BadRequestException if the GraphQL query returns no results', async () => {
+      jest.spyOn(graphQlService, 'getNftServiceData').mockResolvedValue(Promise.resolve(null));
+
+      await expect(service.getAuctionsCount()).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/src/test/root-test.module.ts
+++ b/src/test/root-test.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { GraphQlService } from "src/common/graphql/graphql.service";
+
+@Module({
+  providers: [GraphQlService, ApiConfigService, ConfigService],
+  exports: [GraphQlService],
+})
+export class RootTestModule { }


### PR DESCRIPTION
## Reasoning
- The query from nft data service returns 10 auctions so that the number of elements cannot be changed. 
  
## Proposed Changes
- Apply a cursor and pagination in the query that allows the display of several elements depending on the required size. By default will be 25.

## How to test
- /auctions -> return 25 auctions
- /auctions?size=1 -> return 1 auction

Auction details:
- /auctions/842224 -> return auction details for a specific auction id

Auctions count:
- /auctions/count -> return auctions count ~436631
- /auctions/count?status=running -> return auctions count with status `running` ~122405

Collection auctions:
- /collection/CRTMBT-9b5699/auctions -> return all auctions with status = running for a specific collection   

Account auctions count:
- /accounts/erd14qqefhazlg7j7ea5v58vfzen3y6wycpyzjle7m24mx3nae9vpz9q95atps/auctions/count -> return running auctions count for a specific address

Collection auctions count:
- /collections/COW-cd463d/auctions/count -> return running auctions count for a specific collection