### PR TITLE
Feature flag for exchange service

### DIFF
--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -654,13 +654,35 @@ export class ApiConfigService {
     return this.configService.get<number>('nftProcess.maxRetries') ?? 3;
   }
 
+  private isExchangeEnabledInternal(): boolean {
+    return this.configService.get<boolean>('features.exchange.enabled') ?? false;
+  }
+
+  private getExchangeServiceUrlLegacy(): string | undefined {
+    return this.configService.get<string>('transaction-action.mex.microServiceUrl') ?? this.configService.get<string>('plugins.transaction-action.mex.microServiceUrl');
+  }
+
+  isExchangeEnabled(): boolean {
+    const isExchangeEnabled = this.isExchangeEnabledInternal();
+    if (isExchangeEnabled) {
+      return true;
+    }
+
+    const legacyUrl = this.getExchangeServiceUrlLegacy();
+    if (legacyUrl) {
+      return true;
+    }
+
+    return false;
+  }
+
   getExchangeServiceUrl(): string | undefined {
-    const isExchangeEnabled = this.configService.get<boolean>('features.exchange.enabled') ?? false;
+    const isExchangeEnabled = this.isExchangeEnabledInternal();
     if (isExchangeEnabled) {
       return this.configService.get<string>('features.exchange.serviceUrl');
     }
 
-    const legacyUrl = this.configService.get<string>('transaction-action.mex.microServiceUrl') ?? this.configService.get<string>('plugins.transaction-action.mex.microServiceUrl');
+    const legacyUrl = this.getExchangeServiceUrlLegacy();
     if (legacyUrl) {
       return legacyUrl;
     }

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -411,7 +411,7 @@ export class ApiConfigService {
   }
 
   getIsAuthActive(): boolean {
-    return this.configService.get<boolean>('api.auth') ?? false;
+    return this.configService.get<boolean>('features.auth.enabled') ?? this.configService.get<boolean>('api.auth') ?? false;
   }
 
   getDatabaseType(): string {

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -411,7 +411,7 @@ export class ApiConfigService {
   }
 
   getIsAuthActive(): boolean {
-    return this.configService.get<boolean>('features.auth.enabled') ?? this.configService.get<boolean>('api.auth') ?? false;
+    return this.configService.get<boolean>('api.auth') ?? false;
   }
 
   getDatabaseType(): string {

--- a/src/common/locked-asset/locked-asset.module.ts
+++ b/src/common/locked-asset/locked-asset.module.ts
@@ -6,7 +6,7 @@ import { MexModule } from 'src/endpoints/mex/mex.module';
 @Module({
   imports: [
     VmQueryModule,
-    MexModule,
+    MexModule.forRoot(),
   ],
   providers: [
     LockedAssetService,

--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -15,7 +15,7 @@ import { PluginModule } from 'src/plugins/plugin.module';
     ScheduleModule.forRoot(),
     EndpointsServicesModule,
     KeybaseModule,
-    MexModule,
+    MexModule.forRoot(),
     AssetsModule,
     NftCronModule,
     PluginModule,

--- a/src/endpoints/endpoints.controllers.module.ts
+++ b/src/endpoints/endpoints.controllers.module.ts
@@ -44,13 +44,18 @@ export class EndpointsControllersModule {
       KeysController, MiniBlockController, NetworkController, NftController, TagController, NodeController,
       ProviderController, ProxyController, RoundController, SmartContractResultController, ShardController, StakeController, StakeController,
       TokenController, TransactionController, UsernameController, VmQueryController, WaitingListController,
-      HealthCheckController, DappConfigController, WebsocketController, MexController, TransferController,
+      HealthCheckController, DappConfigController, WebsocketController, TransferController,
       ProcessNftsPublicController, TransactionsBatchController,
     ];
 
     const isMarketplaceFeatureEnabled = configuration().features?.marketplace?.enabled ?? false;
     if (isMarketplaceFeatureEnabled) {
       controllers.push(NftMarketplaceController);
+    }
+
+    const isExchangeEnabled = configuration().features?.exchange?.enabled ?? false;
+    if (isExchangeEnabled) {
+      controllers.push(MexController);
     }
 
     return {

--- a/src/endpoints/endpoints.controllers.module.ts
+++ b/src/endpoints/endpoints.controllers.module.ts
@@ -53,7 +53,11 @@ export class EndpointsControllersModule {
       controllers.push(NftMarketplaceController);
     }
 
-    const isExchangeEnabled = configuration().features?.exchange?.enabled ?? false;
+    const isExchangeEnabled =
+      (configuration().features?.exchange?.enabled ?? false) ||
+      (configuration()['transaction-action']?.mex?.microServiceUrl) ||
+      (configuration()['plugins']?.['transaction-action']?.['mex']?.['microServiceUrl']);
+
     if (isExchangeEnabled) {
       controllers.push(MexController);
     }

--- a/src/endpoints/endpoints.services.module.ts
+++ b/src/endpoints/endpoints.services.module.ts
@@ -65,7 +65,7 @@ import { WebsocketModule } from "./websocket/websocket.module";
     TransferModule,
     TransactionActionModule,
     WebsocketModule,
-    MexModule,
+    MexModule.forRoot(),
     ProcessNftsModule,
     NftMarketplaceModule,
     TransactionsBatchModule,

--- a/src/endpoints/esdt/esdt.module.ts
+++ b/src/endpoints/esdt/esdt.module.ts
@@ -17,7 +17,7 @@ import { AssetsModule } from "src/common/assets/assets.module";
     forwardRef(() => TokenModule),
     VmQueryModule,
     forwardRef(() => TransactionModule),
-    forwardRef(() => MexModule),
+    forwardRef(() => MexModule.forRoot()),
     forwardRef(() => AssetsModule),
   ],
   providers: [

--- a/src/endpoints/mex/mex.farm.service.ts
+++ b/src/endpoints/mex/mex.farm.service.ts
@@ -7,6 +7,7 @@ import { GraphQlService } from "src/common/graphql/graphql.service";
 import { MexFarm } from "./entities/mex.farm";
 import { MexTokenService } from "./mex.token.service";
 import { MexStakingProxy } from "./entities/mex.staking.proxy";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
 
 @Injectable()
 export class MexFarmService {
@@ -15,6 +16,7 @@ export class MexFarmService {
     private readonly graphQlService: GraphQlService,
     @Inject(forwardRef(() => MexTokenService))
     private readonly mexTokenService: MexTokenService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   async refreshMexFarms(): Promise<void> {
@@ -31,6 +33,10 @@ export class MexFarmService {
   }
 
   async getAllMexFarms(): Promise<MexFarm[]> {
+    if (!this.apiConfigService.isExchangeEnabled()) {
+      return [];
+    }
+
     return await this.cachingService.getOrSetCache(
       CacheInfo.MexFarms.key,
       async () => await this.getAllMexFarmsRaw(),
@@ -158,6 +164,10 @@ export class MexFarmService {
   }
 
   async getAllStakingProxies(): Promise<MexStakingProxy[]> {
+    if (!this.apiConfigService.isExchangeEnabled()) {
+      return [];
+    }
+
     return await this.cachingService.getOrSetCache(
       CacheInfo.StakingProxies.key,
       async () => await this.getAllStakingProxiesRaw(),

--- a/src/endpoints/mex/mex.module.ts
+++ b/src/endpoints/mex/mex.module.ts
@@ -1,28 +1,44 @@
-import { Module } from "@nestjs/common";
+import { DynamicModule, Module, Provider, Type } from "@nestjs/common";
+import configuration from "config/configuration";
 import { GraphQlModule } from "src/common/graphql/graphql.module";
+import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { MexEconomicsService } from "./mex.economics.service";
 import { MexFarmService } from "./mex.farm.service";
 import { MexPairService } from "./mex.pair.service";
 import { MexSettingsService } from "./mex.settings.service";
 import { MexTokenService } from "./mex.token.service";
+import { MexWarmerService } from "./mex.warmer.service";
 
-@Module({
-  imports: [
-    GraphQlModule,
-  ],
-  providers: [
-    MexEconomicsService,
-    MexSettingsService,
-    MexPairService,
-    MexTokenService,
-    MexFarmService,
-  ],
-  exports: [
-    MexEconomicsService,
-    MexPairService,
-    MexSettingsService,
-    MexTokenService,
-    MexFarmService,
-  ],
-})
-export class MexModule { }
+@Module({})
+export class MexModule {
+  static forRoot(): DynamicModule {
+    const providers: (Type<any> | Provider<any>)[] = [
+      DynamicModuleUtils.getPubSubService(),
+      MexEconomicsService,
+      MexSettingsService,
+      MexPairService,
+      MexTokenService,
+      MexFarmService,
+    ];
+
+    const isExchangeEnabled = configuration().features?.exchange?.enabled ?? false;
+    if (isExchangeEnabled) {
+      providers.push(MexWarmerService);
+    }
+
+    return {
+      module: MexModule,
+      imports: [
+        GraphQlModule,
+      ],
+      providers,
+      exports: [
+        MexEconomicsService,
+        MexPairService,
+        MexSettingsService,
+        MexTokenService,
+        MexFarmService,
+      ],
+    };
+  }
+}

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -8,6 +8,7 @@ import { MexPairState } from "./entities/mex.pair.state";
 import { MexPairType } from "./entities/mex.pair.type";
 import { MexSettingsService } from "./mex.settings.service";
 import { OriginLogger } from "@multiversx/sdk-nestjs";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
 
 @Injectable()
 export class MexPairService {
@@ -17,6 +18,7 @@ export class MexPairService {
     private readonly cachingService: CachingService,
     private readonly mexSettingService: MexSettingsService,
     private readonly graphQlService: GraphQlService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   async refreshMexPairs(): Promise<void> {
@@ -37,6 +39,10 @@ export class MexPairService {
   }
 
   async getAllMexPairs(): Promise<MexPair[]> {
+    if (!this.apiConfigService.isExchangeEnabled()) {
+      return [];
+    }
+
     return await this.cachingService.getOrSetCache(
       CacheInfo.MexPairs.key,
       async () => await this.getAllMexPairsRaw(),

--- a/src/endpoints/mex/mex.settings.service.ts
+++ b/src/endpoints/mex/mex.settings.service.ts
@@ -6,6 +6,7 @@ import { GraphQlService } from "src/common/graphql/graphql.service";
 import { TransactionMetadata } from "../transactions/transaction-action/entities/transaction.metadata";
 import { TransactionMetadataTransfer } from "../transactions/transaction-action/entities/transaction.metadata.transfer";
 import { MexSettings } from "./entities/mex.settings";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
 
 @Injectable()
 export class MexSettingsService {
@@ -14,6 +15,7 @@ export class MexSettingsService {
   constructor(
     private readonly cachingService: CachingService,
     private readonly graphQlService: GraphQlService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   getTransfers(metadata: TransactionMetadata): TransactionMetadataTransfer[] | undefined {
@@ -41,6 +43,10 @@ export class MexSettingsService {
   }
 
   async getSettings(): Promise<MexSettings | null> {
+    if (!this.apiConfigService.isExchangeEnabled()) {
+      return null;
+    }
+
     const settings = await this.cachingService.getOrSetCache(
       CacheInfo.MexSettings.key,
       async () => await this.getSettingsRaw(),

--- a/src/endpoints/mex/mex.warmer.service.ts
+++ b/src/endpoints/mex/mex.warmer.service.ts
@@ -1,0 +1,64 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { ClientProxy } from "@nestjs/microservices";
+import { CacheInfo } from "src/utils/cache.info";
+import { MexSettingsService } from "src/endpoints/mex/mex.settings.service";
+import { MexEconomicsService } from "src/endpoints/mex/mex.economics.service";
+import { MexPairService } from "src/endpoints/mex/mex.pair.service";
+import { MexTokenService } from "src/endpoints/mex/mex.token.service";
+import { MexFarmService } from "src/endpoints/mex/mex.farm.service";
+import { CachingService, Lock, Locker } from "@multiversx/sdk-nestjs";
+
+@Injectable()
+export class MexWarmerService {
+  constructor(
+    private readonly cachingService: CachingService,
+    @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
+    private readonly mexEconomicsService: MexEconomicsService,
+    private readonly mexPairsService: MexPairService,
+    private readonly mexTokensService: MexTokenService,
+    private readonly mexSettingsService: MexSettingsService,
+    private readonly mexFarmsService: MexFarmService,
+  ) { }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleMexInvalidations() {
+    await Locker.lock('Refreshing mex pairs', async () => {
+      await this.mexPairsService.refreshMexPairs();
+    }, true);
+
+    await Locker.lock('Refreshing mex economics', async () => {
+      await this.mexEconomicsService.refreshMexEconomics();
+    }, true);
+
+    await Locker.lock('Refreshing mex tokens', async () => {
+      await this.mexTokensService.refreshMexTokens();
+    }, true);
+
+    await Locker.lock('Refreshing mex farms', async () => {
+      await this.mexFarmsService.refreshMexFarms();
+    }, true);
+
+    await Locker.lock('Refreshing mex settings', async () => {
+      await this.mexSettingsService.refreshSettings();
+    }, true);
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  @Lock({ name: 'Mex settings invalidations' })
+  async handleMexSettings() {
+    const settings = await this.mexSettingsService.getSettingsRaw();
+    if (settings) {
+      await this.invalidateKey(CacheInfo.MexSettings.key, settings, CacheInfo.MexSettings.ttl);
+    }
+  }
+
+  private async invalidateKey(key: string, data: any, ttl: number) {
+    await this.cachingService.setCache(key, data, ttl);
+    await this.refreshCacheKey(key, ttl);
+  }
+
+  private async refreshCacheKey(key: string, ttl: number) {
+    await this.clientProxy.emit('refreshCacheKey', { key, ttl });
+  }
+}

--- a/src/endpoints/nfts/nft.module.ts
+++ b/src/endpoints/nfts/nft.module.ts
@@ -18,7 +18,7 @@ import { LockedAssetModule } from "../../common/locked-asset/locked-asset.module
     forwardRef(() => CollectionModule),
     forwardRef(() => PluginModule),
     forwardRef(() => NftMetadataModule),
-    forwardRef(() => MexModule),
+    forwardRef(() => MexModule.forRoot()),
     forwardRef(() => AssetsModule),
     forwardRef(() => LockedAssetModule),
     NftMediaModule,

--- a/src/endpoints/tokens/token.module.ts
+++ b/src/endpoints/tokens/token.module.ts
@@ -14,7 +14,7 @@ import { CollectionModule } from "../collections/collection.module";
     forwardRef(() => NftModule),
     forwardRef(() => TransactionModule),
     forwardRef(() => AssetsModule),
-    forwardRef(() => MexModule),
+    forwardRef(() => MexModule.forRoot()),
     forwardRef(() => CollectionModule),
   ],
   providers: [

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.module.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.module.ts
@@ -14,9 +14,8 @@ import { MexModule } from "src/endpoints/mex/mex.module";
   imports: [
     forwardRef(() => TokenModule),
     forwardRef(() => TransactionActionModule),
-    MexModule,
     ApiConfigModule,
-    MexModule,
+    MexModule.forRoot(),
   ],
   providers: [
     TransactionActionMexRecognizerService,

--- a/src/graphql/entities/graphql.services.module.ts
+++ b/src/graphql/entities/graphql.services.module.ts
@@ -21,7 +21,7 @@ import { NodeModule } from "src/graphql/entities/nodes/nodes.module";
 import { RoundModule } from "src/graphql/entities/rounds/rounds.module";
 import { ProviderModule } from "src/graphql/entities/providers/providers.module";
 import { StakeModule } from "src/graphql/entities/stake/stake.module";
-import { MexModule } from "src/graphql/entities/xexchange/mex.token.module";
+import { MexTokenModule } from "src/graphql/entities/xexchange/mex.token.module";
 import { TokenModule } from "src/graphql/entities/tokens/tokens.module";
 import { WebsocketModule } from "src/graphql/entities/web.socket/web.socket.module";
 import { TransferModule } from "src/graphql/entities/transfers/transfers.module";
@@ -51,7 +51,7 @@ import { TransferModule } from "src/graphql/entities/transfers/transfers.module"
     RoundModule,
     ProviderModule,
     StakeModule,
-    MexModule,
+    MexTokenModule,
     TokenModule,
     WebsocketModule,
     TransferModule,
@@ -60,7 +60,7 @@ import { TransferModule } from "src/graphql/entities/transfers/transfers.module"
     AccountDetailedModule, AccountModule, NftModule, NftCollectionModule, SmartContractResultModule, TransactionDetailedModule,
     TransactionModule, TagModule, DelegationModule, DappConfigModule, WaitingListModule, UsernameModule, BlockModule,
     MiniBlockModule, NetworkModule, ShardModule, DelegationLegacyModule, IdentitiesModule, NodeModule, RoundModule, ProviderModule,
-    StakeModule, MexModule, TokenModule, WebsocketModule, TransferModule,
+    StakeModule, MexTokenModule, TokenModule, WebsocketModule, TransferModule,
   ],
 })
 export class GraphQLServicesModule { }

--- a/src/graphql/entities/xexchange/mex.token.module.ts
+++ b/src/graphql/entities/xexchange/mex.token.module.ts
@@ -1,16 +1,16 @@
 import { Module } from "@nestjs/common";
-import { MexModule as InternalMexModule } from "src/endpoints/mex/mex.module";
+import { MexModule } from "src/endpoints/mex/mex.module";
 import { MexEconomicsResolver } from "./mex.economics/mex.economics.resolver";
 import { MexFarmResolver } from "./mex.farms/mex.farms.resolver";
 import { MexTokenPairsResolver } from "./mex.pairs/mex.pairs.resolver";
-import { MexTokensResolver } from "./mex.token/mex.token.resolver";
+import { MexTokenResolver } from "./mex.token/mex.token.resolver";
 @Module({
-  imports: [InternalMexModule],
+  imports: [MexModule.forRoot()],
   providers: [
-    MexTokensResolver,
+    MexTokenResolver,
     MexEconomicsResolver,
     MexTokenPairsResolver,
     MexFarmResolver,
   ],
 })
-export class MexModule { }
+export class MexTokenModule { }

--- a/src/graphql/entities/xexchange/mex.token/mex.token.resolver.ts
+++ b/src/graphql/entities/xexchange/mex.token/mex.token.resolver.ts
@@ -4,7 +4,7 @@ import { MexTokenService } from "src/endpoints/mex/mex.token.service";
 import { MexTokensQuery } from "./mex.token.query";
 
 @Resolver(() => MexToken)
-export class MexTokensResolver extends MexTokensQuery {
+export class MexTokenResolver extends MexTokensQuery {
   constructor(mexTokenService: MexTokenService) {
     super(mexTokenService);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,7 +140,10 @@ async function bootstrap() {
   logger.log(`Cache warmer active: ${apiConfigService.getIsCacheWarmerCronActive()}`);
   logger.log(`Queue worker active: ${apiConfigService.getIsQueueWorkerCronActive()}`);
   logger.log(`Elastic updater active: ${apiConfigService.getIsElasticUpdaterCronActive()}`);
-  logger.log(`Events notifier active: ${apiConfigService.isEventsNotifierFeatureActive()}`);
+  logger.log(`Events notifier feature active: ${apiConfigService.isEventsNotifierFeatureActive()}`);
+  logger.log(`Exchange feature active: ${apiConfigService.isExchangeEnabled()}`);
+  logger.log(`Marketplace feature active: ${apiConfigService.isMarketplaceFeatureEnabled()}`);
+  logger.log(`Auth active: ${apiConfigService.getIsAuthActive()}`);
 
   logger.log(`Use tracing: ${apiConfigService.getUseTracingFlag()}`);
   logger.log(`Process NFTs flag: ${apiConfigService.getIsProcessNftsFlagActive()}`);


### PR DESCRIPTION
## Reasoning
- Work in progress for moving optional functionality inside the `features` element
  
## Proposed Changes
- Backwards compatible support for both the legacy way and the new way of integrating exchange url

## How to test (mainnet)
Add the following config value
```yaml
features:
  exchange:
    enabled: true
    serviceUrl: 'https://graph.xexchange.com/graphql'
```
Then verify that the mex-specific endpoints are loaded and the cache warmer processes start. When disabling / omitting this feature, the mex specific endpoints should not appear, and also no mex-specific cache warmer actions should be performed