### PR TITLE
Proxify guardian data endpoint

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -22,6 +22,7 @@ export enum GatewayComponentRequest {
   addressNonce = 'addressNonce',
   addressShard = 'addressShard',
   addressStorage = 'addressStorage',
+  guardianData = 'guardianData',
   addressTransactions = 'addressTransactions',
   simulateTransaction = 'simulateTransaction',
   sendTransactionMultiple = 'sendTransactionMultiple',

--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -57,6 +57,12 @@ export class ProxyController {
     return await this.gatewayGet(`address/${address}/transactions`, GatewayComponentRequest.addressTransactions);
   }
 
+  @Get('/address/:address/guardian-data')
+  @ApiExcludeEndpoint()
+  async getAddressGuardianData(@Param('address', ParseAddressPipe) address: string) {
+    return await this.gatewayGet(`address/${address}/guardian-data`, GatewayComponentRequest.guardianData);
+  }
+
   @Get('/address/:address/esdt')
   @ApiExcludeEndpoint()
   async getAddressEsdt(@Param('address', ParseAddressPipe) address: string) {


### PR DESCRIPTION
## Proposed Changes
- Include support for account guardian data

## How to test
- `/address/:address/guardian-data` should return guardian data if supported on gateway
