### PR TITLE
Corrected endpoint for retrieving account key from storage

### DIFF
--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -45,10 +45,10 @@ export class ProxyController {
     return await this.gatewayGet(`address/${address}/shard`, GatewayComponentRequest.addressShard);
   }
 
-  @Get('/address/:address/storage/:key')
+  @Get('/address/:address/key/:key')
   @ApiExcludeEndpoint()
   async getAddressStorageKey(@Param('address', ParseAddressPipe) address: string, @Param('key') key: string) {
-    return await this.gatewayGet(`address/${address}/storage/${key}`, GatewayComponentRequest.addressStorage);
+    return await this.gatewayGet(`address/${address}/key/${key}`, GatewayComponentRequest.addressStorage);
   }
 
   @Get('/address/:address/transactions')


### PR DESCRIPTION
## Proposed Changes
- Replaced address `storage` with `key` for fetching key information

## How to test (mainnet)
- `/address/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l/key/0000000000000000000100000000000000000000000000000000000002ffffff` should return the content of the storage of the given key, just like it does from the gateway
