### PR TITLE
JWT or native auth for cache controllers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
         "@multiversx/sdk-data-api-client": "^0.4.4",
-        "@multiversx/sdk-nestjs": "^0.4.2",
+        "@multiversx/sdk-nestjs": "^0.4.3",
         "@nestjs/apollo": "^10.1.3",
         "@nestjs/common": "^9.1.4",
         "@nestjs/config": "^2.2.0",
@@ -3503,9 +3503,9 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@multiversx/sdk-nestjs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.2.tgz",
-      "integrity": "sha512-NaHXaN6avGzhp9DZT33IhMtALYC3bK22TPyZ+2zGZOL4QFpt62BvVZzUCTLzDwrzcWq1cdVMxaLALXZKLWIZQQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.3.tgz",
+      "integrity": "sha512-DRPNuANbGpT0X5ss9STihvcM2AbUGmGiQeVGYnUM/FQVp6urd5yM/JVxU+1iZk+bu40gt7I5kVDbxVq3uzU9Pw==",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",
@@ -18396,9 +18396,9 @@
       }
     },
     "@multiversx/sdk-nestjs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.2.tgz",
-      "integrity": "sha512-NaHXaN6avGzhp9DZT33IhMtALYC3bK22TPyZ+2zGZOL4QFpt62BvVZzUCTLzDwrzcWq1cdVMxaLALXZKLWIZQQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.3.tgz",
+      "integrity": "sha512-DRPNuANbGpT0X5ss9STihvcM2AbUGmGiQeVGYnUM/FQVp6urd5yM/JVxU+1iZk+bu40gt7I5kVDbxVq3uzU9Pw==",
       "requires": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",
     "@multiversx/sdk-data-api-client": "^0.4.4",
-    "@multiversx/sdk-nestjs": "^0.4.2",
+    "@multiversx/sdk-nestjs": "^0.4.3",
     "@nestjs/apollo": "^10.1.3",
     "@nestjs/common": "^9.1.4",
     "@nestjs/config": "^2.2.0",

--- a/src/endpoints/caching/local.cache.controller.ts
+++ b/src/endpoints/caching/local.cache.controller.ts
@@ -1,4 +1,4 @@
-import { CachingService, JwtAdminGuard, JwtAuthenticateGuard } from "@multiversx/sdk-nestjs";
+import { CachingService, JwtAdminGuard, JwtOrNativeAuthGuard } from "@multiversx/sdk-nestjs";
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Param, Put, UseGuards } from "@nestjs/common";
 import { ApiExcludeController, ApiResponse } from "@nestjs/swagger";
 import { CacheValue } from "./entities/cache.value";
@@ -10,7 +10,7 @@ export class LocalCacheController {
     private readonly cachingService: CachingService,
   ) { }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Get("/:key")
   @ApiResponse({
     status: 200,
@@ -29,7 +29,7 @@ export class LocalCacheController {
     return JSON.stringify(value);
   }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Put("/:key")
   @ApiResponse({
     status: 200,
@@ -39,7 +39,7 @@ export class LocalCacheController {
     await this.cachingService.setCacheLocal(key, cacheValue.value, cacheValue.ttl);
   }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Delete("/:key")
   @ApiResponse({
     status: 200,

--- a/src/endpoints/caching/remote.cache.controller.ts
+++ b/src/endpoints/caching/remote.cache.controller.ts
@@ -1,4 +1,4 @@
-import { CachingService, JwtAdminGuard, JwtAuthenticateGuard } from "@multiversx/sdk-nestjs";
+import { CachingService, JwtAdminGuard, JwtOrNativeAuthGuard } from "@multiversx/sdk-nestjs";
 import { Body, Controller, Delete, Get, HttpException, HttpStatus, Inject, Param, Put, Query, UseGuards } from "@nestjs/common";
 import { ClientProxy } from "@nestjs/microservices";
 import { ApiExcludeController, ApiResponse } from "@nestjs/swagger";
@@ -12,7 +12,7 @@ export class RemoteCacheController {
     @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
   ) { }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Get("/:key")
   @ApiResponse({
     status: 200,
@@ -31,7 +31,7 @@ export class RemoteCacheController {
     return JSON.stringify(value);
   }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Put("/:key")
   @ApiResponse({
     status: 200,
@@ -42,7 +42,7 @@ export class RemoteCacheController {
     this.clientProxy.emit('deleteCacheKeys', [key]);
   }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Delete("/:key")
   @ApiResponse({
     status: 200,
@@ -57,7 +57,7 @@ export class RemoteCacheController {
     this.clientProxy.emit('deleteCacheKeys', keys);
   }
 
-  @UseGuards(JwtAuthenticateGuard, JwtAdminGuard)
+  @UseGuards(JwtOrNativeAuthGuard, JwtAdminGuard)
   @Get("/")
   async getKeys(
     @Query('keys') keys: string | undefined,


### PR DESCRIPTION
## Proposed Changes
- Allow using both tokens for accessing private cache controllers

## How to test
- use native auth token on `http://localhost:4001/cache/remote?keys=*historical-price:EGLD* `
