### PR TITLE
fix required fields for upgrades endpoint

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -898,6 +898,8 @@ export class AccountController {
 
   @Get("/accounts/:address/upgrades")
   @ApiOperation({ summary: 'Account upgrades details', description: 'Returns all upgrades details for a specific contract address' })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiOkResponse({ type: ContractUpgrades })
   getContractUpgrades(
     @Param('address', ParseAddressPipe) address: string,


### PR DESCRIPTION
## Reasoning
-  /upgrades endpoint fields `from` and `size` was required
  
## Proposed Changes
-  Set required = false for `from` and `size` fields

## How to test
- go to swagger docs and verify if `from` and `size` are not longer required
- verify accounts/erd1qqqqqqqqqqqqqpgqeel2kumf0r8ffyhth7pqdujjat9nx0862jpsg2pqaq/upgrades?size=1
