### PR TITLE
fix performance issue for auctions endpoint

### DIFF
--- a/src/endpoints/marketplace/graphql/auctions.query.ts
+++ b/src/endpoints/marketplace/graphql/auctions.query.ts
@@ -1,7 +1,6 @@
 import { gql } from "graphql-request";
-
 export const auctionsQuery = gql`
-query GetAuctions($first: Int, $after: String, $before: String) {
+query GetAuctions($first: Int, $after: String, $before: String, $currentTimestamp: String) {
   auctions(
     pagination: {
       first: $first,
@@ -16,12 +15,20 @@ query GetAuctions($first: Int, $after: String, $before: String) {
           op: EQ,
           values: ["Running"]
         }
+        {
+          field: "startDate",
+          op: LE,
+          values: [$currentTimestamp]
+        }
       ]
     }
     sorting: {
       direction: DESC,
       field: "creationDate"
     }
+    grouping:{
+      groupBy: IDENTIFIER
+    },
   ) {
     edges {
       cursor

--- a/src/endpoints/marketplace/nft.marketplace.service.ts
+++ b/src/endpoints/marketplace/nft.marketplace.service.ts
@@ -125,6 +125,7 @@ export class NftMarketplaceService {
 
     const pageSize = pagination.size;
     const totalPages = Math.ceil(pagination.size / pageSize);
+    const currentTimestamp = Math.round(Date.now() / 1000).toString();
 
     let pagesLeft = Math.min(totalPages, 3); // Fetch up to 3 pages by default
 
@@ -138,6 +139,7 @@ export class NftMarketplaceService {
       const variables = {
         "first": pageSize,
         "after": after,
+        "currentTimestamp": currentTimestamp,
       };
 
       const result: any = await this.graphQlService.getNftServiceData(auctionsQuery, variables);


### PR DESCRIPTION
## Reasoning
-  Auctions endpoint had response time > 1000 ms
  
## Proposed Changes
- Add currentTimestamp for the live auctions query
- Add Grouping by identifier

## How to test
- make an request to /auctions and response time should be < 300 ms
