### PR TITLE
More precision for node versions

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -94,7 +94,7 @@ export class NodeService {
     }, 0);
 
     Object.keys(data).forEach((key) => {
-      data[key] = parseFloat((data[key] / sum).toFixed(2));
+      data[key] = parseFloat((data[key] / sum).toFixed(4));
     });
 
     const numbers: number[] = Object.values(data);
@@ -103,7 +103,7 @@ export class NodeService {
 
     for (const key of Object.keys(data)) {
       if (data[key] === largestNumber) {
-        data[key] = parseFloat((largestNumber + 1 - totalSum).toFixed(2));
+        data[key] = parseFloat((largestNumber + 1 - totalSum).toFixed(4));
         break;
       }
     }


### PR DESCRIPTION
## Reasoning
- when > 99% of the network has upgraded nodes, it is difficult from the `/nodes/versions` route to find out whether there are still some nodes with older versions
  
## Proposed Changes
- change precision for node versions from 2 decimals to 4 decimals

## How to test
- `/nodes/versions` route should return 4 decimal precision
