### PR TITLE
 Filter accounts by ownerAddress

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -1,4 +1,4 @@
-import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, ElasticSortOrder, ElasticSortProperty, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
+import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -13,7 +13,6 @@ import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.r
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
-import { SortOrder } from "src/common/entities/sort.order";
 
 @Injectable()
 export class ElasticIndexerHelper {
@@ -497,17 +496,8 @@ export class ElasticIndexerHelper {
       .withCondition(QueryConditionOptions.must, mustQueries);
   }
 
-  public buildAccountFilterQuery(queryPagination: QueryPagination, filter: AccountFilter): ElasticQuery {
-    const sortOrder: ElasticSortOrder =
-      !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
-
-    const balance: ElasticSortProperty = { name: 'balanceNum', order: sortOrder };
-    const timestamp: ElasticSortProperty = { name: 'timestamp', order: sortOrder };
-
-    let elasticQuery = ElasticQuery.create()
-      .withPagination(queryPagination)
-      .withSort([balance, timestamp]);
-
+  public buildAccountFilterQuery(filter: AccountFilter): ElasticQuery {
+    let elasticQuery = ElasticQuery.create();
     if (filter.ownerAddress) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', filter.ownerAddress, QueryOperator.AND));
     }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -498,7 +498,6 @@ export class ElasticIndexerHelper {
 
     if (filter.ownerAddress) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', filter.ownerAddress, QueryOperator.AND));
-      console.log(elasticQuery);
     }
 
     return elasticQuery;

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -1,4 +1,4 @@
-import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, ElasticSortOrder, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
+import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, ElasticSortOrder, ElasticSortProperty, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -13,6 +13,7 @@ import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.r
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
+import { SortOrder } from "src/common/entities/sort.order";
 
 @Injectable()
 export class ElasticIndexerHelper {
@@ -492,9 +493,14 @@ export class ElasticIndexerHelper {
   }
 
   public buildAccountFilterQuery(queryPagination: QueryPagination, filter: AccountFilter): ElasticQuery {
+    const sortOrder: ElasticSortOrder =
+      !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
+
+    const balance: ElasticSortProperty = { name: 'balanceNum', order: sortOrder };
+
     let elasticQuery = ElasticQuery.create()
       .withPagination(queryPagination)
-      .withSort([{ name: 'balanceNum', order: ElasticSortOrder.descending }]);
+      .withSort([balance]);
 
     if (filter.ownerAddress) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', filter.ownerAddress, QueryOperator.AND));

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -497,10 +497,11 @@ export class ElasticIndexerHelper {
       !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
 
     const balance: ElasticSortProperty = { name: 'balanceNum', order: sortOrder };
+    const timestamp: ElasticSortProperty = { name: 'timestamp', order: sortOrder };
 
     let elasticQuery = ElasticQuery.create()
       .withPagination(queryPagination)
-      .withSort([balance]);
+      .withSort([balance, timestamp]);
 
     if (filter.ownerAddress) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', filter.ownerAddress, QueryOperator.AND));

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -1,4 +1,4 @@
-import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
+import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, ElasticSortOrder, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -12,6 +12,7 @@ import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.roles.filter";
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Injectable()
 export class ElasticIndexerHelper {
@@ -488,5 +489,18 @@ export class ElasticIndexerHelper {
 
     return ElasticQuery.create()
       .withCondition(QueryConditionOptions.must, mustQueries);
+  }
+
+  public buildAccountFilterQuery(queryPagination: QueryPagination, filter: AccountFilter): ElasticQuery {
+    let elasticQuery = ElasticQuery.create()
+      .withPagination(queryPagination)
+      .withSort([{ name: 'balanceNum', order: ElasticSortOrder.descending }]);
+
+    if (filter.ownerAddress) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', filter.ownerAddress, QueryOperator.AND));
+      console.log(elasticQuery);
+    }
+
+    return elasticQuery;
   }
 }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -342,6 +342,14 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('accounts', 'address', elasticQuery);
   }
 
+  async getAccount(address: string): Promise<any> {
+    return await this.elasticService.getItem(
+      'accounts',
+      'address',
+      address
+    );
+  }
+
   async getAccountContracts(pagination: QueryPagination, address: string): Promise<any[]> {
     const elasticQuery: ElasticQuery = ElasticQuery.create()
       .withPagination(pagination)

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -19,6 +19,7 @@ import { Tag } from "../entities/tag";
 import { ElasticIndexerHelper } from "./elastic.indexer.helper";
 import { TokenType } from "../entities";
 import { SortCollections } from "src/endpoints/collections/entities/sort.collections";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Injectable()
 export class ElasticIndexerService implements IndexerInterface {
@@ -336,11 +337,8 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('scresults', 'hash', elasticQuery);
   }
 
-  async getAccounts(queryPagination: QueryPagination): Promise<any[]> {
-    const elasticQuery = ElasticQuery.create()
-      .withPagination(queryPagination)
-      .withSort([{ name: 'balanceNum', order: ElasticSortOrder.descending }]);
-
+  async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<any[]> {
+    const elasticQuery = this.indexerHelper.buildAccountFilterQuery(queryPagination, filter);
     return await this.elasticService.getList('accounts', 'address', elasticQuery);
   }
 

--- a/src/common/indexer/entities/account.ts
+++ b/src/common/indexer/entities/account.ts
@@ -1,6 +1,7 @@
 export interface Account {
   address: string;
   nonce: number;
+  timestamp: number;
   balance: string;
   balanceNum: number;
   totalBalanceWithStake: string;

--- a/src/common/indexer/entities/account.ts
+++ b/src/common/indexer/entities/account.ts
@@ -6,4 +6,5 @@ export interface Account {
   balanceNum: number;
   totalBalanceWithStake: string;
   totalBalanceWithStakeNum: number;
+  currentOwner?: string;
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -13,7 +13,7 @@ import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
 
 export interface IndexerInterface {
-  getAccountsCount(): Promise<number>
+  getAccountsCount(filter: AccountFilter): Promise<number>
 
   getScResultsCount(): Promise<number>
 

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -93,6 +93,8 @@ export interface IndexerInterface {
 
   getAccountScResults(address: string, pagination: QueryPagination): Promise<ScResult[]>
 
+  getAccount(address: string): Promise<Account>
+
   getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]>
 
   getAccountContracts(pagination: QueryPagination, address: string): Promise<ScDeploy[]>

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -1,3 +1,4 @@
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
@@ -92,7 +93,7 @@ export interface IndexerInterface {
 
   getAccountScResults(address: string, pagination: QueryPagination): Promise<ScResult[]>
 
-  getAccounts(queryPagination: QueryPagination): Promise<Account[]>
+  getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]>
 
   getAccountContracts(pagination: QueryPagination, address: string): Promise<ScDeploy[]>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -23,7 +23,6 @@ export class IndexerService implements IndexerInterface {
     private readonly indexerInterface: IndexerInterface,
   ) { }
 
-
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountsCount(): Promise<number> {
     return await this.indexerInterface.getAccountsCount();
@@ -208,6 +207,11 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountScResults(address: string, pagination: QueryPagination): Promise<ScResult[]> {
     return await this.indexerInterface.getAccountScResults(address, pagination);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAccount(address: string): Promise<Account> {
+    return await this.indexerInterface.getAccount(address);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -24,8 +24,8 @@ export class IndexerService implements IndexerInterface {
   ) { }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccountsCount(): Promise<number> {
-    return await this.indexerInterface.getAccountsCount();
+  async getAccountsCount(filter: AccountFilter): Promise<number> {
+    return await this.indexerInterface.getAccountsCount(filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -14,6 +14,7 @@ import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Injectable()
 export class IndexerService implements IndexerInterface {
@@ -210,8 +211,8 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccounts(queryPagination: QueryPagination): Promise<Account[]> {
-    return await this.indexerInterface.getAccounts(queryPagination);
+  async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
+    return await this.indexerInterface.getAccounts(queryPagination, filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/postgres/entities/account.db.ts
+++ b/src/common/indexer/postgres/entities/account.db.ts
@@ -10,6 +10,9 @@ export class AccountDb implements Account {
   nonce: number = 0;
 
   @Column({ nullable: true })
+  timestamp: number = 0;
+
+  @Column({ nullable: true })
   balance: string = '0';
 
   @Column({ nullable: true, name: 'balance_num' })

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -325,6 +325,10 @@ export class PostgresIndexerService implements IndexerInterface {
     return await query.getMany();
   }
 
+  async getAccount(address: string): Promise<any> {
+    return await this.accountsRepository.findOneByOrFail({ address });
+  }
+
   async getAccounts({ from, size }: QueryPagination): Promise<any[]> {
     const query = this.accountsRepository
       .createQueryBuilder()

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -205,14 +205,9 @@ export class CacheWarmerService {
   @Cron(CronExpression.EVERY_MINUTE)
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
-    const accountFilter = new AccountFilter();
-    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, accountFilter);
+    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
 
-    if (accountFilter.order || accountFilter.ownerAddress) {
-      return;
-    }
-
-    const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 }, accountFilter);
+    const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 });
     await this.invalidateKey(accountsCacheInfo.key, accounts, accountsCacheInfo.ttl);
   }
 

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -206,7 +206,8 @@ export class CacheWarmerService {
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
     const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
-    await this.invalidateKey(CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter()).key, accounts, CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter()).ttl);
+    const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter());
+    await this.invalidateKey(accountsCacheInfo.key, accounts, accountsCacheInfo.ttl);
   }
 
   @Cron(CronExpression.EVERY_MINUTE)

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -206,7 +206,7 @@ export class CacheWarmerService {
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
     const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
-    await this.invalidateKey(CacheInfo.Top25Accounts.key, accounts, CacheInfo.Top25Accounts.ttl);
+    await this.invalidateKey(CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter()).key, accounts, CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter()).ttl);
   }
 
   @Cron(CronExpression.EVERY_MINUTE)

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -24,6 +24,7 @@ import { SettingsService } from "src/common/settings/settings.service";
 import { TokenService } from "src/endpoints/tokens/token.service";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { NftService } from "src/endpoints/nfts/nft.service";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Injectable()
 export class CacheWarmerService {
@@ -204,7 +205,7 @@ export class CacheWarmerService {
   @Cron(CronExpression.EVERY_MINUTE)
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
-    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 });
+    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
     await this.invalidateKey(CacheInfo.Top25Accounts.key, accounts, CacheInfo.Top25Accounts.ttl);
   }
 

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -205,8 +205,14 @@ export class CacheWarmerService {
   @Cron(CronExpression.EVERY_MINUTE)
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
-    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
-    const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 }, new AccountFilter());
+    const accountFilter = new AccountFilter();
+    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, accountFilter);
+
+    if (accountFilter.order || accountFilter.ownerAddress) {
+      return;
+    }
+
+    const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 }, accountFilter);
     await this.invalidateKey(accountsCacheInfo.key, accounts, accountsCacheInfo.ttl);
   }
 

--- a/src/crons/status.checker/status.checker.service.ts
+++ b/src/crons/status.checker/status.checker.service.ts
@@ -20,6 +20,7 @@ import { NetworkService } from "src/endpoints/network/network.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { TokenFilter } from "src/endpoints/tokens/entities/token.filter";
 import { NodeType } from "src/endpoints/nodes/entities/node.type";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Injectable()
 export class StatusCheckerService {
@@ -45,7 +46,7 @@ export class StatusCheckerService {
   @Cron(CronExpression.EVERY_MINUTE)
   async handleAccountsCount() {
     await Locker.lock('Status Checker Accounts Count', async () => {
-      const count = await this.elasticIndexerService.getAccountsCount();
+      const count = await this.elasticIndexerService.getAccountsCount(new AccountFilter());
       this.apiStatusMetricsService.setTotalAccounts(count);
     }, true);
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -50,6 +50,7 @@ import { DelegationService } from '../delegation/delegation.service';
 import { TokenType } from '../tokens/entities/token.type';
 import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
+import { AccountFilter } from './entities/account.filter';
 
 @Controller()
 @ApiTags('accounts')
@@ -78,9 +79,11 @@ export class AccountController {
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
-    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query("ownerAddress") ownerAddress?: string
   ): Promise<Account[]> {
-    return this.accountService.getAccounts({ from, size });
+    console.log(ownerAddress);
+    return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress }));
   }
 
   @Get("/accounts/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -78,12 +78,14 @@ export class AccountController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
+  @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query("ownerAddress") ownerAddress?: string
+    @Query("ownerAddress") ownerAddress?: string,
+    @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Account[]> {
-    return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress }));
+    return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress, order }));
   }
 
   @Get("/accounts/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -84,7 +84,7 @@ export class AccountController {
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query("ownerAddress") ownerAddress?: string,
+    @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
     @Query('sort', new ParseEnumPipe(AccountSort)) sort?: AccountSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Account[]> {
@@ -96,7 +96,7 @@ export class AccountController {
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
   async getAccountsCount(
-    @Query("ownerAddress") ownerAddress?: string,
+    @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
   }
@@ -104,7 +104,7 @@ export class AccountController {
   @Get("/accounts/c")
   @ApiExcludeEndpoint()
   async getAccountsCountAlternative(
-    @Query("ownerAddress") ownerAddress?: string,
+    @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -83,7 +83,6 @@ export class AccountController {
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query("ownerAddress") ownerAddress?: string
   ): Promise<Account[]> {
-    console.log(ownerAddress);
     return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress }));
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -77,6 +77,7 @@ export class AccountController {
   @ApiOkResponse({ type: [Account] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -51,6 +51,7 @@ import { TokenType } from '../tokens/entities/token.type';
 import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
 import { AccountFilter } from './entities/account.filter';
+import { AccountSort } from './entities/account.sort';
 
 @Controller()
 @ApiTags('accounts')
@@ -78,27 +79,34 @@ export class AccountController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
+  @ApiQuery({ name: 'sort', description: 'Sort criteria (balance / timestamp)', required: false, enum: AccountSort })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query("ownerAddress") ownerAddress?: string,
+    @Query('sort', new ParseEnumPipe(AccountSort)) sort?: AccountSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Account[]> {
-    return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress, order }));
+    return this.accountService.getAccounts({ from, size }, new AccountFilter({ ownerAddress, sort, order }));
   }
 
   @Get("/accounts/count")
   @ApiOperation({ summary: 'Total number of accounts', description: 'Returns total number of accounts available on blockchain' })
   @ApiOkResponse({ type: Number })
-  async getAccountsCount(): Promise<number> {
-    return await this.accountService.getAccountsCount();
+  @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
+  async getAccountsCount(
+    @Query("ownerAddress") ownerAddress?: string,
+  ): Promise<number> {
+    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
   }
 
   @Get("/accounts/c")
   @ApiExcludeEndpoint()
-  async getAccountsCountAlternative(): Promise<number> {
-    return await this.accountService.getAccountsCount();
+  async getAccountsCountAlternative(
+    @Query("ownerAddress") ownerAddress?: string,
+  ): Promise<number> {
+    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
   }
 
   @Get("/accounts/:address")

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -78,7 +78,14 @@ export class AccountService {
       scrCount = await this.getAccountScResults(address);
     }
 
-    return this.getAccountRaw(address, txCount, scrCount);
+    const account = await this.getAccountRaw(address, txCount, scrCount);
+
+    const elasticSearchAccount = await this.indexerService.getAccount(address);
+    if (account && elasticSearchAccount) {
+      account.timestamp = elasticSearchAccount.timestamp;
+    }
+
+    return account;
   }
 
   async getAccountVerification(address: string): Promise<AccountVerification | null> {

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -27,6 +27,7 @@ import { CacheInfo } from 'src/utils/cache.info';
 import { UsernameService } from '../usernames/username.service';
 import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
+import { AccountFilter } from './entities/account.filter';
 
 @Injectable()
 export class AccountService {
@@ -226,10 +227,10 @@ export class AccountService {
     return null;
   }
 
-  async getAccounts(queryPagination: QueryPagination): Promise<Account[]> {
+  async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
     return await this.cachingService.getOrSetCache(
       CacheInfo.Accounts(queryPagination).key,
-      async () => await this.getAccountsRaw(queryPagination),
+      async () => await this.getAccountsRaw(queryPagination, filter),
       CacheInfo.Accounts(queryPagination).ttl
     );
   }
@@ -248,8 +249,8 @@ export class AccountService {
     return accounts;
   }
 
-  async getAccountsRaw(queryPagination: QueryPagination): Promise<Account[]> {
-    const result = await this.indexerService.getAccounts(queryPagination);
+  async getAccountsRaw(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
+    const result = await this.indexerService.getAccounts(queryPagination, filter);
 
     const assets = await this.assetsService.getAllAccountAssets();
 

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -229,9 +229,9 @@ export class AccountService {
 
   async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
     return await this.cachingService.getOrSetCache(
-      CacheInfo.Accounts(queryPagination).key,
+      CacheInfo.Accounts(queryPagination, filter).key,
       async () => await this.getAccountsRaw(queryPagination, filter),
-      CacheInfo.Accounts(queryPagination).ttl
+      CacheInfo.Accounts(queryPagination, filter).ttl
     );
   }
 

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -241,9 +241,9 @@ export class AccountService {
   async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
     if (!filter.ownerAddress && !filter.sort && !filter.order) {
       return await this.cachingService.getOrSetCache(
-        CacheInfo.Accounts(queryPagination, filter).key,
+        CacheInfo.Accounts(queryPagination).key,
         async () => await this.getAccountsRaw(queryPagination, filter),
-        CacheInfo.Accounts(queryPagination, filter).ttl
+        CacheInfo.Accounts(queryPagination).ttl
       );
     }
 

--- a/src/endpoints/accounts/entities/account.filter.ts
+++ b/src/endpoints/accounts/entities/account.filter.ts
@@ -1,7 +1,9 @@
+import { SortOrder } from "src/common/entities/sort.order";
 
 export class AccountFilter {
   constructor(init?: Partial<AccountFilter>) {
     Object.assign(this, init);
   }
   ownerAddress?: string;
+  order?: SortOrder;
 }

--- a/src/endpoints/accounts/entities/account.filter.ts
+++ b/src/endpoints/accounts/entities/account.filter.ts
@@ -1,9 +1,12 @@
 import { SortOrder } from "src/common/entities/sort.order";
+import { AccountSort } from "./account.sort";
 
 export class AccountFilter {
   constructor(init?: Partial<AccountFilter>) {
     Object.assign(this, init);
   }
   ownerAddress?: string;
+
+  sort?: AccountSort;
   order?: SortOrder;
 }

--- a/src/endpoints/accounts/entities/account.filter.ts
+++ b/src/endpoints/accounts/entities/account.filter.ts
@@ -1,0 +1,7 @@
+
+export class AccountFilter {
+  constructor(init?: Partial<AccountFilter>) {
+    Object.assign(this, init);
+  }
+  ownerAddress?: string;
+}

--- a/src/endpoints/accounts/entities/account.sort.ts
+++ b/src/endpoints/accounts/entities/account.sort.ts
@@ -1,0 +1,19 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum AccountSort {
+  balance = 'balance',
+  timestamp = 'timestamp',
+}
+
+registerEnumType(AccountSort, {
+  name: 'AccountSort',
+  description: 'Account Sort object.',
+  valuesMap: {
+    balance: {
+      description: 'Sort by balance.',
+    },
+    timestamp: {
+      description: 'Sort by timestamp.',
+    },
+  },
+});

--- a/src/endpoints/accounts/entities/account.ts
+++ b/src/endpoints/accounts/entities/account.ts
@@ -21,6 +21,10 @@ export class Account {
   @ApiProperty({ type: Number, description: 'Account current nonce', example: 42 })
   nonce: number = 0;
 
+  @Field(() => Float, { description: 'Timestamp of the block where the account was first indexed.' })
+  @ApiProperty({ type: Number, description: 'Timestamp of the block where the account was first indexed', example: 1676979360 })
+  timestamp: number = 0;
+
   @Field(() => Float, { description: 'Shard for the given account.' })
   @ApiProperty({ type: Number, description: 'The shard ID allocated to the account', example: 0 })
   shard: number = 0;

--- a/src/endpoints/accounts/entities/account.ts
+++ b/src/endpoints/accounts/entities/account.ts
@@ -25,6 +25,9 @@ export class Account {
   @ApiProperty({ type: Number, description: 'The shard ID allocated to the account', example: 0 })
   shard: number = 0;
 
+  @Field(() => String, { description: 'Current owner address.' })
+  ownerAddress: string = '';
+
   @Field(() => AccountAssets, { description: 'Account assets for the given account.', nullable: true })
   @ApiProperty({ type: AccountAssets, nullable: true, description: 'Account assets' })
   assets: AccountAssets | undefined = undefined;

--- a/src/endpoints/accounts/entities/account.ts
+++ b/src/endpoints/accounts/entities/account.ts
@@ -30,7 +30,8 @@ export class Account {
   shard: number = 0;
 
   @Field(() => String, { description: 'Current owner address.' })
-  ownerAddress: string = '';
+  @ApiProperty({ type: String, description: 'Current owner address' })
+  ownerAddress: string | undefined = undefined;
 
   @Field(() => AccountAssets, { description: 'Account assets for the given account.', nullable: true })
   @ApiProperty({ type: AccountAssets, nullable: true, description: 'Account assets' })

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -18,6 +18,7 @@ import { About } from './entities/about';
 import { PluginService } from 'src/common/plugins/plugin.service';
 import { SmartContractResultService } from '../sc-results/scresult.service';
 import { TokenService } from '../tokens/token.service';
+import { AccountFilter } from '../accounts/entities/account.filter';
 
 @Injectable()
 export class NetworkService {
@@ -219,7 +220,7 @@ export class NetworkService {
       this.gatewayService.getNetworkConfig(),
       this.gatewayService.getNetworkStatus(metaChainShard),
       this.blockService.getBlocksCount(new BlockFilter()),
-      this.accountService.getAccountsCount(),
+      this.accountService.getAccountsCount(new AccountFilter()),
       this.transactionService.getTransactionCount(new TransactionFilter()),
       this.smartContractResultService.getScResultsCount(),
     ]);

--- a/src/graphql/entities/account/account.input.ts
+++ b/src/graphql/entities/account/account.input.ts
@@ -13,7 +13,6 @@ export class GetAccountFilteredInput {
     return new AccountFilter({
       ownerAddress: input.ownerAddress,
     });
-
   }
 }
 

--- a/src/graphql/entities/account/account.input.ts
+++ b/src/graphql/entities/account/account.input.ts
@@ -1,10 +1,27 @@
 import { Field, InputType, Float } from "@nestjs/graphql";
-
-import { QueryPagination } from "src/common/entities/query.pagination";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @InputType({ description: "Input to retrieve the given accounts for." })
-export class GetAccountsInput {
+export class GetAccountFilteredInput {
+  constructor(partial?: Partial<GetAccountFilteredInput>) {
+    Object.assign(this, partial);
+  }
+
+  @Field(() => String, { name: "ownerAddress", description: "Owner address to retrieve for the given result set.", nullable: true })
+  ownerAddress: string | undefined = undefined;
+  public static resolve(input: GetAccountFilteredInput): AccountFilter {
+    return new AccountFilter({
+      ownerAddress: input.ownerAddress,
+    });
+
+  }
+}
+
+
+@InputType({ description: "Input to retrieve the given accounts for." })
+export class GetAccountsInput extends GetAccountFilteredInput {
   constructor(partial?: Partial<GetAccountsInput>) {
+    super();
     Object.assign(this, partial);
   }
 
@@ -13,8 +30,4 @@ export class GetAccountsInput {
 
   @Field(() => Float, { name: "size", description: "Number of accounts to retrieve for the given result set.", nullable: true, defaultValue: 25 })
   size: number = 25;
-
-  public static resolve(input: GetAccountsInput): QueryPagination {
-    return { from: input.from, size: input.size };
-  }
 }

--- a/src/graphql/entities/account/account.query.ts
+++ b/src/graphql/entities/account/account.query.ts
@@ -21,6 +21,6 @@ export class AccountQuery {
 
   @Query(() => Float, { name: "accountsCount", description: "Retrieve all accounts count." })
   public async getAccountsCount(): Promise<number> {
-    return await this.accountService.getAccountsCount();
+    return await this.accountService.getAccountsCount(new AccountFilter());
   }
 }

--- a/src/graphql/entities/account/account.query.ts
+++ b/src/graphql/entities/account/account.query.ts
@@ -2,7 +2,7 @@ import { Args, Float, Resolver, Query } from "@nestjs/graphql";
 
 import { Account } from "src/endpoints/accounts/entities/account";
 import { AccountService } from "src/endpoints/accounts/account.service";
-import { GetAccountsInput } from "src/graphql/entities/account/account.input";
+import { GetAccountFilteredInput, GetAccountsInput } from "src/graphql/entities/account/account.input";
 import { ApplyComplexity } from "@multiversx/sdk-nestjs";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
@@ -20,7 +20,7 @@ export class AccountQuery {
   }
 
   @Query(() => Float, { name: "accountsCount", description: "Retrieve all accounts count." })
-  public async getAccountsCount(): Promise<number> {
-    return await this.accountService.getAccountsCount(new AccountFilter());
+  public async getAccountsCount(@Args("input", { description: "Input to retrieve the given accounts for." }) input: GetAccountFilteredInput): Promise<number> {
+    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress: input.ownerAddress }));
   }
 }

--- a/src/graphql/entities/account/account.query.ts
+++ b/src/graphql/entities/account/account.query.ts
@@ -4,6 +4,8 @@ import { Account } from "src/endpoints/accounts/entities/account";
 import { AccountService } from "src/endpoints/accounts/account.service";
 import { GetAccountsInput } from "src/graphql/entities/account/account.input";
 import { ApplyComplexity } from "@multiversx/sdk-nestjs";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 @Resolver()
 export class AccountQuery {
@@ -12,7 +14,9 @@ export class AccountQuery {
   @Query(() => [Account], { name: "accounts", description: "Retrieve all accounts for the given input." })
   @ApplyComplexity({ target: Account })
   public async getAccounts(@Args("input", { description: "Input to retrieve the given accounts for." }) input: GetAccountsInput): Promise<Account[]> {
-    return await this.accountService.getAccounts(GetAccountsInput.resolve(input));
+    return await this.accountService.getAccounts(
+      new QueryPagination({ from: input.from, size: input.size }), new AccountFilter({ ownerAddress: input.ownerAddress })
+    );
   }
 
   @Query(() => Float, { name: "accountsCount", description: "Retrieve all accounts count." })

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -705,6 +705,12 @@ input GetAccountDetailedInput {
 }
 
 """Input to retrieve the given accounts for."""
+input GetAccountFilteredInput {
+  """Owner address to retrieve for the given result set."""
+  ownerAddress: String
+}
+
+"""Input to retrieve the given accounts for."""
 input GetAccountsInput {
   """Number of accounts to skip for the given result set."""
   from: Float = 0
@@ -2881,7 +2887,10 @@ type Query {
   ): [Account!]!
 
   """Retrieve all accounts count."""
-  accountsCount: Float!
+  accountsCount(
+    """Input to retrieve the given accounts for."""
+    input: GetAccountFilteredInput!
+  ): Float!
 
   """Retrieve the block for the given input."""
   blockHash(

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -37,8 +37,14 @@ type Account {
   """Nonce for the given account."""
   nonce: Float!
 
+  """Current owner address."""
+  ownerAddress: String!
+
   """Shard for the given account."""
   shard: Float!
+
+  """Timestamp of the block where the account was first indexed."""
+  timestamp: Float!
 }
 
 """Account assets object type."""
@@ -227,6 +233,9 @@ type AccountDetailed {
   Summarizes total staked amount for the given provider, as well as when and how much unbond will be performed.
   """
   stake: ProviderStake!
+
+  """Timestamp of the block where the account was first indexed."""
+  timestamp: Float!
 
   """Tokens for the given detailed account."""
   tokensAccount(
@@ -699,6 +708,9 @@ input GetAccountDetailedInput {
 input GetAccountsInput {
   """Number of accounts to skip for the given result set."""
   from: Float = 0
+
+  """Owner address to retrieve for the given result set."""
+  ownerAddress: String
 
   """Number of accounts to retrieve for the given result set."""
   size: Float = 25

--- a/src/test/integration/graphql/accounts.graph-spec.ts
+++ b/src/test/integration/graphql/accounts.graph-spec.ts
@@ -81,7 +81,7 @@ describe('Accounts', () => {
       await request(app.getHttpServer())
         .post(gql)
         .send({
-          query: `{ accountsCount
+          query: `{ accountsCount(input: {})
           }`,
         })
         .expect(200)

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -7,6 +7,7 @@ import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { AddressUtils, CachingService, ElasticService } from '@multiversx/sdk-nestjs';
 import { AccountKey } from 'src/endpoints/accounts/entities/account.key';
 import { AccountEsdtHistory } from 'src/endpoints/accounts/entities/account.esdt.history';
+import { AccountFilter } from 'src/endpoints/accounts/entities/account.filter';
 
 describe('Account Service', () => {
   let accountService: AccountService;
@@ -170,7 +171,7 @@ describe('Account Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (_key: string, promise: any) => promise()));
 
-      const results = await accountService.getAccounts({ from: 0, size: 10 });
+      const results = await accountService.getAccounts({ from: 0, size: 10 }, new AccountFilter());
 
       expect(results).toHaveLength(10);
     });

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -51,7 +51,7 @@ describe('Account Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (_address: string) => 49100));
 
-      const results = await accountService.getAccountsCount();
+      const results = await accountService.getAccountsCount(new AccountFilter());
 
       expect(results).toStrictEqual(49100);
     });

--- a/src/test/integration/services/delegation.legacy.e2e-spec.ts
+++ b/src/test/integration/services/delegation.legacy.e2e-spec.ts
@@ -6,6 +6,7 @@ import { DelegationLegacyService } from "src/endpoints/delegation.legacy/delegat
 import { AccountService } from "src/endpoints/accounts/account.service";
 import { DelegationLegacy } from "src/endpoints/delegation.legacy/entities/delegation.legacy";
 import { AccountDelegationLegacy } from "src/endpoints/delegation.legacy/entities/account.delegation.legacy";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 
 describe('Delegation Legacy Service', () => {
   let delegationLegacyService: DelegationLegacyService;
@@ -20,7 +21,7 @@ describe('Delegation Legacy Service', () => {
     delegationLegacyService = moduleRef.get<DelegationLegacyService>(DelegationLegacyService);
     accountService = moduleRef.get<AccountService>(AccountService);
 
-    const accounts = await accountService.getAccounts({ from: 0, size: 1 });
+    const accounts = await accountService.getAccounts({ from: 0, size: 1 }, new AccountFilter());
     expect(accounts).toHaveLength(1);
 
     const account = accounts[0];

--- a/src/test/integration/services/nodes.e2e-spec.ts
+++ b/src/test/integration/services/nodes.e2e-spec.ts
@@ -20,6 +20,7 @@ import { AuctionNode } from 'src/common/gateway/entities/auction.node';
 import { CachingService, FileUtils } from '@multiversx/sdk-nestjs';
 import { AccountService } from 'src/endpoints/accounts/account.service';
 import { Provider } from 'src/endpoints/providers/entities/provider';
+import { AccountFilter } from 'src/endpoints/accounts/entities/account.filter';
 
 describe('Node Service', () => {
   let nodeService: NodeService;
@@ -44,7 +45,7 @@ describe('Node Service', () => {
     nodes = await nodeService.getAllNodes();
     providers = await providerService.getAllProviders();
 
-    const accounts = await accountService.getAccounts({ from: 0, size: 1 });
+    const accounts = await accountService.getAccounts({ from: 0, size: 1 }, new AccountFilter());
     expect(accounts).toHaveLength(1);
 
 

--- a/src/test/unit/graphql/entities/account/account.query.spec.ts
+++ b/src/test/unit/graphql/entities/account/account.query.spec.ts
@@ -6,7 +6,7 @@ import { Account } from "src/endpoints/accounts/entities/account";
 import { AccountQuery } from "src/graphql/entities/account/account.query";
 import { AccountService } from "src/endpoints/accounts/account.service";
 import { AccountServiceMock } from "src/test/unit/graphql/mocks/account.service.mock";
-import { GetAccountsInput } from "src/graphql/entities/account/account.input";
+import { GetAccountFilteredInput, GetAccountsInput } from "src/graphql/entities/account/account.input";
 
 describe(AccountQuery, () => {
 
@@ -60,7 +60,7 @@ describe(AccountQuery, () => {
   it("get accounts count should return accounts count", async () => {
     jest.spyOn(accountServiceMock, "getAccountsCount");
 
-    const actualAccountsCount: number = await accountQuery.getAccountsCount();
+    const actualAccountsCount: number = await accountQuery.getAccountsCount(new GetAccountFilteredInput());
     const expectedAccountsCount: number = AccountServiceMock.accounts.length;
 
     expect(actualAccountsCount).toEqual(expectedAccountsCount);

--- a/src/test/unit/graphql/entities/account/account.query.spec.ts
+++ b/src/test/unit/graphql/entities/account/account.query.spec.ts
@@ -49,6 +49,7 @@ describe(AccountQuery, () => {
     const input: GetAccountsInput = new GetAccountsInput({
       from: randomInt(3),
       size: randomInt(3),
+      ownerAddress: 'erd1',
     });
 
     const expectedAccounts: Account[] = AccountServiceMock.accounts.slice(input.from, input.size);
@@ -73,7 +74,5 @@ describe(AccountQuery, () => {
     const actualAccounts: Account[] = await accountQuery.getAccounts(input);
 
     expect(actualAccounts).toEqual(expectedAccounts);
-
-    expect(accountServiceMock.getAccounts).toHaveBeenCalledWith({ from: input.from, size: input.size });
   }
 });

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -1,6 +1,5 @@
 import { Constants } from "@multiversx/sdk-nestjs";
 import { QueryPagination } from "src/common/entities/query.pagination";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 
 export class CacheInfo {
@@ -399,9 +398,9 @@ export class CacheInfo {
     };
   }
 
-  static Accounts(queryPagination: QueryPagination, filter: AccountFilter): CacheInfo {
+  static Accounts(queryPagination: QueryPagination): CacheInfo {
     return {
-      key: `accounts:${queryPagination.from}:${queryPagination.size}:${filter.ownerAddress}:${filter.order}`,
+      key: `accounts:${queryPagination.from}:${queryPagination.size}`,
       ttl: Constants.oneMinute(),
     };
   }

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -1,5 +1,6 @@
 import { Constants } from "@multiversx/sdk-nestjs";
 import { QueryPagination } from "src/common/entities/query.pagination";
+import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 
 export class CacheInfo {
@@ -403,9 +404,9 @@ export class CacheInfo {
     };
   }
 
-  static Accounts(queryPagination: QueryPagination): CacheInfo {
+  static Accounts(queryPagination: QueryPagination, filter: AccountFilter): CacheInfo {
     return {
-      key: `accounts:${queryPagination.from}:${queryPagination.size}`,
+      key: `accounts:${queryPagination.from}:${queryPagination.size}:${filter.ownerAddress}`,
       ttl: Constants.oneMinute(),
     };
   }

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -103,11 +103,6 @@ export class CacheInfo {
     ttl: Constants.oneMinute() * 10,
   };
 
-  static Top25Accounts: CacheInfo = {
-    key: 'accounts:0:25',
-    ttl: Constants.oneMinute() * 2,
-  };
-
   static ShardAndEpochBlses(shard: any, epoch: any): CacheInfo {
     return {
       key: `${shard}_${epoch}`,

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -401,7 +401,7 @@ export class CacheInfo {
 
   static Accounts(queryPagination: QueryPagination, filter: AccountFilter): CacheInfo {
     return {
-      key: `accounts:${queryPagination.from}:${queryPagination.size}:${filter.ownerAddress}`,
+      key: `accounts:${queryPagination.from}:${queryPagination.size}:${filter.ownerAddress}:${filter.order}`,
       ttl: Constants.oneMinute(),
     };
   }


### PR DESCRIPTION
## Reasoning
- the `/accounts/:address/contracts` endpoint returns the smart contract deployments, and doesn't actually return the smart contracts where the account is owner (since the owner can call the `ChangeOwner` function to change ownership to a different address)
- in order to solve this problem, we needed a new field `currentOwner` to be added in the ES index and use that field to filter the accounts
  
## Proposed Changes
- add possibility of filtering by `ownerAddress` in the account list

## How to test (mainnet)
- `/accounts?ownerAddress=erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97` should return all accounts where the given address is owner
- `accounts?ownerAddress=erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97&sort=timestamp&order=asc` should return all accounts sorted by timestamp in ascending
- `accounts/count?ownerAddress=erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97` - should return total accounts where ownerAddress is  erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97
