### PR TITLE
Add support for guardian fields

### DIFF
--- a/src/endpoints/transactions/entities/transaction.create.ts
+++ b/src/endpoints/transactions/entities/transaction.create.ts
@@ -37,4 +37,10 @@ export class TransactionCreate {
 
   @ApiProperty()
   options?: number = undefined;
+
+  @ApiProperty()
+  guardian?: string = undefined;
+
+  @ApiProperty()
+  guardianSignature?: string = undefined;
 }


### PR DESCRIPTION
## Proposed Changes
- Add support for new fields necessary for the guardian functionality

## How to test
- route `POST /transactions` should also pass to the proxy the `guardian` and `guardianSignature` fields
