### PR TITLE
add filter by EGLD

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -405,7 +405,6 @@ export class ElasticIndexerHelper {
 
   public buildTransactionFilterQuery(filter: TransactionFilter, address?: string): ElasticQuery {
     let elasticQuery = ElasticQuery.create()
-      .withMustMatchCondition('tokens', filter.token, QueryOperator.AND)
       .withMustMatchCondition('function', this.apiConfigService.getIsIndexerV3FlagActive() ? filter.function : undefined)
       .withMustMatchCondition('senderShard', filter.senderShard)
       .withMustMatchCondition('receiverShard', filter.receiverShard)
@@ -414,6 +413,13 @@ export class ElasticIndexerHelper {
       .withMustMatchCondition('status', filter.status)
       .withMustMultiShouldCondition(filter.tokens, token => QueryType.Match('tokens', token, QueryOperator.AND))
       .withDateRangeFilter('timestamp', filter.before, filter.after);
+
+    if (filter.token !== 'EGLD') {
+      elasticQuery = elasticQuery.withMustMatchCondition('tokens', filter.token, QueryOperator.AND);
+    } else {
+      elasticQuery = elasticQuery.withMustNotCondition(
+        QueryType.Match('value', '0'));
+    }
 
     if (filter.condition === QueryConditionOptions.should) {
       if (filter.sender) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -414,11 +414,10 @@ export class ElasticIndexerHelper {
       .withMustMultiShouldCondition(filter.tokens, token => QueryType.Match('tokens', token, QueryOperator.AND))
       .withDateRangeFilter('timestamp', filter.before, filter.after);
 
-    if (filter.token !== 'EGLD') {
-      elasticQuery = elasticQuery.withMustMatchCondition('tokens', filter.token, QueryOperator.AND);
+    if (filter.token === 'EGLD') {
+      elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('value', '0'));
     } else {
-      elasticQuery = elasticQuery.withMustNotCondition(
-        QueryType.Match('value', '0'));
+      elasticQuery = elasticQuery.withMustMatchCondition('tokens', filter.token, QueryOperator.AND);
     }
 
     if (filter.condition === QueryConditionOptions.should) {

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -639,7 +639,7 @@ export class AccountController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
-    @Query('token', ParseTokenPipe) token?: string,
+    @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
     @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,

--- a/src/test/integration/graphql/transactions.graph-spec.ts
+++ b/src/test/integration/graphql/transactions.graph-spec.ts
@@ -218,6 +218,50 @@ describe('Transactions', () => {
     });
   });
 
+  describe('Query - Get Transactions', () => {
+    it('should return an array of transactions with value field value <> 0', async () => {
+      await request(app.getHttpServer())
+        .post(gql)
+        .send({
+          query: `{
+            transactions(input:{
+              token: "EGLD"
+            }){
+              txHash
+              gasLimit
+              gasPrice
+              gasUsed
+              miniBlockHash
+              nonce
+              receiverAddress
+              receiverShard
+              round
+              senderAddress
+              senderShard
+              signature
+              status
+              value
+              fee
+              timestamp
+              data
+              function
+              action{
+                category
+                name
+                description
+                arguments
+              }
+            }
+          }`,
+        })
+        .expect(200)
+        .then(res => {
+          expect(res.body.data.transactions).toBeDefined();
+          expect(res.body.data.transactions.value).not.toEqual('0');
+        });
+    });
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -139,6 +139,19 @@ describe('Transaction Service', () => {
       expect(txResults.includes("29a2bed2543197e69c9bf16b30c4b0196f5e7a59584aba2e1a2127bf06cdfd2d")).toBeTruthy();
       expect(txResults.includes("0cbaeb61cd2d901e7363b83e35750d0cbf2045ed853ef8f7af7cefdef622671e")).toBeTruthy();
     });
+
+    it('should return an array of transactions only with EGLD', async () => {
+      const filter = new TransactionFilter();
+      filter.token = "EGLD";
+
+      const results = await transactionService.getTransactions(filter, new QueryPagination());
+
+      expect(results).toHaveLength(25);
+
+      for (const result of results) {
+        expect(result.value).not.toEqual('0');
+      }
+    });
   });
 
   describe('getTransaction', () => {


### PR DESCRIPTION
## Reasoning
-  When filter.token was applied in transactions endpoint, we did not have the possibility to filter by EGLD.
  
## Proposed Changes
-  Add query condition when filter.token = "EGLD", retrieve all transactions where value field is <> 0

## How to test
- /transactions?token=EGLD -> should return an array of transactions where value field is <> 0

