### PR TITLE
add before and after query params for accounts history

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -21,6 +21,7 @@ import { TokenType } from "../entities";
 import { SortCollections } from "src/endpoints/collections/entities/sort.collections";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { AccountSort } from "src/endpoints/accounts/entities/account.sort";
+import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 
 @Injectable()
 export class ElasticIndexerService implements IndexerInterface {
@@ -377,16 +378,16 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('scdeploys', "contract", elasticQuery);
   }
 
-  async getAccountHistory(address: string, pagination: QueryPagination): Promise<any[]> {
-    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address)
+  async getAccountHistory(address: string, pagination: QueryPagination, filter?: AccountHistoryFilter): Promise<any[]> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter)
       .withPagination(pagination)
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
 
     return await this.elasticService.getList('accountshistory', 'address', elasticQuery);
   }
 
-  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination): Promise<any[]> {
-    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, tokenIdentifier)
+  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<any[]> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, tokenIdentifier, filter)
       .withPagination(pagination)
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
 

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -1,4 +1,5 @@
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
+import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
@@ -99,9 +100,9 @@ export interface IndexerInterface {
 
   getAccountContracts(pagination: QueryPagination, address: string): Promise<ScDeploy[]>
 
-  getAccountHistory(address: string, pagination: QueryPagination): Promise<AccountHistory[]>
+  getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]>
 
-  getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination): Promise<AccountTokenHistory[]>
+  getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
   getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -15,6 +15,7 @@ import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBl
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
+import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 
 @Injectable()
 export class IndexerService implements IndexerInterface {
@@ -225,13 +226,13 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccountHistory(address: string, pagination: QueryPagination): Promise<AccountHistory[]> {
-    return await this.indexerInterface.getAccountHistory(address, pagination);
+  async getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]> {
+    return await this.indexerInterface.getAccountHistory(address, pagination, filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination): Promise<AccountTokenHistory[]> {
-    return await this.indexerInterface.getAccountTokenHistory(address, tokenIdentifier, pagination);
+  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]> {
+    return await this.indexerInterface.getAccountTokenHistory(address, tokenIdentifier, pagination, filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -52,6 +52,7 @@ import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
 import { AccountFilter } from './entities/account.filter';
 import { AccountSort } from './entities/account.sort';
+import { AccountHistoryFilter } from './entities/account.history.filter';
 
 @Controller()
 @ApiTags('accounts')
@@ -1006,31 +1007,45 @@ export class AccountController {
   @ApiOperation({ summary: 'Account history', description: 'Return account EGLD balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiOkResponse({ type: [AccountHistory] })
   getAccountHistory(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
   ): Promise<AccountHistory[]> {
-    return this.accountService.getAccountHistory(address, new QueryPagination({ from, size }));
+    return this.accountService.getAccountHistory(
+      address,
+      new QueryPagination({ from, size }),
+      new AccountHistoryFilter({ before, after }));
   }
 
   @Get("/accounts/:address/history/:tokenIdentifier")
   @ApiOperation({ summary: 'Account token history', description: 'Returns account token balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiOkResponse({ type: [AccountEsdtHistory] })
   async getAccountTokenHistory(
     @Param('address', ParseAddressPipe) address: string,
     @Param('tokenIdentifier', ParseTokenOrNftPipe) tokenIdentifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
   ): Promise<AccountEsdtHistory[]> {
     const isToken = await this.tokenService.isToken(tokenIdentifier);
     if (!isToken) {
       throw new NotFoundException(`Token '${tokenIdentifier}' not found`);
     }
 
-    return await this.accountService.getAccountTokenHistory(address, tokenIdentifier, new QueryPagination({ from, size }));
+    return await this.accountService.getAccountTokenHistory(
+      address, tokenIdentifier,
+      new QueryPagination({ from, size }),
+      new AccountHistoryFilter({ before, after }));
   }
 }

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -28,6 +28,7 @@ import { UsernameService } from '../usernames/username.service';
 import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
 import { AccountFilter } from './entities/account.filter';
+import { AccountHistoryFilter } from './entities/account.history.filter';
 
 @Injectable()
 export class AccountService {
@@ -453,13 +454,13 @@ export class AccountService {
     return upgrades.slice(queryPagination.from, queryPagination.from + queryPagination.size);
   }
 
-  async getAccountHistory(address: string, pagination: QueryPagination): Promise<AccountHistory[]> {
-    const elasticResult = await this.indexerService.getAccountHistory(address, pagination);
+  async getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]> {
+    const elasticResult = await this.indexerService.getAccountHistory(address, pagination, filter);
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountHistory(), item));
   }
 
-  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination): Promise<AccountEsdtHistory[]> {
-    const elasticResult = await this.indexerService.getAccountTokenHistory(address, tokenIdentifier, pagination);
+  async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountEsdtHistory[]> {
+    const elasticResult = await this.indexerService.getAccountTokenHistory(address, tokenIdentifier, pagination, filter);
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
   }
 }

--- a/src/endpoints/accounts/entities/account.history.filter.ts
+++ b/src/endpoints/accounts/entities/account.history.filter.ts
@@ -1,0 +1,8 @@
+
+export class AccountHistoryFilter {
+  constructor(init?: Partial<AccountHistoryFilter>) {
+    Object.assign(this, init);
+  }
+  before?: number;
+  after?: number;
+}

--- a/src/graphql/entities/account.detailed/account.detailed.input.ts
+++ b/src/graphql/entities/account.detailed/account.detailed.input.ts
@@ -259,8 +259,22 @@ export class GetTransfersAccountInput {
   withUsername: boolean | undefined = undefined;
 }
 
+
+@InputType({ description: "Input to retrieve the given transactions count for." })
+export class GetAccountHistory extends GetFromAndSizeInput {
+  constructor(partial?: Partial<GetAccountHistory>) {
+    super();
+    Object.assign(this, partial);
+  }
+  @Field(() => Float, { name: "before", description: "Before timestamp for the given result set.", nullable: true })
+  before: number | undefined = undefined;
+
+  @Field(() => Float, { name: "after", description: "After timestamp for the given result set.", nullable: true })
+  after: number | undefined = undefined;
+}
+
 @InputType({ description: "Input to retrieve the given history token for." })
-export class GetHistoryTokenAccountInput extends GetFromAndSizeInput {
+export class GetHistoryTokenAccountInput extends GetAccountHistory {
   constructor(partial?: Partial<GetFromAndSizeInput>) {
     super();
     Object.assign(this, partial);

--- a/src/graphql/entities/account.detailed/account.detailed.resolver.ts
+++ b/src/graphql/entities/account.detailed/account.detailed.resolver.ts
@@ -7,7 +7,7 @@ import { AccountDetailedQuery } from "src/graphql/entities/account.detailed/acco
 import { AccountService } from "src/endpoints/accounts/account.service";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
 import { CollectionService } from "src/endpoints/collections/collection.service";
-import { GetFromAndSizeInput, GetHistoryTokenAccountInput, GetNftCollectionsAccountInput, GetNftsAccountInput, GetTokensAccountInput, GetTransactionsAccountCountInput, GetTransactionsAccountInput, GetTransfersAccountInput } from "src/graphql/entities/account.detailed/account.detailed.input";
+import { GetAccountHistory, GetFromAndSizeInput, GetHistoryTokenAccountInput, GetNftCollectionsAccountInput, GetNftsAccountInput, GetTokensAccountInput, GetTransactionsAccountCountInput, GetTransactionsAccountInput, GetTransfersAccountInput } from "src/graphql/entities/account.detailed/account.detailed.input";
 import { NftAccountFlat, NftCollectionAccountFlat, TokenWithBalanceAccountFlat } from "src/graphql/entities/account.detailed/account.detailed.object";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftService } from "src/endpoints/nfts/nft.service";
@@ -97,13 +97,16 @@ export class AccountDetailedResolver extends AccountDetailedQuery {
   }
 
   @ResolveField("historyAccount", () => [AccountHistory], { name: "historyAccount", description: "Return account EGLD balance history." })
-  public async getAccountHistory(@Args("input", { description: "Input to retrieve the given EGLD balance history for." }) input: GetFromAndSizeInput, @Parent() account: AccountDetailed) {
+  public async getAccountHistory(@Args("input", { description: "Input to retrieve the given EGLD balance history for." }) input: GetAccountHistory, @Parent() account: AccountDetailed) {
     return await this.accountService.getAccountHistory(
       account.address,
       new QueryPagination({
         from: input.from,
         size: input.size,
-      }), new AccountHistoryFilter({}));
+      }), new AccountHistoryFilter({
+        before: input.before,
+        after: input.after,
+      }));
   }
 
   @ResolveField("historyTokenAccount", () => [AccountEsdtHistory], { name: "historyTokenAccount", description: "Return account balance history for a specifc token." })
@@ -114,7 +117,10 @@ export class AccountDetailedResolver extends AccountDetailedQuery {
       new QueryPagination({
         from: input.from,
         size: input.size,
-      }), new AccountHistoryFilter({}));
+      }), new AccountHistoryFilter({
+        before: input.before,
+        after: input.after,
+      }));
   }
 
   @ResolveField("contractAccount", () => [DeployedContract], { name: "contractAccount", description: "Contracts for the given detailed account.", nullable: true })

--- a/src/graphql/entities/account.detailed/account.detailed.resolver.ts
+++ b/src/graphql/entities/account.detailed/account.detailed.resolver.ts
@@ -32,6 +32,7 @@ import { SmartContractResult } from "src/endpoints/sc-results/entities/smart.con
 import { SmartContractResultService } from "src/endpoints/sc-results/scresult.service";
 import { AccountHistory } from "src/endpoints/accounts/entities/account.history";
 import { AccountEsdtHistory } from "src/endpoints/accounts/entities/account.esdt.history";
+import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 
 @Resolver(() => AccountDetailed)
 export class AccountDetailedResolver extends AccountDetailedQuery {
@@ -102,7 +103,7 @@ export class AccountDetailedResolver extends AccountDetailedQuery {
       new QueryPagination({
         from: input.from,
         size: input.size,
-      }));
+      }), new AccountHistoryFilter({}));
   }
 
   @ResolveField("historyTokenAccount", () => [AccountEsdtHistory], { name: "historyTokenAccount", description: "Return account balance history for a specifc token." })
@@ -113,7 +114,7 @@ export class AccountDetailedResolver extends AccountDetailedQuery {
       new QueryPagination({
         from: input.from,
         size: input.size,
-      }));
+      }), new AccountHistoryFilter({}));
   }
 
   @ResolveField("contractAccount", () => [DeployedContract], { name: "contractAccount", description: "Contracts for the given detailed account.", nullable: true })

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -159,7 +159,7 @@ type AccountDetailed {
   """Return account EGLD balance history."""
   historyAccount(
     """Input to retrieve the given EGLD balance history for."""
-    input: GetFromAndSizeInput!
+    input: GetAccountHistory!
   ): [AccountHistory!]!
 
   """Return account balance history for a specifc token."""
@@ -710,6 +710,21 @@ input GetAccountFilteredInput {
   ownerAddress: String
 }
 
+"""Input to retrieve the given transactions count for."""
+input GetAccountHistory {
+  """After timestamp for the given result set."""
+  after: Float
+
+  """Before timestamp for the given result set."""
+  before: Float
+
+  """Number of collections to skip for the given result set."""
+  from: Float = 0
+
+  """Number of collections to retrieve for the given result set."""
+  size: Float = 25
+}
+
 """Input to retrieve the given accounts for."""
 input GetAccountsInput {
   """Number of accounts to skip for the given result set."""
@@ -784,6 +799,12 @@ input GetFromAndSizeInput {
 
 """Input to retrieve the given history token for."""
 input GetHistoryTokenAccountInput {
+  """After timestamp for the given result set."""
+  after: Float
+
+  """Before timestamp for the given result set."""
+  before: Float
+
   """Number of collections to skip for the given result set."""
   from: Float = 0
 

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -8,6 +8,7 @@ import { AddressUtils, CachingService, ElasticService } from '@multiversx/sdk-ne
 import { AccountKey } from 'src/endpoints/accounts/entities/account.key';
 import { AccountEsdtHistory } from 'src/endpoints/accounts/entities/account.esdt.history';
 import { AccountFilter } from 'src/endpoints/accounts/entities/account.filter';
+import { AccountHistoryFilter } from 'src/endpoints/accounts/entities/account.history.filter';
 
 describe('Account Service', () => {
   let accountService: AccountService;
@@ -268,7 +269,7 @@ describe('Account Service', () => {
         .mockImplementation(jest.fn(async () => accountHistory));
 
       const address: string = "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97";
-      const results = await accountService.getAccountHistory(address, { from: 0, size: 2 });
+      const results = await accountService.getAccountHistory(address, { from: 0, size: 2 }, new AccountHistoryFilter({}));
 
       expect(results).toHaveLength(2);
 
@@ -289,7 +290,7 @@ describe('Account Service', () => {
     it("should return account token history", async () => {
       const token: string = "RIDE-7d18e9";
       const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
-      const results = await accountService.getAccountTokenHistory(address, token, { from: 0, size: 1 });
+      const results = await accountService.getAccountTokenHistory(address, token, { from: 0, size: 1 }, new AccountHistoryFilter({}));
 
       if (!results) {
         throw new Error('Properties are not defined');
@@ -313,7 +314,7 @@ describe('Account Service', () => {
 
       const token: string = "";
       const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
-      const results = await accountService.getAccountTokenHistory(address, token, { from: 0, size: 1 });
+      const results = await accountService.getAccountTokenHistory(address, token, { from: 0, size: 1 }, new AccountHistoryFilter({}));
 
       expect(results).toStrictEqual([]);
     });

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -571,7 +571,7 @@ describe('Token Service', () => {
   describe("getTokensForAddress", () => {
     it("should return a list of tokens for a specific address", async () => {
       const MOCK_PATH = apiConfigService.getMockPath();
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
 
       const filter: TokenFilter = new TokenFilter();
       filter.identifier = "RIDE-7d18e9";
@@ -633,7 +633,7 @@ describe('Token Service', () => {
   describe("getTokensForAddressFromElastic", () => {
     it("should return one token for a specific address with source ELASTIC and identifier filter applied", async () => {
       const MOCK_PATH = apiConfigService.getMockPath();
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
 
       const filter: TokenFilter = new TokenFilter();
       filter.identifier = "RIDE-7d18e9";
@@ -1025,7 +1025,7 @@ describe('Token Service', () => {
   //TBD: getTokenForAddress return undefined for SC address
   describe("getTokenForAddress", () => {
     it("should return token for a specific address", async () => {
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
       const identifier: string = "RIDE-7d18e9";
       const result = await tokenService.getTokenForAddress(address, identifier);
 
@@ -1033,7 +1033,7 @@ describe('Token Service', () => {
     });
 
     it("should return undefined because test simulates that token is not defined for address", async () => {
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
       const identifier: string = "RIDE-7d18e9";
 
       jest


### PR DESCRIPTION
## Reasoning
- Account history endpoint  did not allow searching by a timestamp
  
## Proposed Changes
- Add in elastic query before and after filters condition

## How to test
- accounts/erd103a544heqlz0hh63x8637nhtkuy99j2dn4t5dnf2u4u28gezr7xqrxn3cc/history?after=1677618270
- accounts/erd103a544heqlz0hh63x8637nhtkuy99j2dn4t5dnf2u4u28gezr7xqrxn3cc/history?before=1677618270&after=1677618216

- accounts/erd103a544heqlz0hh63x8637nhtkuy99j2dn4t5dnf2u4u28gezr7xqrxn3cc/history/WEGLD-bd4d79?after=1677618216
