### PR TITLE
 add scheduledRootHash block field

### DIFF
--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -38,9 +38,11 @@ export class BlockService {
       const blockRaw = await this.computeProposerAndValidators(item);
 
       const block = Block.mergeWithElasticResponse(new Block(), blockRaw);
+
       if (blockRaw.scheduledData && blockRaw.scheduledData.rootHash) {
         block.scheduledRootHash = blockRaw.scheduledData.rootHash;
       }
+
       blocks.push(block);
     }
 

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -38,6 +38,9 @@ export class BlockService {
       const blockRaw = await this.computeProposerAndValidators(item);
 
       const block = Block.mergeWithElasticResponse(new Block(), blockRaw);
+      if (blockRaw.scheduledData && blockRaw.scheduledData.rootHash) {
+        block.scheduledRootHash = blockRaw.scheduledData.rootHash;
+      }
       blocks.push(block);
     }
 

--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -81,6 +81,10 @@ export class Block {
   @ApiProperty({ type: Number })
   maxGasLimit: number = 0;
 
+  @Field(() => String, { description: "Scheduled Root Hash for the given Block." })
+  @ApiProperty({ type: String })
+  scheduledRootHash: string = '';
+
   static mergeWithElasticResponse<T extends Block>(newBlock: T, blockRaw: any): T {
     blockRaw.shard = blockRaw.shardId;
 

--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -81,9 +81,9 @@ export class Block {
   @ApiProperty({ type: Number })
   maxGasLimit: number = 0;
 
-  @Field(() => String, { description: "Scheduled Root Hash for the given Block." })
-  @ApiProperty({ type: String })
-  scheduledRootHash: string = '';
+  @Field(() => String, { description: "Scheduled Root Hash for the given Block.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  scheduledRootHash: string | undefined = undefined;
 
   static mergeWithElasticResponse<T extends Block>(newBlock: T, blockRaw: any): T {
     blockRaw.shard = blockRaw.shardId;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -374,6 +374,9 @@ type Block {
   """Round for the given Block."""
   round: Float!
 
+  """Scheduled Root Hash for the given Block."""
+  scheduledRootHash: String!
+
   """Shard for the given Block."""
   shard: Float!
 
@@ -436,6 +439,9 @@ type BlockDetailed {
 
   """Round for the given Block."""
   round: Float!
+
+  """Scheduled Root Hash for the given Block."""
+  scheduledRootHash: String!
 
   """Shard for the given Block."""
   shard: Float!

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -375,7 +375,7 @@ type Block {
   round: Float!
 
   """Scheduled Root Hash for the given Block."""
-  scheduledRootHash: String!
+  scheduledRootHash: String
 
   """Shard for the given Block."""
   shard: Float!
@@ -441,7 +441,7 @@ type BlockDetailed {
   round: Float!
 
   """Scheduled Root Hash for the given Block."""
-  scheduledRootHash: String!
+  scheduledRootHash: String
 
   """Shard for the given Block."""
   shard: Float!

--- a/src/test/integration/services/blocks.e2e-spec.ts
+++ b/src/test/integration/services/blocks.e2e-spec.ts
@@ -81,7 +81,7 @@ describe('Blocks Service', () => {
     });
   });
 
-  describe.only('getBlocks', () => {
+  describe('getBlocks', () => {
     it('should return an array of blocks and scheduledRootHash field should be defined', async () => {
       const results = await blocksService.getBlocks(new BlockFilter(), { from: 0, size: 25 });
 

--- a/src/test/integration/services/blocks.e2e-spec.ts
+++ b/src/test/integration/services/blocks.e2e-spec.ts
@@ -80,4 +80,14 @@ describe('Blocks Service', () => {
       expect(typeof block).toBe('number');
     });
   });
+
+  describe.only('getBlocks', () => {
+    it('should return an array of blocks and scheduledRootHash field should be defined', async () => {
+      const results = await blocksService.getBlocks(new BlockFilter(), { from: 0, size: 25 });
+
+      for (const result of results) {
+        expect(result.scheduledRootHash).toBeDefined();
+      }
+    });
+  });
 });

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -571,7 +571,7 @@ describe('Token Service', () => {
   describe("getTokensForAddress", () => {
     it("should return a list of tokens for a specific address", async () => {
       const MOCK_PATH = apiConfigService.getMockPath();
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
 
       const filter: TokenFilter = new TokenFilter();
       filter.identifier = "RIDE-7d18e9";
@@ -633,7 +633,7 @@ describe('Token Service', () => {
   describe("getTokensForAddressFromElastic", () => {
     it("should return one token for a specific address with source ELASTIC and identifier filter applied", async () => {
       const MOCK_PATH = apiConfigService.getMockPath();
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
 
       const filter: TokenFilter = new TokenFilter();
       filter.identifier = "RIDE-7d18e9";
@@ -1025,7 +1025,7 @@ describe('Token Service', () => {
   //TBD: getTokenForAddress return undefined for SC address
   describe("getTokenForAddress", () => {
     it("should return token for a specific address", async () => {
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
       const identifier: string = "RIDE-7d18e9";
       const result = await tokenService.getTokenForAddress(address, identifier);
 
@@ -1033,7 +1033,7 @@ describe('Token Service', () => {
     });
 
     it("should return undefined because test simulates that token is not defined for address", async () => {
-      const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
+      const address: string = "erd1nxw88rdky83txukp87wnlpak8c6ykf2yx3nq7uymjepma975wv2qxhcsnq";
       const identifier: string = "RIDE-7d18e9";
 
       jest


### PR DESCRIPTION
## Reasoning
-  scheduledData .rootHash is not defined in block response body
  
## Proposed Changes
- Add scheduledRootHash field

## How to test
-  /blocks -> scheduledRootHash field should be defined
- /blocks/ed57df70de13292f22202dbbd8f64c805489fffc32b787851563df7cba8f4e5d -> scheduledRootHash should be defined

`"scheduledRootHash": "2edb1f5ee77edfa818b4d56b1c19b3aadd6d43c9d1bdb1d4357dde115d6681a1"`
