### PR TITLE
Remove unnecessary logs

### DIFF
--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -49,7 +49,7 @@ export class ProxyController {
   @ApiExcludeEndpoint()
   async getAddressStorageKey(@Param('address', ParseAddressPipe) address: string, @Param('key') key: string) {
     // eslint-disable-next-line require-await
-    return await await this.gatewayGet(`address/${address}/key/${key}`, GatewayComponentRequest.addressStorage, undefined, async (error) => {
+    return await this.gatewayGet(`address/${address}/key/${key}`, GatewayComponentRequest.addressStorage, undefined, async (error) => {
       if (error?.response?.data?.error?.includes('get value for key error')) {
         throw error;
       }

--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -48,7 +48,14 @@ export class ProxyController {
   @Get('/address/:address/key/:key')
   @ApiExcludeEndpoint()
   async getAddressStorageKey(@Param('address', ParseAddressPipe) address: string, @Param('key') key: string) {
-    return await this.gatewayGet(`address/${address}/key/${key}`, GatewayComponentRequest.addressStorage);
+    // eslint-disable-next-line require-await
+    return await await this.gatewayGet(`address/${address}/key/${key}`, GatewayComponentRequest.addressStorage, undefined, async (error) => {
+      if (error?.response?.data?.error?.includes('get value for key error')) {
+        throw error;
+      }
+
+      return false;
+    });
   }
 
   @Get('/address/:address/transactions')
@@ -169,7 +176,15 @@ export class ProxyController {
   @Post('/vm-values/hex')
   @ApiExcludeEndpoint()
   async vmValuesHex(@Body() body: any) {
-    return await this.gatewayPost('vm-values/hex', GatewayComponentRequest.vmQuery, body);
+    // eslint-disable-next-line require-await
+    return await this.gatewayPost('vm-values/hex', GatewayComponentRequest.vmQuery, body, async (error) => {
+      const message = error.response?.data?.error;
+      if (message && message.includes('doGetVMValue: no return data')) {
+        throw error;
+      }
+
+      return false;
+    });
   }
 
   @Post('/vm-values/string')


### PR DESCRIPTION
## Reasoning
- Error logs contained a lot of errors due to bad user input
  
## Proposed Changes
- Filter out errors for certain failures inside the proxy controller

## How to test
- `/vm-values/hex` with the body
```json
{
    "Args": [
        "fbe99a95a6925693679933db8eb7cb19ef4d187ac63db1b0204ad978e1263112"
    ],
    "FuncName": "getPublicKey",
    "ScAddress": "erd1qqqqqqqqqqqqqpgqjq0h2hy6ppj5yze2t3gr6kadvaahkljch77qynjfg8"
}
```
should not log any error
- `/address/:address/key/:key` should not return error for a key that doesn't exist