### PR TITLE
support for multiple miniblocks hashes

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -52,6 +52,12 @@ export class ElasticIndexerHelper {
       queries.push(validatorsQuery);
     }
 
+    if (filter.hashes !== undefined && filter.hashes.length > 0) {
+      const hashQueries = filter.hashes.map(hash => QueryType.Match('_id', hash));
+      const shouldQuery = QueryType.Should(hashQueries);
+      queries.push(shouldQuery);
+    }
+
     return queries;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -21,6 +21,7 @@ import { TokenType } from "../entities";
 import { SortCollections } from "src/endpoints/collections/entities/sort.collections";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { AccountSort } from "src/endpoints/accounts/entities/account.sort";
+import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 
 @Injectable()
 export class ElasticIndexerService implements IndexerInterface {
@@ -330,6 +331,18 @@ export class ElasticIndexerService implements IndexerInterface {
     }
 
     return await this.elasticService.getList('scresults', 'hash', query);
+  }
+
+  async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<any[]> {
+    let query = ElasticQuery.create()
+      .withPagination(pagination)
+      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+
+    if (filter.hashes) {
+      query = query.withShouldCondition(filter.hashes.map(hash => QueryType.Match('_id', hash)));
+    }
+
+    return await this.elasticService.getList('miniblocks', 'miniBlockHash', query);
   }
 
   async getAccountScResults(address: string, pagination: QueryPagination): Promise<any[]> {

--- a/src/common/indexer/entities/miniblock.ts
+++ b/src/common/indexer/entities/miniblock.ts
@@ -1,5 +1,5 @@
 export interface MiniBlock {
-  hash: string;
+  miniBlockHash: string;
   senderShard: number;
   receiverShard: number;
   senderBlockHash: string;
@@ -8,4 +8,6 @@ export interface MiniBlock {
   procTypeD: string;
   timestamp: number;
   procTypeS: string;
+  senderBlockNonce: string;
+  receiverBlockNonce: string;
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -1,6 +1,7 @@
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
+import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 import { RoundFilter } from "src/endpoints/rounds/entities/round.filter";
@@ -68,6 +69,8 @@ export interface IndexerInterface {
   getBlock(hash: string): Promise<Block>
 
   getMiniBlock(miniBlockHash: string): Promise<MiniBlock>
+
+  getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<MiniBlock[]>
 
   getTag(tag: string): Promise<Tag>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -15,6 +15,7 @@ import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBl
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
 import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
+import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 
 @Injectable()
 export class IndexerService implements IndexerInterface {
@@ -162,6 +163,11 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getMiniBlock(miniBlockHash: string): Promise<MiniBlock> {
     return await this.indexerInterface.getMiniBlock(miniBlockHash);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<MiniBlock[]> {
+    return await this.indexerInterface.getMiniBlocks(pagination, filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/postgres/entities/miniblock.db.ts
+++ b/src/common/indexer/postgres/entities/miniblock.db.ts
@@ -4,7 +4,7 @@ import { MiniBlock } from "../../entities";
 @Entity('miniblocks')
 export class MiniBlockDb implements MiniBlock {
   @PrimaryColumn()
-  hash: string = '';
+  miniBlockHash: string = '';
 
   @Column({ nullable: true, name: 'sender_shard_id' })
   senderShard: number = 0;
@@ -29,4 +29,10 @@ export class MiniBlockDb implements MiniBlock {
 
   @Column({ nullable: true })
   timestamp: number = 0;
+
+  @Column({ nullable: true, name: 'sender_block_nonce' })
+  senderBlockNonce: string = '';
+
+  @Column({ nullable: true, name: 'receiver_block_nonce' })
+  receiverBlockNonce: string = '';
 }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -5,6 +5,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { SortOrder } from "src/common/entities/sort.order";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
+import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { RoundFilter } from "src/endpoints/rounds/entities/round.filter";
 import { SmartContractResultFilter } from "src/endpoints/sc-results/entities/smart.contract.result.filter";
@@ -272,6 +273,17 @@ export class PostgresIndexerService implements IndexerInterface {
       .buildCollectionRolesFilter(filter, address)
       .skip(from).take(size)
       .orderBy('timestamp', 'DESC');
+
+    return await query.getMany();
+  }
+
+  async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<any[]> {
+    let query = this.miniBlocksRepository.createQueryBuilder()
+      .skip(pagination.from).take(pagination.size);
+
+    if (filter.hashes) {
+      query = query.andWhere('mb_hash = :hash IN (:...hashes)', { hashes: filter.hashes });
+    }
 
     return await query.getMany();
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -645,6 +645,7 @@ export class AccountController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions. When "withLogs" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   @ApiQuery({ name: 'computeScamInfo', required: false, type: Boolean })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   async getAccountTransactions(
@@ -668,9 +669,10 @@ export class AccountController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ) {
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,
@@ -736,6 +738,7 @@ export class AccountController {
   @Get("/accounts/:address/transfers")
   @ApiOperation({ summary: 'Account value transfers', description: 'Returns both transfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult), thus providing a full picture of all in/out value transfers for a given account' })
   @ApiOkResponse({ type: [Transaction] })
+  @ApplyComplexity({ target: TransactionDetailed })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'sender', description: 'Address of the transfer sender', required: false })
@@ -752,6 +755,7 @@ export class AccountController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   async getAccountTransfers(
     @Param('address', ParseAddressPipe) address: string,
@@ -771,13 +775,14 @@ export class AccountController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ): Promise<Transaction[]> {
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
     }
 
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername, withBlockInfo });
 
     return await this.transferService.getTransfers(new TransactionFilter({
       address,

--- a/src/endpoints/blocks/block.controller.ts
+++ b/src/endpoints/blocks/block.controller.ts
@@ -1,4 +1,4 @@
-import { ParseBlockHashPipe, ParseBlsHashPipe, ParseBoolPipe, ParseIntPipe } from "@multiversx/sdk-nestjs";
+import { ParseArrayPipe, ParseBlockHashPipe, ParseBlsHashPipe, ParseBoolPipe, ParseIntPipe } from "@multiversx/sdk-nestjs";
 import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -31,9 +31,10 @@ export class BlockController {
     @Query('validator', ParseBlsHashPipe) validator?: string,
     @Query('epoch', ParseIntPipe) epoch?: number,
     @Query('nonce', ParseIntPipe) nonce?: number,
+    @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('withProposerIdentity', ParseBoolPipe) withProposerIdentity?: boolean,
   ): Promise<Block[]> {
-    return this.blockService.getBlocks(new BlockFilter({ shard, proposer, validator, epoch, nonce }), new QueryPagination({ from, size }), withProposerIdentity);
+    return this.blockService.getBlocks(new BlockFilter({ shard, proposer, validator, epoch, nonce, hashes }), new QueryPagination({ from, size }), withProposerIdentity);
   }
 
   @Get("/blocks/count")

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -32,7 +32,6 @@ export class BlockService {
 
   async getBlocks(filter: BlockFilter, queryPagination: QueryPagination, withProposerIdentity?: boolean): Promise<Block[]> {
     const result = await this.indexerService.getBlocks(filter, queryPagination);
-
     const blocks = [];
     for (const item of result) {
       const blockRaw = await this.computeProposerAndValidators(item);

--- a/src/endpoints/blocks/entities/block.filter.ts
+++ b/src/endpoints/blocks/entities/block.filter.ts
@@ -8,4 +8,5 @@ export class BlockFilter {
   validator?: string;
   epoch?: number;
   nonce?: number;
+  hashes?: string[];
 }

--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -83,7 +83,7 @@ export class Block {
 
   @Field(() => String, { description: "Scheduled Root Hash for the given Block.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
-  scheduledRootHash?: string = '';
+  scheduledRootHash: string | undefined = undefined;
 
   static mergeWithElasticResponse<T extends Block>(newBlock: T, blockRaw: any): T {
     blockRaw.shard = blockRaw.shardId;

--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -83,7 +83,7 @@ export class Block {
 
   @Field(() => String, { description: "Scheduled Root Hash for the given Block.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
-  scheduledRootHash: string | undefined = undefined;
+  scheduledRootHash?: string = '';
 
   static mergeWithElasticResponse<T extends Block>(newBlock: T, blockRaw: any): T {
     blockRaw.shard = blockRaw.shardId;

--- a/src/endpoints/miniblocks/entities/mini.block.filter.ts
+++ b/src/endpoints/miniblocks/entities/mini.block.filter.ts
@@ -1,0 +1,7 @@
+
+export class MiniBlockFilter {
+  constructor(init?: Partial<MiniBlockFilter>) {
+    Object.assign(this, init);
+  }
+  hashes?: string[];
+}

--- a/src/endpoints/miniblocks/mini.block.controller.ts
+++ b/src/endpoints/miniblocks/mini.block.controller.ts
@@ -1,13 +1,29 @@
-import { ParseBlockHashPipe } from "@multiversx/sdk-nestjs";
-import { Controller, Get, HttpException, HttpStatus, Param } from "@nestjs/common";
-import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ParseArrayPipe, ParseBlockHashPipe } from "@multiversx/sdk-nestjs";
+import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, ParseIntPipe, Query } from "@nestjs/common";
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { QueryPagination } from "src/common/entities/query.pagination";
 import { MiniBlockDetailed } from "./entities/mini.block.detailed";
+import { MiniBlockFilter } from "./entities/mini.block.filter";
 import { MiniBlockService } from "./mini.block.service";
 
 @Controller()
 @ApiTags('miniblocks')
 export class MiniBlockController {
   constructor(private readonly miniBlockService: MiniBlockService) { }
+
+  @Get("/miniblocks")
+  @ApiOperation({ summary: 'Miniblocks details', description: 'Returns all distinct miniblocks' })
+  @ApiOkResponse({ type: [MiniBlockDetailed] })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of miniblocks hashes', required: false })
+  async getMiniBlocks(
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('hashes', ParseArrayPipe) hashes?: string[],
+  ): Promise<MiniBlockDetailed[]> {
+    return await this.miniBlockService.getMiniBlocks(new QueryPagination({ from, size }), new MiniBlockFilter({ hashes }));
+  }
 
   @Get("/miniblocks/:miniBlockHash")
   @ApiOperation({ summary: 'Miniblock details', description: 'Returns miniblock details for a given miniBlockHash.' })

--- a/src/endpoints/miniblocks/mini.block.service.ts
+++ b/src/endpoints/miniblocks/mini.block.service.ts
@@ -1,7 +1,9 @@
 import { ApiUtils } from "@multiversx/sdk-nestjs";
 import { Injectable } from "@nestjs/common";
+import { QueryPagination } from "src/common/entities/query.pagination";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { MiniBlockDetailed } from "./entities/mini.block.detailed";
+import { MiniBlockFilter } from "./entities/mini.block.filter";
 
 @Injectable()
 export class MiniBlockService {
@@ -9,7 +11,11 @@ export class MiniBlockService {
 
   async getMiniBlock(miniBlockHash: string): Promise<MiniBlockDetailed> {
     const result = await this.indexerService.getMiniBlock(miniBlockHash);
-
     return ApiUtils.mergeObjects(new MiniBlockDetailed(), result);
+  }
+
+  async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<MiniBlockDetailed[]> {
+    const results = await this.indexerService.getMiniBlocks(pagination, filter);
+    return results.map(item => ApiUtils.mergeObjects(new MiniBlockDetailed(), item));
   }
 }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -333,6 +333,7 @@ export class TokenController {
   @Get("/tokens/:identifier/transfers")
   @ApiOperation({ summary: 'Token value transfers', description: 'Returns both transfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult), thus providing a full picture of all in/out value transfers for a given account' })
   @ApiOkResponse({ type: [Transaction] })
+  @ApplyComplexity({ target: TransactionDetailed })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'sender', description: 'Address of the transfer sender', required: false })
@@ -347,6 +348,7 @@ export class TokenController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   async getTokenTransfers(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -363,6 +365,7 @@ export class TokenController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
   ): Promise<Transaction[]> {
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
@@ -373,7 +376,7 @@ export class TokenController {
       throw new NotFoundException('Token not found');
     }
 
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername, withBlockInfo });
 
     return await this.transferService.getTransfers(new TransactionFilter({
       sender,

--- a/src/endpoints/transactions/entities/transaction.detailed.ts
+++ b/src/endpoints/transactions/entities/transaction.detailed.ts
@@ -36,5 +36,25 @@ export class TransactionDetailed extends Transaction {
   @ApiProperty({ type: TransactionOperation, isArray: true })
   @ComplexityEstimation({ group: "details", value: 200, alternatives: ["withOperations"] })
   operations: TransactionOperation[] = [];
+
+  @Field(() => String, { description: "Sender Block hash for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  @ComplexityEstimation({ group: "blockInfo", value: 200, alternatives: ["withBlockInfo"] })
+  senderBlockHash: string | undefined = undefined;
+
+  @Field(() => Float, { description: "Sender Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  @ComplexityEstimation({ group: "blockInfo", value: 200, alternatives: ["withBlockInfo"] })
+  senderBlockNonce: number | undefined = undefined;
+
+  @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  @ComplexityEstimation({ group: "blockInfo", value: 200, alternatives: ["withBlockInfo"] })
+  receiverBlockHash: string | undefined = undefined;
+
+  @Field(() => Float, { description: "Receiver Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  @ComplexityEstimation({ group: "blockInfo", value: 200, alternatives: ["withBlockInfo"] })
+  receiverBlockNonce: number | undefined = undefined;
 }
 

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -118,22 +118,6 @@ export class Transaction {
   @ApiProperty({ type: Boolean, nullable: true })
   pendingResults: boolean | undefined = undefined;
 
-  @Field(() => String, { description: "Sender Block hash for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  senderBlockHash: string | undefined = undefined;
-
-  @Field(() => Float, { description: "Sender Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: Number, nullable: true })
-  senderBlockNonce: number | undefined = undefined;
-
-  @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  receiverBlockHash: string | undefined = undefined;
-
-  @Field(() => Float, { description: "Receiver Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: Number, nullable: true })
-  receiverBlockNonce: number | undefined = undefined;
-
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -122,17 +122,17 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true })
   senderBlockHash: string | undefined = undefined;
 
-  @Field(() => Number, { description: "Sender Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: Number, nullable: true })
-  senderBlockNonce: number | undefined = undefined;
+  @Field(() => String, { description: "Sender Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  senderBlockNonce: string | undefined = undefined;
 
   @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   receiverBlockHash: string | undefined = undefined;
 
-  @Field(() => Number, { description: "Receiver Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: Number, nullable: true })
-  receiverBlockNonce: number | undefined = undefined;
+  @Field(() => String, { description: "Receiver Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  receiverBlockNonce: string | undefined = undefined;
 
   getDate(): Date | undefined {
     if (this.timestamp) {

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -118,6 +118,22 @@ export class Transaction {
   @ApiProperty({ type: Boolean, nullable: true })
   pendingResults: boolean | undefined = undefined;
 
+  @Field(() => String, { description: "Sender Block hash for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  senderBlockHash: string | undefined = undefined;
+
+  @Field(() => String, { description: "Sender Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  senderBlockNonce: string | undefined = undefined;
+
+  @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  receiverBlockHash: string | undefined = undefined;
+
+  @Field(() => String, { description: "Receiver Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  receiverBlockNonce: string | undefined = undefined;
+
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -122,17 +122,17 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true })
   senderBlockHash: string | undefined = undefined;
 
-  @Field(() => String, { description: "Sender Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  senderBlockNonce: string | undefined = undefined;
+  @Field(() => Float, { description: "Sender Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  senderBlockNonce: number | undefined = undefined;
 
   @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   receiverBlockHash: string | undefined = undefined;
 
-  @Field(() => String, { description: "Receiver Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  receiverBlockNonce: string | undefined = undefined;
+  @Field(() => Float, { description: "Receiver Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  receiverBlockNonce: number | undefined = undefined;
 
   getDate(): Date | undefined {
     if (this.timestamp) {

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -122,17 +122,17 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true })
   senderBlockHash: string | undefined = undefined;
 
-  @Field(() => String, { description: "Sender Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  senderBlockNonce: string | undefined = undefined;
+  @Field(() => Number, { description: "Sender Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  senderBlockNonce: number | undefined = undefined;
 
   @Field(() => String, { description: "Receiver Block hash for the given transaction.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   receiverBlockHash: string | undefined = undefined;
 
-  @Field(() => String, { description: "Receiver Block nonce for the given transaction.", nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  receiverBlockNonce: string | undefined = undefined;
+  @Field(() => Number, { description: "Receiver Block nonce for the given transaction.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  receiverBlockNonce: number | undefined = undefined;
 
   getDate(): Date | undefined {
     if (this.timestamp) {

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -3,6 +3,7 @@ import { BadRequestException } from "@nestjs/common";
 export class TransactionQueryOptions {
   private static readonly SCAM_INFO_MAX_SIZE: number = 50;
   private static readonly USERNAME_MAX_SIZE: number = 50;
+  private static readonly BLOCK_INFO: number = 50;
 
   constructor(init?: Partial<TransactionQueryOptions>) {
     Object.assign(this, init);
@@ -14,6 +15,7 @@ export class TransactionQueryOptions {
   withScResultLogs?: boolean = true;
   withScamInfo?: boolean;
   withUsername?: boolean;
+  withBlockInfo?: boolean;
 
   static applyDefaultOptions(size: number, options: TransactionQueryOptions): TransactionQueryOptions {
     if (size <= TransactionQueryOptions.SCAM_INFO_MAX_SIZE) {
@@ -22,6 +24,10 @@ export class TransactionQueryOptions {
 
     if (options.withUsername === true && size > TransactionQueryOptions.USERNAME_MAX_SIZE) {
       throw new BadRequestException(`'withUsername' flag can only be activated for a maximum size of ${TransactionQueryOptions.USERNAME_MAX_SIZE}`);
+    }
+
+    if (options.withBlockInfo === true && size > TransactionQueryOptions.BLOCK_INFO) {
+      throw new BadRequestException(`'withBlockInfo' flag can only be activated for a maximum size of ${TransactionQueryOptions.BLOCK_INFO}`);
     }
 
     return options;

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -3,7 +3,6 @@ import { BadRequestException } from "@nestjs/common";
 export class TransactionQueryOptions {
   private static readonly SCAM_INFO_MAX_SIZE: number = 50;
   private static readonly USERNAME_MAX_SIZE: number = 50;
-  private static readonly BLOCK_INFO: number = 50;
 
   constructor(init?: Partial<TransactionQueryOptions>) {
     Object.assign(this, init);
@@ -24,10 +23,6 @@ export class TransactionQueryOptions {
 
     if (options.withUsername === true && size > TransactionQueryOptions.USERNAME_MAX_SIZE) {
       throw new BadRequestException(`'withUsername' flag can only be activated for a maximum size of ${TransactionQueryOptions.USERNAME_MAX_SIZE}`);
-    }
-
-    if (options.withBlockInfo === true && size > TransactionQueryOptions.BLOCK_INFO) {
-      throw new BadRequestException(`'withBlockInfo' flag can only be activated for a maximum size of ${TransactionQueryOptions.BLOCK_INFO}`);
     }
 
     return options;

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -35,6 +35,7 @@ export class TransferController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   async getAccountTransfers(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -1,9 +1,10 @@
-import { ParseBlockHashPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseAddressArrayPipe, ParseBoolPipe } from "@multiversx/sdk-nestjs";
+import { ParseBlockHashPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseAddressArrayPipe, ParseBoolPipe, ApplyComplexity } from "@multiversx/sdk-nestjs";
 import { Controller, DefaultValuePipe, Get, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { SortOrder } from "src/common/entities/sort.order";
 import { Transaction } from "../transactions/entities/transaction";
+import { TransactionDetailed } from "../transactions/entities/transaction.detailed";
 import { TransactionFilter } from "../transactions/entities/transaction.filter";
 import { TransactionStatus } from "../transactions/entities/transaction.status";
 import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
@@ -18,6 +19,7 @@ export class TransferController {
 
   @Get("/transfers")
   @ApiOperation({ summary: 'Value transfers', description: 'Returns both transfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult), thus providing a full picture of all in/out value transfers for a given account' })
+  @ApplyComplexity({ target: TransactionDetailed })
   @ApiOkResponse({ type: [Transaction] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -52,8 +52,9 @@ export class TransferController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
   ): Promise<Transaction[]> {
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername, withBlockInfo });
 
     return await this.transferService.getTransfers(new TransactionFilter({
       senders: sender,

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -69,8 +69,6 @@ export class TransferService {
           if (miniBlockHash && miniBlocks[i]) {
             transaction.senderBlockHash = miniBlocks[i].senderBlockHash;
             transaction.receiverBlockHash = miniBlocks[i].receiverBlockHash;
-            transaction.senderBlockNonce = miniBlocks[i].senderBlockNonce;
-            transaction.receiverBlockNonce = miniBlocks[i].receiverBlockNonce;
           }
 
           if (transaction.type === TransactionType.SmartContractResult) {

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -7,6 +7,7 @@ import { TransactionService } from "../transactions/transaction.service";
 import { ApiUtils } from "@multiversx/sdk-nestjs";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
+import { TransactionDetailed } from "../transactions/entities/transaction.detailed";
 
 @Injectable()
 export class TransferService {
@@ -78,7 +79,7 @@ export class TransferService {
 
         for (let i = 0; i < elasticOperations.length; i++) {
           const elasticOperation = elasticOperations[i];
-          const transaction = ApiUtils.mergeObjects(new Transaction(), elasticOperation);
+          const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
           transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
 
           const miniBlockHash = elasticOperation.miniBlockHash;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3765,12 +3765,6 @@ type Transaction {
   """Receiver assets for the given transaction."""
   receiverAssets: AccountAssets
 
-  """Receiver Block hash for the given transaction."""
-  receiverBlockHash: String
-
-  """Receiver Block nonce for the given transaction."""
-  receiverBlockNonce: Float
-
   """Receiver account shard for the given transaction."""
   receiverShard: String!
 
@@ -3788,12 +3782,6 @@ type Transaction {
 
   """Sender assets for the given transaction."""
   senderAssets: AccountAssets
-
-  """Sender Block hash for the given transaction."""
-  senderBlockHash: String
-
-  """Sender Block nonce for the given transaction."""
-  senderBlockNonce: Float
 
   """Sender account shard for the given transaction."""
   senderShard: Float!

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3765,6 +3765,12 @@ type Transaction {
   """Receiver assets for the given transaction."""
   receiverAssets: AccountAssets
 
+  """Receiver Block hash for the given transaction."""
+  receiverBlockHash: String
+
+  """Receiver Block nonce for the given transaction."""
+  receiverBlockNonce: String
+
   """Receiver account shard for the given transaction."""
   receiverShard: String!
 
@@ -3782,6 +3788,12 @@ type Transaction {
 
   """Sender assets for the given transaction."""
   senderAssets: AccountAssets
+
+  """Sender Block hash for the given transaction."""
+  senderBlockHash: String
+
+  """Sender Block nonce for the given transaction."""
+  senderBlockNonce: String
 
   """Sender account shard for the given transaction."""
   senderShard: Float!
@@ -3876,6 +3888,12 @@ type TransactionDetailed {
   """Receiver assets for the given transaction."""
   receiverAssets: AccountAssets
 
+  """Receiver Block hash for the given transaction."""
+  receiverBlockHash: String
+
+  """Receiver Block nonce for the given transaction."""
+  receiverBlockNonce: String
+
   """Receiver account shard for the given transaction."""
   receiverShard: String!
 
@@ -3896,6 +3914,12 @@ type TransactionDetailed {
 
   """Sender assets for the given transaction."""
   senderAssets: AccountAssets
+
+  """Sender Block hash for the given transaction."""
+  senderBlockHash: String
+
+  """Sender Block nonce for the given transaction."""
+  senderBlockNonce: String
 
   """Sender account shard for the given transaction."""
   senderShard: Float!

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3769,7 +3769,7 @@ type Transaction {
   receiverBlockHash: String
 
   """Receiver Block nonce for the given transaction."""
-  receiverBlockNonce: String
+  receiverBlockNonce: Float
 
   """Receiver account shard for the given transaction."""
   receiverShard: String!
@@ -3793,7 +3793,7 @@ type Transaction {
   senderBlockHash: String
 
   """Sender Block nonce for the given transaction."""
-  senderBlockNonce: String
+  senderBlockNonce: Float
 
   """Sender account shard for the given transaction."""
   senderShard: Float!
@@ -3892,7 +3892,7 @@ type TransactionDetailed {
   receiverBlockHash: String
 
   """Receiver Block nonce for the given transaction."""
-  receiverBlockNonce: String
+  receiverBlockNonce: Float
 
   """Receiver account shard for the given transaction."""
   receiverShard: String!
@@ -3919,7 +3919,7 @@ type TransactionDetailed {
   senderBlockHash: String
 
   """Sender Block nonce for the given transaction."""
-  senderBlockNonce: String
+  senderBlockNonce: Float
 
   """Sender account shard for the given transaction."""
   senderShard: Float!

--- a/src/test/integration/services/blocks.e2e-spec.ts
+++ b/src/test/integration/services/blocks.e2e-spec.ts
@@ -83,7 +83,7 @@ describe('Blocks Service', () => {
 
   describe('getBlocks', () => {
     it('should return an array of blocks and scheduledRootHash field should be defined', async () => {
-      const results = await blocksService.getBlocks(new BlockFilter(), { from: 0, size: 25 });
+      const results = await blocksService.getBlocks(new BlockFilter({ hashes: ['a2a5bf23fcecb4e2f14f5d5a793a9e2fa84b8d9487e269c1e7c4e1628c451eb1'] }), { from: 0, size: 25 });
 
       for (const result of results) {
         expect(result.scheduledRootHash).toBeDefined();


### PR DESCRIPTION
## Reasoning
-  To extend miniblocks endpoint functionality, we need to add possibility to retrieve all miniblocks details and filter by multiple miniblocks hashes
  
## Proposed Changes
-  Add the following functionalities
 - /miniblocks -> retrieve by default 25 miniblocks, sorted descending by timestamp
 - /miniblocks/?hashes = [hash1, hash2,...] -> retrieve specific miniblocks details

## How to test
- `/miniblocks?hashes=26be327a240e0ec88e6c06dda117e1235a656523849260bed35751906f44c29d,7f233a09e3ed3636efd2f8edb2755aa1faa528e7375549c2eec39cc0adf435db` -> return 2 miniblocks details
-  `/miniblocks` -> returns an array of 25 miniblocks
-  /transfers?withBlockInfo=true -> 
- `extra fields` 
   senderBlockHash
   senderBlockNonce
   receiverBlockHash
   receiverBlockNonce
   
 - /transfers?withBlockInfo=false -> extra fields should not be defined
 - max size <= 50
