### PR TITLE
Provide token collection in account tokens endpoints if MetaESDT

### DIFF
--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -18,6 +18,10 @@ export class Token {
   @ApiProperty({ type: String })
   identifier: string = '';
 
+  @Field(() => String, { description: "Token Collection if type is MetaESDT.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  collection: string | undefined = undefined;
+
   @Field(() => String, { description: "Token name." })
   @ApiProperty({ type: String })
   name: string = '';

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -206,11 +206,21 @@ export class TokenService {
   }
 
   async getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
+    let tokens: TokenWithBalance[];
     if (AddressUtils.isSmartContractAddress(address)) {
-      return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
+      tokens = await this.getTokensForAddressFromElastic(address, queryPagination, filter);
+    } else {
+      tokens = await this.getTokensForAddressFromGateway(address, queryPagination, filter);
     }
 
-    return await this.getTokensForAddressFromGateway(address, queryPagination, filter);
+    for (const token of tokens) {
+      if (token.type === TokenType.MetaESDT) {
+        token.collection = token.identifier.split('-').slice(0, 2).join('-');
+      }
+
+    }
+
+    return tokens;
   }
 
   async getTokensForAddressFromElastic(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3505,6 +3505,9 @@ type TokenDetailed {
   """Token circulating supply amount details."""
   circulatingSupply: String
 
+  """Token Collection if type is MetaESDT."""
+  collection: String
+
   """Token decimals."""
   decimals: Float!
 
@@ -3677,6 +3680,9 @@ type TokenWithBalanceAccountFlat {
 
   """Token circulating supply amount details."""
   circulatingSupply: String
+
+  """Token Collection if type is MetaESDT."""
+  collection: String
 
   """Token decimals."""
   decimals: Float!

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -640,6 +640,8 @@ describe('Token Service', () => {
       for (const result of results) {
         if (result.type === 'MetaESDT') {
           expect(result.collection).toBeDefined();
+        } else {
+          expect(result.collection).not.toBeDefined();
         }
       }
     });

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -628,6 +628,21 @@ describe('Token Service', () => {
 
       expect(results).toEqual([]);
     });
+
+    it("should return an array of tokens for a specific account that includes MetaESDT and verify if collection field is defined only for MetaESDTs", async () => {
+      const address: string = "erd1ut8kxtrkx8llshtcvsr42yu4ajgqrttvlg9ejacjn7xgs5g7werqwj8jxn";
+
+      const filter: TokenFilter = new TokenFilter();
+      filter.includeMetaESDT = true;
+
+      const results = await tokenService.getTokensForAddress(address, new QueryPagination({ size: 50 }), filter);
+
+      for (const result of results) {
+        if (result.type === 'MetaESDT') {
+          expect(result.collection).toBeDefined();
+        }
+      }
+    });
   });
 
   describe("getTokensForAddressFromElastic", () => {


### PR DESCRIPTION
## Proposed Changes
- Provide token collection in account tokens endpoints if MetaESDT

## How to test
- `/accounts/erd1ut8kxtrkx8llshtcvsr42yu4ajgqrttvlg9ejacjn7xgs5g7werqwj8jxn/tokens?includeMetaESDT=true&type=MetaESDT` should all have the `collection` attribute
