### PR TITLE
Count token accounts in chunks

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -24,6 +24,7 @@ import { SettingsService } from "src/common/settings/settings.service";
 import { TokenService } from "src/endpoints/tokens/token.service";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { NftService } from "src/endpoints/nfts/nft.service";
+import { TokenType } from "src/common/indexer/entities";
 
 @Injectable()
 export class CacheWarmerService {
@@ -283,6 +284,10 @@ export class CacheWarmerService {
     for (const key of Object.keys(allAssets)) {
       const collection = await this.indexerService.getCollection(key);
       if (!collection) {
+        continue;
+      }
+
+      if (![TokenType.NonFungibleESDT, TokenType.SemiFungibleESDT].includes(collection.type as TokenType)) {
         continue;
       }
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -348,16 +348,24 @@ export class EsdtService {
   async countAllAccounts(identifiers: string[]): Promise<number> {
     const key = `tokens:${identifiers[0]}:distinctAccounts`;
 
+    this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Counting all accounts`);
+
     for (const identifier of identifiers) {
+      this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Started fetching all accounts from ES for identifier ${identifier}`);
+      let total = 0;
       await this.indexerService.getAllAccountsWithToken(identifier, async items => {
         const distinctAccounts: string[] = items.map(x => x.address).distinct();
         if (distinctAccounts.length > 0) {
           await this.cachingService.setAdd(key, ...distinctAccounts);
         }
+
+        total += items.length;
       });
+      this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Finished fetching all accounts from ES for identifier ${identifier}. Total fetched accounts: ${total}`);
     }
 
     const count = await this.cachingService.setCount(key);
+    this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: All accounts count is ${count}`);
 
     await this.cachingService.deleteInCache(key);
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -358,7 +358,7 @@ export class EsdtService {
       await this.indexerService.getAllAccountsWithToken(identifier, async items => {
         const distinctAccounts: string[] = items.map(x => x.address).distinct();
         if (distinctAccounts.length > 0) {
-          const chunks = BatchUtils.splitArrayIntoChunks(distinctAccounts, 1000);
+          const chunks = BatchUtils.splitArrayIntoChunks(distinctAccounts, 100);
           for (const chunk of chunks) {
             await this.cachingService.setAdd(key, ...chunk);
           }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -13,6 +13,7 @@ import { BinaryUtils, Constants, CachingService, AddressUtils, OriginLogger, Bat
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { EsdtType } from "./entities/esdt.type";
 import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
+import { randomUUID } from "crypto";
 
 @Injectable()
 export class EsdtService {
@@ -346,7 +347,7 @@ export class EsdtService {
   }
 
   async countAllAccounts(identifiers: string[]): Promise<number> {
-    const key = `tokens:${identifiers[0]}:distinctAccounts`;
+    const key = `tokens:${identifiers[0]}:distinctAccounts:${randomUUID()}`;
 
     try {
       for (const identifier of identifiers) {

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -358,7 +358,7 @@ export class EsdtService {
       await this.indexerService.getAllAccountsWithToken(identifier, async items => {
         const distinctAccounts: string[] = items.map(x => x.address).distinct();
         if (distinctAccounts.length > 0) {
-          const chunks = BatchUtils.splitArrayIntoChunks(distinctAccounts, 100);
+          const chunks = BatchUtils.splitArrayIntoChunks(distinctAccounts, 1000);
           for (const chunk of chunks) {
             await this.cachingService.setAdd(key, ...chunk);
           }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -350,13 +350,19 @@ export class EsdtService {
 
     this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Counting all accounts`);
 
+    const set = new Set<string>();
+
     for (const identifier of identifiers) {
       this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Started fetching all accounts from ES for identifier ${identifier}`);
       let total = 0;
       await this.indexerService.getAllAccountsWithToken(identifier, async items => {
         const distinctAccounts: string[] = items.map(x => x.address).distinct();
-        if (distinctAccounts.length > 0) {
-          await this.cachingService.setAdd(key, ...distinctAccounts);
+        // if (distinctAccounts.length > 0) {
+        //   await this.cachingService.setAdd(key, ...distinctAccounts);
+        // }
+
+        for (const account of distinctAccounts) {
+          set.add(account);
         }
 
         total += items.length;
@@ -364,7 +370,8 @@ export class EsdtService {
       this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: Finished fetching all accounts from ES for identifier ${identifier}. Total fetched accounts: ${total}`);
     }
 
-    const count = await this.cachingService.setCount(key);
+    // const count = await this.cachingService.setCount(key);
+    const count = set.size;
     this.logger.log(`TempTokenAccountLogging for identifiers ${identifiers.join(', ')}: All accounts count is ${count}`);
 
     await this.cachingService.deleteInCache(key);


### PR DESCRIPTION
## Reasoning
- Distinct accounts counter with the help of redis can silently fail if too many arguments are provided at once on redis distributions such as ElastiCache
  
## Proposed Changes
- Count distinct accounts in chunks of 100
- Attach collection-specific extra fields only on NFT & SFT collections (previously it was also updating MetaESDT & FungibleESDT tokens

## How to test
- `Token assets extra info invalidations` cache warmer should behave the same as before, but with chunked updates
