### PR TITLE
Provide token nonce in account tokens endpoints if meta esdt

### DIFF
--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -22,6 +22,10 @@ export class Token {
   @ApiProperty({ type: String, nullable: true })
   collection: string | undefined = undefined;
 
+  @Field(() => Number, { description: "Token Nonce if type is MetaESDT.", nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  nonce: number | undefined = undefined;
+
   @Field(() => String, { description: "Token name." })
   @ApiProperty({ type: String })
   name: string = '';

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -19,7 +19,7 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { TokenSort } from "./entities/token.sort";
 import { TokenWithRoles } from "./entities/token.with.roles";
 import { TokenWithRolesFilter } from "./entities/token.with.roles.filter";
-import { AddressUtils, ApiUtils, CachingService, NumberUtils, TokenUtils } from "@multiversx/sdk-nestjs";
+import { AddressUtils, ApiUtils, BinaryUtils, CachingService, NumberUtils, TokenUtils } from "@multiversx/sdk-nestjs";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { OriginLogger } from "@multiversx/sdk-nestjs";
 import { TokenLogo } from "./entities/token.logo";
@@ -216,8 +216,8 @@ export class TokenService {
     for (const token of tokens) {
       if (token.type === TokenType.MetaESDT) {
         token.collection = token.identifier.split('-').slice(0, 2).join('-');
+        token.nonce = BinaryUtils.hexToNumber(token.identifier.split('-').slice(2, 3)[0]);
       }
-
     }
 
     return tokens;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3529,6 +3529,9 @@ type TokenDetailed {
   """Token name."""
   name: String!
 
+  """Token Nonce if type is MetaESDT."""
+  nonce: Float
+
   """Token owner address."""
   owner: String!
 
@@ -3704,6 +3707,9 @@ type TokenWithBalanceAccountFlat {
 
   """Token name."""
   name: String!
+
+  """Token Nonce if type is MetaESDT."""
+  nonce: Float
 
   """Current token price."""
   price: Float

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -640,8 +640,10 @@ describe('Token Service', () => {
       for (const result of results) {
         if (result.type === 'MetaESDT') {
           expect(result.collection).toBeDefined();
+          expect(result.nonce).toBeDefined();
         } else {
           expect(result.collection).not.toBeDefined();
+          expect(result.nonce).not.toBeDefined();
         }
       }
     });


### PR DESCRIPTION
## Proposed Changes
- Provide token collection in account tokens endpoints if MetaESDT

## How to test
- `/accounts/erd1ut8kxtrkx8llshtcvsr42yu4ajgqrttvlg9ejacjn7xgs5g7werqwj8jxn/tokens?includeMetaESDT=true&type=MetaESDT` should all have the `nonce` attribute
