### PR TITLE
support for extra block info for transactions endpoint

### DIFF
--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -201,6 +201,7 @@ export class TokenController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   async getTokenTransactions(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -221,8 +222,9 @@ export class TokenController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
   ) {
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -43,6 +43,7 @@ export class TransactionController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions. When "withLogs" parameter is applied, complexity estimation is 200', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   getTransactions(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -64,8 +65,10 @@ export class TransactionController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
+
   ) {
-    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
+    const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 
     return this.transactionService.getTransactions(new TransactionFilter({
       sender,

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -164,12 +164,11 @@ export class TransactionService {
           }
         }
       }
-    }
 
-    if (queryOptions && (queryOptions.withScResults || queryOptions.withOperations || queryOptions.withLogs)) {
-      queryOptions.withScResultLogs = queryOptions.withLogs;
-
-      transactions = await this.getExtraDetailsForTransactions(elasticTransactions, transactions, queryOptions);
+      if (queryOptions && (queryOptions.withScResults || queryOptions.withOperations || queryOptions.withLogs)) {
+        queryOptions.withScResultLogs = queryOptions.withLogs;
+        transactions = await this.getExtraDetailsForTransactions(elasticTransactions, transactions, queryOptions);
+      }
     }
 
     await this.processTransactions(transactions, {

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -160,6 +160,55 @@ export class TransactionService {
       }
     }
 
+    if (queryOptions && queryOptions.withBlockInfo) {
+      const miniBlockHashes: string[] = [];
+
+      for (const elasticTransaction of elasticTransactions) {
+        if (elasticTransaction.miniBlockHash) {
+          miniBlockHashes.push(elasticTransaction.miniBlockHash);
+        }
+      }
+
+      if (miniBlockHashes.length > 0) {
+        const miniBlocks = await this.indexerService.getMiniBlocks(pagination, { hashes: miniBlockHashes });
+        const senderBlockHashes: string[] = [];
+        const receiverBlockHashes: string[] = [];
+
+        for (const elasticTransaction of elasticTransactions) {
+          if (elasticTransaction.miniBlockHash) {
+            const miniBlock = miniBlocks.find((block) => block.miniBlockHash === elasticTransaction.miniBlockHash);
+
+            if (miniBlock) {
+              senderBlockHashes.push(miniBlock.senderBlockHash);
+              receiverBlockHashes.push(miniBlock.receiverBlockHash);
+            }
+          }
+        }
+
+        const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].filter((hash, index, hashes) => hashes.indexOf(hash) === index);
+        const blocks = await this.indexerService.getBlocks({ hashes: blockHashes }, pagination);
+
+        for (let i = 0; i < elasticTransactions.length; i++) {
+          const elasticOperation = elasticTransactions[i];
+          const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
+          const miniBlockHash = elasticOperation.miniBlockHash;
+
+          if (miniBlockHash && miniBlocks[i]) {
+            transaction.senderBlockHash = miniBlocks[i].senderBlockHash;
+            transaction.receiverBlockHash = miniBlocks[i].receiverBlockHash;
+          }
+
+          const senderBlockNonce = blocks.find((block) => block.hash === transaction.senderBlockHash)?.nonce;
+          const receiverBlockNonce = blocks.find((block) => block.hash === transaction.receiverBlockHash)?.nonce;
+
+          transaction.senderBlockNonce = senderBlockNonce;
+          transaction.receiverBlockNonce = receiverBlockNonce;
+
+          transactions.push(transaction);
+        }
+      }
+    }
+
     if (queryOptions && (queryOptions.withScResults || queryOptions.withOperations || queryOptions.withLogs)) {
       queryOptions.withScResultLogs = queryOptions.withLogs;
 
@@ -405,7 +454,6 @@ export class TransactionService {
           }
         }
       }
-
       detailedTransactions.push(transactionDetailed);
     }
 

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -46,79 +46,24 @@ export class TransferService {
     let elasticOperations = await this.indexerService.getTransfers(filter, pagination);
     elasticOperations = this.sortElasticTransfers(elasticOperations);
 
-    const transactions: Transaction[] = [];
+    const transactions: TransactionDetailed[] = [];
+
+    for (const elasticOperation of elasticOperations) {
+      const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
+      transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
+
+      if (transaction.type === TransactionType.SmartContractResult) {
+        delete transaction.gasLimit;
+        delete transaction.gasPrice;
+        delete transaction.gasUsed;
+        delete transaction.nonce;
+        delete transaction.round;
+      }
+      transactions.push(transaction);
+    }
 
     if (queryOptions.withBlockInfo) {
-      const miniBlockHashes: string[] = [];
-
-      for (const elasticOperation of elasticOperations) {
-        if (elasticOperation.miniBlockHash) {
-          miniBlockHashes.push(elasticOperation.miniBlockHash);
-        }
-      }
-
-      if (miniBlockHashes.length > 0) {
-        const miniBlocks = await this.indexerService.getMiniBlocks(pagination, { hashes: miniBlockHashes });
-
-        const senderBlockHashes: string[] = [];
-        const receiverBlockHashes: string[] = [];
-
-        for (const elasticOperation of elasticOperations) {
-          if (elasticOperation.miniBlockHash) {
-            const miniBlock = miniBlocks.find((block) => block.miniBlockHash === elasticOperation.miniBlockHash);
-
-            if (miniBlock) {
-              senderBlockHashes.push(miniBlock.senderBlockHash);
-              receiverBlockHashes.push(miniBlock.receiverBlockHash);
-            }
-          }
-        }
-
-        const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].filter((hash, index, hashes) => hashes.indexOf(hash) === index);
-        const blocks = await this.indexerService.getBlocks({ hashes: blockHashes }, pagination);
-
-        for (let i = 0; i < elasticOperations.length; i++) {
-          const elasticOperation = elasticOperations[i];
-          const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
-          transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
-
-          const miniBlockHash = elasticOperation.miniBlockHash;
-
-          if (miniBlockHash && miniBlocks[i]) {
-            transaction.senderBlockHash = miniBlocks[i].senderBlockHash;
-            transaction.receiverBlockHash = miniBlocks[i].receiverBlockHash;
-          }
-
-          const senderBlockNonce = blocks.find((block) => block.hash === transaction.senderBlockHash)?.nonce;
-          const receiverBlockNonce = blocks.find((block) => block.hash === transaction.receiverBlockHash)?.nonce;
-
-          transaction.senderBlockNonce = senderBlockNonce;
-          transaction.receiverBlockNonce = receiverBlockNonce;
-
-          if (transaction.type === TransactionType.SmartContractResult) {
-            delete transaction.gasLimit;
-            delete transaction.gasPrice;
-            delete transaction.gasUsed;
-            delete transaction.nonce;
-            delete transaction.round;
-          }
-          transactions.push(transaction);
-        }
-      }
-    } else {
-      for (const elasticOperation of elasticOperations) {
-        const transaction = ApiUtils.mergeObjects(new Transaction(), elasticOperation);
-        transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
-
-        if (transaction.type === TransactionType.SmartContractResult) {
-          delete transaction.gasLimit;
-          delete transaction.gasPrice;
-          delete transaction.gasUsed;
-          delete transaction.nonce;
-          delete transaction.round;
-        }
-        transactions.push(transaction);
-      }
+      await this.transactionService.applyBlockInfo(transactions);
     }
 
     await this.transactionService.processTransactions(transactions, {

--- a/src/test/integration/api/accounts.api-spec.ts
+++ b/src/test/integration/api/accounts.api-spec.ts
@@ -23,8 +23,8 @@ describe("API Testing", () => {
   it("/accounts", async () => {
     const checker = new ApiChecker('accounts', app.getHttpServer());
     checker.skipFields = ['balance', 'nonce'];
+    await checker.checkDetails();
     await checker.checkStatus();
     await checker.checkPagination();
-    await checker.checkDetails();
   });
 });

--- a/src/test/integration/api/accounts.api-spec.ts
+++ b/src/test/integration/api/accounts.api-spec.ts
@@ -26,5 +26,6 @@ describe("API Testing", () => {
     await checker.checkDetails();
     await checker.checkStatus();
     await checker.checkPagination();
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/blocks.api-spec.ts
+++ b/src/test/integration/api/blocks.api-spec.ts
@@ -29,6 +29,5 @@ describe("API Testing", () => {
     await checker.checkPagination();
     await checker.checkDetails();
     await checker.checkFilter(['shard', 'epoch', 'nonce']);
-    await checker.checkAlternativeCount(['validator']);
   });
 });

--- a/src/test/integration/api/blocks.api-spec.ts
+++ b/src/test/integration/api/blocks.api-spec.ts
@@ -29,5 +29,6 @@ describe("API Testing", () => {
     await checker.checkPagination();
     await checker.checkDetails();
     await checker.checkFilter(['shard', 'epoch', 'nonce']);
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/blocks.api-spec.ts
+++ b/src/test/integration/api/blocks.api-spec.ts
@@ -22,7 +22,9 @@ describe("API Testing", () => {
 
   it("/blocks", async () => {
     const checker = new ApiChecker('blocks', app.getHttpServer());
-    checker.defaultParams = { epoch: 500 };
+    const randomShard = Math.floor(Math.random() * 3);
+    checker.defaultParams = { epoch: 500, shard: randomShard };
+    checker.skipFields = ['scheduledRootHash'];
     await checker.checkStatus();
     await checker.checkPagination();
     await checker.checkDetails();

--- a/src/test/integration/api/collections.api-spec.ts
+++ b/src/test/integration/api/collections.api-spec.ts
@@ -26,5 +26,6 @@ describe.skip("API Testing", () => {
     await checker.checkPagination();
     await checker.checkDetails();
     await checker.checkFilter(['type']);
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/collections.api-spec.ts
+++ b/src/test/integration/api/collections.api-spec.ts
@@ -26,6 +26,5 @@ describe.skip("API Testing", () => {
     await checker.checkPagination();
     await checker.checkDetails();
     await checker.checkFilter(['type']);
-    await checker.checkAlternativeCount(['type']);
   });
 });

--- a/src/test/integration/api/nfts.api-spec.ts
+++ b/src/test/integration/api/nfts.api-spec.ts
@@ -24,6 +24,6 @@ describe("API Testing", () => {
     const checker = new ApiChecker('nfts', app.getHttpServer());
     checker.skipFields = ['message', 'statusCode'];
     await checker.checkStatus();
-    await checker.checkFilter(['collection', 'creator']);
+    await checker.checkFilter(['collection']);
   });
 });

--- a/src/test/integration/api/nfts.api-spec.ts
+++ b/src/test/integration/api/nfts.api-spec.ts
@@ -25,6 +25,5 @@ describe("API Testing", () => {
     checker.skipFields = ['message', 'statusCode'];
     await checker.checkStatus();
     await checker.checkFilter(['collection', 'creator']);
-    await checker.checkAlternativeCount(['type', 'collection']);
   });
 });

--- a/src/test/integration/api/nfts.api-spec.ts
+++ b/src/test/integration/api/nfts.api-spec.ts
@@ -25,5 +25,6 @@ describe("API Testing", () => {
     checker.skipFields = ['message', 'statusCode'];
     await checker.checkStatus();
     await checker.checkFilter(['collection']);
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/nodes.api-spec.ts
+++ b/src/test/integration/api/nodes.api-spec.ts
@@ -26,6 +26,5 @@ describe("API Testing", () => {
     await checker.checkPagination();
     await checker.checkDetails();
     await checker.checkFilter(['shard']);
-    await checker.checkAlternativeCount(['type', 'online']);
   });
 });

--- a/src/test/integration/api/rounds.api-spec.ts
+++ b/src/test/integration/api/rounds.api-spec.ts
@@ -24,5 +24,6 @@ describe("API Testing", () => {
     const checker = new ApiChecker('rounds', app.getHttpServer());
     await checker.checkStatus();
     await checker.checkFilter(['epoch', 'shard']);
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/rounds.api-spec.ts
+++ b/src/test/integration/api/rounds.api-spec.ts
@@ -24,6 +24,5 @@ describe("API Testing", () => {
     const checker = new ApiChecker('rounds', app.getHttpServer());
     await checker.checkStatus();
     await checker.checkFilter(['epoch', 'shard']);
-    await checker.checkAlternativeCount(['shard']);
   });
 });

--- a/src/test/integration/api/tokens.api-spec.ts
+++ b/src/test/integration/api/tokens.api-spec.ts
@@ -25,5 +25,6 @@ describe("API Testing", () => {
     await checker.checkStatus();
     await checker.checkPagination();
     await checker.checkTokensDetails();
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/api/tokens.api-spec.ts
+++ b/src/test/integration/api/tokens.api-spec.ts
@@ -25,6 +25,5 @@ describe("API Testing", () => {
     await checker.checkStatus();
     await checker.checkPagination();
     await checker.checkTokensDetails();
-    await checker.checkAlternativeCount(['identifier']);
   });
 });

--- a/src/test/integration/api/transactions.api-spec.ts
+++ b/src/test/integration/api/transactions.api-spec.ts
@@ -24,6 +24,5 @@ describe("API Testing", () => {
     const checker = new ApiChecker('transactions', app.getHttpServer());
     await checker.checkStatus();
     await checker.checkDetails();
-    await checker.checkAlternativeCount(['miniBlockHash']);
   });
 });

--- a/src/test/integration/api/transactions.api-spec.ts
+++ b/src/test/integration/api/transactions.api-spec.ts
@@ -24,5 +24,6 @@ describe("API Testing", () => {
     const checker = new ApiChecker('transactions', app.getHttpServer());
     await checker.checkStatus();
     await checker.checkDetails();
+    await checker.checkAlternativeCount();
   });
 });

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -224,4 +224,20 @@ describe('Transaction Service', () => {
       expect([sender, receiver].includes(transfer.receiver)).toBe(true);
     }
   });
+
+  it('should return an array of transactions and if withBlockInfo is set to true, block extra fields should be defined', async () => {
+    const transactions = await transactionService.getTransactions(
+      new TransactionFilter(),
+      new QueryPagination(),
+      new TransactionQueryOptions({ withBlockInfo: true }));
+
+    const extraFields = transactions.every(transaction =>
+      'senderBlockHash' in transaction &&
+      'senderBlockNonce' in transaction &&
+      'receiverBlockHash' in transaction &&
+      'receiverBlockNonce' in transaction
+    );
+
+    expect(extraFields).toBeTruthy();
+  });
 });

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -45,6 +45,17 @@ export class ApiChecker {
     expect(details).toEqual(item);
   }
 
+  async checkAlternativeCount(params: Record<string, any>) {
+    const count = await this.requestCount(params);
+    const alternativeCount = await this.requestAlternativeCount(params);
+
+    try {
+      expect(count).toStrictEqual(alternativeCount);
+    } catch (error) {
+      throw new Error(`Count value ${count} for '/count' is not equal with count value ${alternativeCount} of '/c' endpoint`);
+    }
+  }
+
   async checkFilter(criterias: string[]) {
     for (const criteria of criterias) {
       await this.checkFilterInternal(criteria);
@@ -146,6 +157,18 @@ export class ApiChecker {
 
     const { body: result } = await request(this.httpServer)
       .get(`/${this.endpoint}/count?${urlParams}`);
+
+    return result;
+  }
+
+  private async requestAlternativeCount(params: Record<string, any>): Promise<number> {
+    const urlParams = new URLSearchParams({
+      ...this.defaultParams,
+      ...params,
+    });
+
+    const { body: result } = await request(this.httpServer)
+      .get(`/${this.endpoint}/c?${urlParams}`);
 
     return result;
   }

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -45,7 +45,7 @@ export class ApiChecker {
     expect(details).toEqual(item);
   }
 
-  async checkAlternativeCount(params: Record<string, any>) {
+  async checkAlternativeCount(params: Record<string, any> = {}) {
     const count = await this.requestCount(params);
     const alternativeCount = await this.requestAlternativeCount(params);
 

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -21,17 +21,12 @@ export class ApiChecker {
 
   async checkDetails() {
     const [item] = await this.requestList({ size: 1 });
-
     const [idAttribute] = Object.keys(item);
     const id = item[idAttribute];
 
-    const [details, requestResult] = await Promise.all([
-      this.requestItem(id, { fields: Object.keys(item).join(',') }),
-      this.requestList({ size: 1 }),
-    ]);
+    const details = await this.requestItem(id, { fields: Object.keys(item).join(',') });
 
     expect(details).toEqual(item);
-    expect(requestResult).toEqual([item]);
   }
 
   async checkTokensDetails() {

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -46,19 +46,6 @@ export class ApiChecker {
     expect(details).toEqual(item);
   }
 
-  async checkAlternativeCount(fields: Record<string, any>) {
-    try {
-      const [count, alternativeCount] = await Promise.all([
-        this.requestCount(fields),
-        this.requestAlternativeCount(fields),
-      ]);
-
-      expect(count).toStrictEqual(alternativeCount);
-    } catch (error) {
-      throw new Error(`Count values are not equal`);
-    }
-  }
-
   async checkFilter(criterias: string[]) {
     const promises = criterias.map((criteria) => {
       return this.checkFilterInternal(criteria);
@@ -167,22 +154,12 @@ export class ApiChecker {
     return result;
   }
 
-  private async requestAlternativeCount(params: Record<string, any>): Promise<number> {
-    const urlParams = new URLSearchParams({
-      ...this.defaultParams,
-      ...params,
-    });
-
-    const { body: result } = await request(this.httpServer)
-      .get(`/${this.endpoint}/c?${urlParams}`);
-
-    return result;
-  }
-
   private async requestStatus(): Promise<number> {
     const result = await request(this.httpServer)
       .get(`/${this.endpoint}`);
 
     return result.statusCode;
   }
+
+
 }

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -25,9 +25,13 @@ export class ApiChecker {
     const [idAttribute] = Object.keys(item);
     const id = item[idAttribute];
 
-    const details = await this.requestItem(id, { fields: Object.keys(item).join(',') });
+    const [details, requestResult] = await Promise.all([
+      this.requestItem(id, { fields: Object.keys(item).join(',') }),
+      this.requestList({ size: 1 }),
+    ]);
 
     expect(details).toEqual(item);
+    expect(requestResult).toEqual([item]);
   }
 
   async checkTokensDetails() {

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -160,6 +160,4 @@ export class ApiChecker {
 
     return result.statusCode;
   }
-
-
 }

--- a/src/utils/api.checker.ts
+++ b/src/utils/api.checker.ts
@@ -12,17 +12,16 @@ export class ApiChecker {
   async checkPagination() {
     const items = await this.requestList({ size: 100 });
 
-    await Promise.all([
-      this.checkPaginationInternal(items, 0, 1),
-      this.checkPaginationInternal(items, 1, 5),
-      this.checkPaginationInternal(items, 5, 5),
-      this.checkPaginationInternal(items, 5, 10),
-      this.checkPaginationInternal(items, 10, 20),
-    ]);
+    await this.checkPaginationInternal(items, 0, 1);
+    await this.checkPaginationInternal(items, 1, 5);
+    await this.checkPaginationInternal(items, 5, 5);
+    await this.checkPaginationInternal(items, 5, 10);
+    await this.checkPaginationInternal(items, 10, 20);
   }
 
   async checkDetails() {
     const [item] = await this.requestList({ size: 1 });
+
     const [idAttribute] = Object.keys(item);
     const id = item[idAttribute];
 
@@ -47,25 +46,22 @@ export class ApiChecker {
   }
 
   async checkFilter(criterias: string[]) {
-    const promises = criterias.map((criteria) => {
-      return this.checkFilterInternal(criteria);
-    });
-
-    await Promise.all(promises);
+    for (const criteria of criterias) {
+      await this.checkFilterInternal(criteria);
+    }
   }
 
   async checkFilterInternal(criteria: string) {
     const items = await this.requestList({ size: 100, fields: criteria });
 
     const distinctCriteria = items.map(x => x[criteria]).distinct();
+
     const shuffled = distinctCriteria.sort(() => 0.5 - Math.random());
     const selected = shuffled.slice(0, 10);
 
-    const promises = selected.map((value) => {
-      return this.checkFilterValueInternal(criteria, value);
-    });
-
-    await Promise.all(promises);
+    for (const value of selected) {
+      await this.checkFilterValueInternal(criteria, value);
+    }
   }
 
   async checkStatus() {


### PR DESCRIPTION
## Reasoning
- Similar to /transfer?withBlockInfo = true/false, for consistency, the query option withBlockInfo must be added to return the fields with information from the block in transactions endpoint
  
## Proposed Changes
-  Add withBlockInfo query option in transaction service, 

## How to test ( Testnet )
- transactions?withBlockInfo=true&size=100 -> should throw 400 `Complexity 20000 exceeded`
- transactions?withBlockInfo=true -> senderBlockHash / senderBlockNonce / receiverBlockHash /receiverBlockNonce should be defined in transaction details

- tokens/BBB-3e120a/transactions?withBlockInfo=true -> senderBlockHash / senderBlockNonce / receiverBlockHash /receiverBlockNonce should be defined in transaction details
- tokens/BBB-3e120a/transactions?withBlockInfo=false -> block extra fields should not be defined

- accounts/erd17afegwvvm5wy0jggw8lzka6ser0qpav97rchjaj0am6fkp6lanssn99e0a/transactions?withBlockInfo=true -> senderBlockHash / senderBlockNonce / receiverBlockHash /receiverBlockNonce should be defined in transaction details
- accounts/erd17afegwvvm5wy0jggw8lzka6ser0qpav97rchjaj0am6fkp6lanssn99e0a/transactions?withBlockInfo=false -> block extra fields should not be defined
