### PR TITLE
add block info fields when withBlockInfo = false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
         "@multiversx/sdk-data-api-client": "^0.4.4",
-        "@multiversx/sdk-nestjs": "^0.4.14",
+        "@multiversx/sdk-nestjs": "^0.4.20",
         "@nestjs/apollo": "^10.1.3",
         "@nestjs/common": "^9.1.4",
         "@nestjs/config": "^2.2.0",
@@ -3503,9 +3503,9 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@multiversx/sdk-nestjs": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.14.tgz",
-      "integrity": "sha512-V55CZvmlMqc4nsEkiwdHyd41Cg9qDMsmfJt+lm/LpNFfr6S8k85If8ICdgKhsO+eSqsInGzcUy8Ic/sj9UQTlg==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.20.tgz",
+      "integrity": "sha512-vCM/ovNb1EBqVSPHDei6u9Yl1IbVtwKH9zpjZuPizmwCFPDxGAJLKHsKJdCIwMH4FURyE9p1qDrcmYV0b9hfQg==",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",
@@ -18396,9 +18396,9 @@
       }
     },
     "@multiversx/sdk-nestjs": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.14.tgz",
-      "integrity": "sha512-V55CZvmlMqc4nsEkiwdHyd41Cg9qDMsmfJt+lm/LpNFfr6S8k85If8ICdgKhsO+eSqsInGzcUy8Ic/sj9UQTlg==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.20.tgz",
+      "integrity": "sha512-vCM/ovNb1EBqVSPHDei6u9Yl1IbVtwKH9zpjZuPizmwCFPDxGAJLKHsKJdCIwMH4FURyE9p1qDrcmYV0b9hfQg==",
       "requires": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",
     "@multiversx/sdk-data-api-client": "^0.4.4",
-    "@multiversx/sdk-nestjs": "^0.4.14",
+    "@multiversx/sdk-nestjs": "^0.4.20",
     "@nestjs/apollo": "^10.1.3",
     "@nestjs/common": "^9.1.4",
     "@nestjs/config": "^2.2.0",

--- a/src/common/protocol/protocol.service.ts
+++ b/src/common/protocol/protocol.service.ts
@@ -20,15 +20,28 @@ export class ProtocolService {
 
   async getShardIds(): Promise<number[]> {
     return await this.cachingService.getOrSetCache(
-      CacheInfo.NumShards.key,
+      CacheInfo.ShardIds.key,
       async () => await this.getShardIdsRaw(),
-      CacheInfo.NumShards.ttl,
+      CacheInfo.ShardIds.ttl,
     );
   }
 
-  private async getShardIdsRaw(): Promise<number[]> {
+  async getShardCount(): Promise<number> {
+    return await this.cachingService.getOrSetCache(
+      CacheInfo.ShardCount.key,
+      async () => await this.getShardCountRaw(),
+      CacheInfo.ShardCount.ttl,
+    );
+  }
+
+  private async getShardCountRaw(): Promise<number> {
     const networkConfig = await this.gatewayService.getNetworkConfig();
     const shardCount = networkConfig.erd_num_shards_without_meta;
+    return shardCount;
+  }
+
+  private async getShardIdsRaw(): Promise<number[]> {
+    const shardCount = await this.getShardCountRaw();
 
     const result = [];
     for (let i = 0; i < shardCount; i++) {

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -664,6 +664,7 @@ export class AccountController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
@@ -688,7 +689,7 @@ export class AccountController {
       after,
       order,
       senderOrReceiver,
-    }), new QueryPagination({ from, size }), options, address);
+    }), new QueryPagination({ from, size }), options, address, fields);
   }
 
   @Get("/accounts/:address/transactions/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -753,6 +753,7 @@ export class AccountController {
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -772,6 +773,7 @@ export class AccountController {
     @Query('function') scFunction?: string,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
@@ -802,6 +804,7 @@ export class AccountController {
     }),
       new QueryPagination({ from, size }),
       options,
+      fields
     );
   }
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -189,7 +189,7 @@ export class NftService {
   }
 
   async applyAssetsAndTicker(token: Nft, fields?: string[]) {
-    if (fields && !fields.includes('assets') && !fields.includes('ticker')) {
+    if (fields && fields.includesNone(['ticker', 'assets'])) {
       return;
     }
 
@@ -238,7 +238,7 @@ export class NftService {
   }
 
   private async applyUnlockFields(nft: Nft, fields?: string[]): Promise<void> {
-    if (fields && (!fields.includes('unlockSchedule') && !fields.includes('unlockEpoch'))) {
+    if (fields && fields.includesNone(['unlockSchedule', 'unlockEpoch'])) {
       return;
     }
 
@@ -454,7 +454,7 @@ export class NftService {
 
     await this.batchProcessNfts(nfts, fields);
 
-    if (this.apiConfigService.isNftExtendedAttributesEnabled() && (!fields || fields.includes('score') || fields.includes('rank') || fields.includes('isNsfw'))) {
+    if (this.apiConfigService.isNftExtendedAttributesEnabled() && (!fields || fields.includesSome(['score', 'rank', 'isNsfw']))) {
       const internalNfts = await this.getNftsInternalByIdentifiers(nfts.map(x => x.identifier));
 
       const indexedInternalNfts = internalNfts.toRecord<Nft>(x => x.identifier);
@@ -492,7 +492,7 @@ export class NftService {
   }
 
   private async applyPriceUsd(nft: NftAccount, fields?: string[]) {
-    if (fields && !fields.includes('price') && !fields.includes('valueUsd')) {
+    if (fields && fields.includesNone(['price', 'valueUsd'])) {
       return;
     }
 

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -346,6 +346,7 @@ export class TokenController {
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -362,6 +363,7 @@ export class TokenController {
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
@@ -393,6 +395,7 @@ export class TokenController {
     }),
       new QueryPagination({ from, size }),
       options,
+      fields
     );
   }
 

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -217,6 +217,7 @@ export class TokenController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
@@ -244,7 +245,12 @@ export class TokenController {
       before,
       after,
       order,
-    }), new QueryPagination({ from, size }), options);
+    }),
+      new QueryPagination({ from, size }),
+      options,
+      undefined,
+      fields,
+    );
   }
 
   @Get("/tokens/:identifier/transactions/count")

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -60,13 +60,13 @@ export class TransactionController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
-
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 
@@ -87,6 +87,8 @@ export class TransactionController {
     }),
       new QueryPagination({ from, size }),
       options,
+      undefined,
+      fields,
     );
   }
 

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -93,7 +93,7 @@ export class TransactionGetService {
         }
       }
 
-      if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.logs) || fields.includes(TransactionOptionalFieldOption.operations)) {
+      if (!fields || fields.length === 0 || fields.includesSome([TransactionOptionalFieldOption.logs, TransactionOptionalFieldOption.operations])) {
         const logs = await this.getTransactionLogsFromElastic(hashes);
 
         if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.operations)) {

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -30,6 +30,7 @@ import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { UsernameService } from '../usernames/username.service';
 import { MiniBlock } from 'src/common/indexer/entities/miniblock';
 import { Block } from 'src/common/indexer/entities/block';
+import { ProtocolService } from 'src/common/protocol/protocol.service';
 
 @Injectable()
 export class TransactionService {
@@ -50,6 +51,7 @@ export class TransactionService {
     private readonly assetsService: AssetsService,
     private readonly apiConfigService: ApiConfigService,
     private readonly usernameService: UsernameService,
+    private readonly protocolService: ProtocolService,
   ) { }
 
   async getTransactionCountForAddress(address: string): Promise<number> {
@@ -276,8 +278,9 @@ export class TransactionService {
   }
 
   async createTransaction(transaction: TransactionCreate): Promise<TransactionSendResult | string> {
-    const receiverShard = AddressUtils.computeShard(AddressUtils.bech32Decode(transaction.receiver));
-    const senderShard = AddressUtils.computeShard(AddressUtils.bech32Decode(transaction.sender));
+    const shardCount = await this.protocolService.getShardCount();
+    const receiverShard = AddressUtils.computeShard(AddressUtils.bech32Decode(transaction.receiver), shardCount);
+    const senderShard = AddressUtils.computeShard(AddressUtils.bech32Decode(transaction.sender), shardCount);
 
     const pluginTransaction = await this.pluginsService.processTransactionSend(transaction);
     if (pluginTransaction) {

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -146,7 +146,7 @@ export class TransactionService {
     return result;
   }
 
-  async getTransactions(filter: TransactionFilter, pagination: QueryPagination, queryOptions?: TransactionQueryOptions, address?: string): Promise<Transaction[]> {
+  async getTransactions(filter: TransactionFilter, pagination: QueryPagination, queryOptions?: TransactionQueryOptions, address?: string, fields?: string[]): Promise<Transaction[]> {
     const elasticTransactions = await this.indexerService.getTransactions(filter, pagination, address);
 
     let transactions: TransactionDetailed[] = [];
@@ -165,7 +165,7 @@ export class TransactionService {
       }
     }
 
-    if (queryOptions && queryOptions.withBlockInfo) {
+    if ((queryOptions && queryOptions.withBlockInfo) || (fields && fields.includesSome(['senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce']))) {
       await this.applyBlockInfo(transactions);
     }
 

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -35,6 +35,7 @@ export class TransferController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -53,6 +54,7 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
@@ -75,6 +77,7 @@ export class TransferController {
     }),
       new QueryPagination({ from, size }),
       options,
+      fields
     );
   }
 

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -35,7 +35,6 @@ export class TransferController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
-  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -62,9 +62,7 @@ export class TransferService {
       transactions.push(transaction);
     }
 
-    if (queryOptions.withBlockInfo ||
-      (fields && ['senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce'].some(prop => fields.includes(prop)))
-    ) {
+    if (queryOptions.withBlockInfo || (fields && fields.includesSome(['senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce']))) {
       await this.transactionService.applyBlockInfo(transactions);
     }
 

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -42,13 +42,16 @@ export class TransferService {
     return elasticTransfers;
   }
 
-  async getTransfers(filter: TransactionFilter, pagination: QueryPagination, queryOptions: TransactionQueryOptions): Promise<Transaction[]> {
+  async getTransfers(filter: TransactionFilter, pagination: QueryPagination, queryOptions: TransactionQueryOptions, fields?: string[]): Promise<Transaction[]> {
     let elasticOperations = await this.indexerService.getTransfers(filter, pagination);
     elasticOperations = this.sortElasticTransfers(elasticOperations);
 
     const transactions: Transaction[] = [];
 
-    if (queryOptions.withBlockInfo) {
+    if (queryOptions.withBlockInfo ||
+      (fields && ['senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce']
+        .some(prop => fields.includes(prop)))) {
+
       const miniBlockHashes: string[] = [];
 
       for (const elasticOperation of elasticOperations) {

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -26,8 +26,13 @@ export class CacheInfo {
     ttl: Constants.oneHour(),
   };
 
-  static NumShards: CacheInfo = {
-    key: 'numShards',
+  static ShardIds: CacheInfo = {
+    key: 'shardIds',
+    ttl: Constants.oneWeek(),
+  };
+
+  static ShardCount: CacheInfo = {
+    key: 'shardCount',
     ttl: Constants.oneWeek(),
   };
 


### PR DESCRIPTION
## Reasoning
-  When fields 'senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce' are requested in transfers endpoint should be returned even if withBlockInfo is false
  
## Proposed Changes
- Add fields parameter to be able to return 'senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce' fields when withBlockInfo is false

## How to test
-  transfers?fields=txHash,senderBlockHash,receiverBlockHash,senderBlockNonce,receiverBlockNonce&size=50 -> should be returned 'senderBlockHash', 'receiverBlockHash', 'senderBlockNonce', 'receiverBlockNonce' 
- accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l/transfers?fields=senderBlockHash,senderBlockNonce,receiverBlockNonce,receiverBlockHash
- tokens/WEGLD-bd4d79/transfers?fields=senderBlockHash,senderBlockNonce,receiverBlockNonce,receiverBlockHash
