### PR TITLE
Update sdk nestjs to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
         "@multiversx/sdk-data-api-client": "^0.4.4",
-        "@multiversx/sdk-nestjs": "^0.4.21",
+        "@multiversx/sdk-nestjs": "^0.4.23",
         "@nestjs/apollo": "^10.1.3",
         "@nestjs/common": "^9.1.4",
         "@nestjs/config": "^2.2.0",
@@ -3503,9 +3503,9 @@
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@multiversx/sdk-nestjs": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.21.tgz",
-      "integrity": "sha512-Xad10dzuR1Cd+LlXZUyWvTv/Xry1ObHl+ueSoDgH8ASBDTPl/+pYyc9GISAWZNtd2qGmtS4f8TAb/cisW6bWoQ==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.23.tgz",
+      "integrity": "sha512-ALbocs0BcaAGftWUkCz3QlyVBNLyz2eMyOB3eeQnLunPnmSA/E/N9uZ34+JpBe73AmaUwFisRbdKOnPSPuNztw==",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",
@@ -18396,9 +18396,9 @@
       }
     },
     "@multiversx/sdk-nestjs": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.21.tgz",
-      "integrity": "sha512-Xad10dzuR1Cd+LlXZUyWvTv/Xry1ObHl+ueSoDgH8ASBDTPl/+pYyc9GISAWZNtd2qGmtS4f8TAb/cisW6bWoQ==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.4.23.tgz",
+      "integrity": "sha512-ALbocs0BcaAGftWUkCz3QlyVBNLyz2eMyOB3eeQnLunPnmSA/E/N9uZ34+JpBe73AmaUwFisRbdKOnPSPuNztw==",
       "requires": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",
     "@multiversx/sdk-data-api-client": "^0.4.4",
-    "@multiversx/sdk-nestjs": "^0.4.21",
+    "@multiversx/sdk-nestjs": "^0.4.23",
     "@nestjs/apollo": "^10.1.3",
     "@nestjs/common": "^9.1.4",
     "@nestjs/config": "^2.2.0",


### PR DESCRIPTION
## Proposed Changes
- Update SDK nestjs to latest version, that contains a fix for the `computeShard` function for a given address

## How to test
- when running connected to an observing squad that has different than 3 shards, the account returned shard should be the correct one
