### PR TITLE
Delegation shard

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -107,7 +107,6 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqp699jngundfqw07d8jzkepucvpzush6k3wvqyc44rx'
   metabonding: 'erd1qqqqqqqqqqqqqpgqkg7we73j769ew5we4yyx7uyvnn0nefqgd8ssm6vjc2'
-  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -107,6 +107,7 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqp699jngundfqw07d8jzkepucvpzush6k3wvqyc44rx'
   metabonding: 'erd1qqqqqqqqqqqqqpgqkg7we73j769ew5we4yyx7uyvnn0nefqgd8ssm6vjc2'
+  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -55,7 +55,6 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqxwakt2g7u9atsnr03gqcgmhcv38pt7mkd94q6shuwt'
   metabonding: 'erd1qqqqqqqqqqqqqpgq50dge6rrpcra4tp9hl57jl0893a4r2r72jpsk39rjj'
-  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -55,7 +55,6 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqxwakt2g7u9atsnr03gqcgmhcv38pt7mkd94q6shuwt'
   metabonding: 'erd1qqqqqqqqqqqqqpgq50dge6rrpcra4tp9hl57jl0893a4r2r72jpsk39rjj'
-  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -108,7 +108,6 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqxwakt2g7u9atsnr03gqcgmhcv38pt7mkd94q6shuwt'
   metabonding: 'erd1qqqqqqqqqqqqqpgq50dge6rrpcra4tp9hl57jl0893a4r2r72jpsk39rjj'
-  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -106,7 +106,6 @@ contracts:
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
   delegation: 'erd1qqqqqqqqqqqqqpgqp699jngundfqw07d8jzkepucvpzush6k3wvqyc44rx'
   metabonding: 'erd1qqqqqqqqqqqqqpgq2l9w0qv98htrhdwuz6ppsw47tn3hhff3d8ssqqjpvu'
-  delegationShardId: 2
 inflation:
   - 1952123
   - 1746637

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -143,17 +143,6 @@ export class ApiConfigService {
     return this.configService.get<string>('contracts.metabonding');
   }
 
-  getDelegationContractShardId(): number {
-    const shardId = this.configService.get<number>(
-      'contracts.delegationShardId',
-    );
-    if (!shardId) {
-      throw new Error('No delegation contract shard ID present');
-    }
-
-    return shardId;
-  }
-
   getDelegationManagerContractAddress(): string {
     const address = this.configService.get<string>(
       'contracts.delegationManager',

--- a/src/test/integration/services/api.config.e2e-spec.ts
+++ b/src/test/integration/services/api.config.e2e-spec.ts
@@ -267,25 +267,6 @@ describe('API Config', () => {
     });
   });
 
-  describe("getDelegationContractShardId", () => {
-    it("should return delegation contract shardId address", () => {
-      jest
-        .spyOn(ConfigService.prototype, "get")
-        .mockImplementation(jest.fn(() => '2'));
-
-      const results = apiConfigService.getDelegationContractShardId();
-      expect(results).toEqual('2');
-    });
-
-    it("should throw error because test simulates that delegation contract shardId is not defined", () => {
-      jest
-        .spyOn(ConfigService.prototype, 'get')
-        .mockImplementation(jest.fn(() => undefined));
-
-      expect(() => apiConfigService.getDelegationContractShardId()).toThrowError('No delegation contract shard ID present');
-    });
-  });
-
   describe("getDelegationManagerContractAddress", () => {
     it("should return delegation manager contract address", () => {
       jest


### PR DESCRIPTION
## Reasoning
- Delegation contract shard id can be computed instead of hardcoded in configs files
- Might not work if metachain id is not 4294967295, but it may be smarter to change the way shards are calculated inside mx-nestjs-sdk to take in account custom metachain id as optional parameter?
  
## Proposed Changes
- Compute the delegation contract shard id
