### PR TITLE
Update holder count for MetaESDTs

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -83,9 +83,12 @@ export class CollectionService {
   applyPropertiesToCollectionFromElasticSearch(nftCollection: NftCollection, indexedCollection: Collection) {
     nftCollection.type = indexedCollection.type as NftType;
     nftCollection.timestamp = indexedCollection.timestamp;
-    nftCollection.isVerified = indexedCollection.api_isVerified;
-    nftCollection.nftCount = indexedCollection.api_nftCount;
-    nftCollection.holderCount = indexedCollection.api_holderCount;
+
+    if (nftCollection.type.in(NftType.NonFungibleESDT, NftType.SemiFungibleESDT)) {
+      nftCollection.isVerified = indexedCollection.api_isVerified;
+      nftCollection.nftCount = indexedCollection.api_nftCount;
+      nftCollection.holderCount = indexedCollection.api_holderCount;
+    }
   }
 
   async applyPropertiesToCollections(collectionsIdentifiers: string[]): Promise<NftCollection[]> {

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -346,7 +346,7 @@ export class EsdtService {
     };
   }
 
-  async countAllAccounts(identifiers: string[]): Promise<number> {
+  async countAllDistinctAccounts(identifiers: string[]): Promise<number> {
     const key = `tokens:${identifiers[0]}:distinctAccounts:${randomUUID()}`;
 
     try {


### PR DESCRIPTION
## Reasoning
- MetaESDTs were returning through the `/collections/:collection` endpoint the holderCount which was linked to an attribute that is not updated any more
  
## Proposed Changes
- Provide `accounts` attribute in the `tokens` endpoint as the number of distinct accounts if the token type is MetaESDT
- do not return `isVerified`, `holderCount`, `nftCount` in case of MetaESDT type collections

## How to test (mainnet)
- `/tokens?includeMetaESDT=true&type=MetaESDT` and `/tokens/:token` endpoint should return `accounts` attribute for verified MetaESDTs (the ones that have assets set). The value should represent the number of distinct account holders as opposed to total account holders (even if an address has 2 or more MetaESDTs in the account, count it as 1)
- `/collections?type=MetaESDT` should not return `isVerified`, `holderCount`, `nftCount` attributes
