### PR TITLE
Fix WEGLD in mex tokens endpoint

### DIFF
--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -168,6 +168,16 @@ export class MexTokenService {
 
     const mexTokens: MexToken[] = [];
     for (const pair of filteredPairs) {
+      if (pair.baseSymbol === 'WEGLD' && pair.quoteSymbol === "USDC") {
+        const wegldToken = new MexToken();
+        wegldToken.id = pair.baseId;
+        wegldToken.symbol = pair.baseSymbol;
+        wegldToken.name = pair.baseName;
+        wegldToken.price = pair.basePrice;
+
+        mexTokens.push(wegldToken);
+      }
+
       const mexToken = this.getMexToken(pair);
       if (!mexToken) {
         continue;


### PR DESCRIPTION
## Proposed Changes
- add `WEGLD` ticker for the `WEGLDUSDC` pair in the token list

## How to test 
- `/mex/tokens` endpoint should return `WEGLD` as well
