### PR TITLE
Account token history by collection / nft

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -496,7 +496,7 @@ export class ElasticIndexerHelper {
     }
 
     if (token) {
-      mustQueries.push(QueryType.Match('token', token, QueryOperator.AND));
+      mustQueries.push(QueryType.Match('identifier', token, QueryOperator.AND));
     }
 
     let elasticQuery = ElasticQuery.create().withCondition(QueryConditionOptions.must, mustQueries);

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1047,7 +1047,7 @@ export class AccountController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<AccountEsdtHistory[]> {
-    const isToken = await this.tokenService.isToken(tokenIdentifier);
+    const isToken = await this.tokenService.isToken(tokenIdentifier) || await this.collectionService.isCollection(tokenIdentifier) || await this.nftService.isNft(tokenIdentifier);
     if (!isToken) {
       throw new NotFoundException(`Token '${tokenIdentifier}' not found`);
     }

--- a/src/endpoints/accounts/entities/account.esdt.history.ts
+++ b/src/endpoints/accounts/entities/account.esdt.history.ts
@@ -12,4 +12,8 @@ export class AccountEsdtHistory extends AccountHistory {
   @Field(() => String, { description: 'Token for the given history account details.' })
   @ApiProperty({ type: String, example: 'WEGLD-bd4d79' })
   token: string = '';
+
+  @Field(() => String, { description: 'Identifier for the given history account details.' })
+  @ApiProperty({ type: String, example: 'XPACHIEVE-5a0519-01' })
+  identifier: string | undefined = undefined;
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -282,7 +282,7 @@ export class NftService {
     nft.metadata = await this.nftMetadataService.getMetadata(nft) ?? undefined;
   }
 
-  private async isNft(identifier: string): Promise<boolean> {
+  async isNft(identifier: string): Promise<boolean> {
     if (identifier.split('-').length !== 3) {
       return false;
     }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -278,6 +278,9 @@ type AccountEsdtHistory {
   """Balance for the given account."""
   balance: String!
 
+  """Identifier for the given history account details."""
+  identifier: String!
+
   """IsSender for the given account."""
   isSender: Boolean
 


### PR DESCRIPTION
## Proposed Changes
- Possibility to supply a collection / nft identifier when fetching account token history

## How to test (mainnet)
- `/accounts/erd12q5mp3jgvseghllf8wd65dwxcdhuttxs8s7lte73n3prcn92tn7sxd76ul/history/XPACHIEVE-5a0519-01` should return elements
- `/accounts/erd12q5mp3jgvseghllf8wd65dwxcdhuttxs8s7lte73n3prcn92tn7sxd76ul/history/XPACHIEVE-5a0519` should return elements
