### PR TITLE
Search by proper field in accountsesdthistory index

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -496,7 +496,8 @@ export class ElasticIndexerHelper {
     }
 
     if (token) {
-      mustQueries.push(QueryType.Match('identifier', token, QueryOperator.AND));
+      const field = token.split('-').length === 2 ? 'token' : 'identifier';
+      mustQueries.push(QueryType.Match(field, token, QueryOperator.AND));
     }
 
     let elasticQuery = ElasticQuery.create().withCondition(QueryConditionOptions.must, mustQueries);


### PR DESCRIPTION
## Proposed Changes
- Search by `token` if 2 components, search by `identifier` if 3 components separated by `-`

## How to test
- `/accounts/erd1wp9wdsnck3pu7tmzk2l7q0xnmu9hr550ngrs852yvwa9kzdu9q0spmd7z9/history/XPACHIEVE-5a0519-01` should return data
- `/accounts/erd1wp9wdsnck3pu7tmzk2l7q0xnmu9hr550ngrs852yvwa9kzdu9q0spmd7z9/history/XPACHIEVE-5a0519` should return data
- `/accounts/erd1qqqqqqqqqqqqqpgqa0fsfshnff4n76jhcye6k7uvd7qacsq42jpsp6shh2/history/WEGLD-bd4d79` should return data
