### PR TITLE
 add account token history count

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -408,6 +408,18 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('accountsesdthistory', 'address', elasticQuery);
   }
 
+  async getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter);
+
+    return await this.elasticService.getCount('accountshistory', elasticQuery);
+  }
+
+  async getAccountTokenHistoryCount(address: string, tokenIdentifier: string, filter?: AccountHistoryFilter): Promise<number> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, tokenIdentifier, filter);
+
+    return await this.elasticService.getCount('accountsesdthistory', elasticQuery);
+  }
+
   async getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<any[]> {
     const sortOrder: ElasticSortOrder = !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
 

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -105,6 +105,10 @@ export interface IndexerInterface {
 
   getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]>
 
+  getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number>
+
+  getAccountTokenHistoryCount(address: string, tokenIdentifier: string, filter?: AccountHistoryFilter): Promise<number>
+
   getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
   getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -237,6 +237,16 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number> {
+    return await this.indexerInterface.getAccountHistoryCount(address, filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAccountTokenHistoryCount(address: string, tokenIdentifier: string, filter?: AccountHistoryFilter): Promise<number> {
+    return await this.indexerInterface.getAccountTokenHistoryCount(address, tokenIdentifier, filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]> {
     return await this.indexerInterface.getAccountTokenHistory(address, tokenIdentifier, pagination, filter);
   }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { SortOrder } from "src/common/entities/sort.order";
+import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
 import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
@@ -49,6 +50,14 @@ export class PostgresIndexerService implements IndexerInterface {
     private readonly validatorPublicKeysRepository: Repository<ValidatorPublicKeysDb>,
     private readonly indexerHelper: PostgresIndexerHelper,
   ) { }
+
+  getAccountHistoryCount(_address: string, _filter?: AccountHistoryFilter | undefined): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
+  getAccountTokenHistoryCount(_address: string, _tokenIdentifier: string, _filter?: AccountHistoryFilter | undefined): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
 
   getNftCollectionsByIds(_identifiers: string[]): Promise<Collection[]> {
     throw new Error("Method not implemented.");

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1052,12 +1052,16 @@ export class AccountController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiOkResponse({ type: Number })
-  getAccountTokenHistoryCount(
+  async getAccountTokenHistoryCount(
     @Param('address', ParseAddressPipe) address: string,
     @Param('tokenIdentifier', ParseTokenOrNftPipe) tokenIdentifier: string,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
+    const isToken = await this.tokenService.isToken(tokenIdentifier) || await this.collectionService.isCollection(tokenIdentifier) || await this.nftService.isNft(tokenIdentifier);
+    if (!isToken) {
+      throw new NotFoundException(`Token '${tokenIdentifier}' not found`);
+    }
     return this.accountService.getAccountTokenHistoryCount(
       address,
       tokenIdentifier,

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1032,6 +1032,38 @@ export class AccountController {
       new AccountHistoryFilter({ before, after }));
   }
 
+  @Get("/accounts/:address/history/count")
+  @ApiOperation({ summary: 'Account history count', description: 'Return account EGLD balance history count' })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiOkResponse({ type: Number })
+  getAccountHistoryCount(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+  ): Promise<number> {
+    return this.accountService.getAccountHistoryCount(
+      address,
+      new AccountHistoryFilter({ before, after }));
+  }
+
+  @Get("/accounts/:address/history/:tokenIdentifier/count")
+  @ApiOperation({ summary: 'Account token history count', description: 'Return account token balance history count' })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiOkResponse({ type: Number })
+  getAccountTokenHistoryCount(
+    @Param('address', ParseAddressPipe) address: string,
+    @Param('tokenIdentifier', ParseTokenOrNftPipe) tokenIdentifier: string,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+  ): Promise<number> {
+    return this.accountService.getAccountTokenHistoryCount(
+      address,
+      tokenIdentifier,
+      new AccountHistoryFilter({ before, after }));
+  }
+
   @Get("/accounts/:address/history/:tokenIdentifier")
   @ApiOperation({ summary: 'Account token history', description: 'Returns account token balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -30,7 +30,7 @@ import { AccountVerification } from './entities/account.verification';
 import { AccountFilter } from './entities/account.filter';
 import { AccountHistoryFilter } from './entities/account.history.filter';
 import { ProtocolService } from 'src/common/protocol/protocol.service';
-import {Address} from "@elrondnetwork/erdjs/out";
+import { Address } from "@elrondnetwork/erdjs/out";
 
 @Injectable()
 export class AccountService {
@@ -466,6 +466,14 @@ export class AccountService {
   async getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]> {
     const elasticResult = await this.indexerService.getAccountHistory(address, pagination, filter);
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountHistory(), item));
+  }
+
+  async getAccountHistoryCount(address: string, filter: AccountHistoryFilter): Promise<number> {
+    return await this.indexerService.getAccountHistoryCount(address, filter);
+  }
+
+  async getAccountTokenHistoryCount(address: string, tokenIdentifier: string, filter: AccountHistoryFilter): Promise<number> {
+    return await this.indexerService.getAccountTokenHistoryCount(address, tokenIdentifier, filter);
   }
 
   async getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountEsdtHistory[]> {


### PR DESCRIPTION
## Reasoning
- 
- 
- 
  
## Proposed Changes
- Add support for account token history count

## How to test ( DEVNET )
- accounts/erd19wkhfgs2glf97chl926fvwzgaq9eeakz474tzak6d998yu7xxtzqd3tng3/history/count -> should return~1034
- accounts/erd19wkhfgs2glf97chl926fvwzgaq9eeakz474tzak6d998yu7xxtzqd3tng3/history/count?after=1678893372 -> should return 2
- accounts/erd19wkhfgs2glf97chl926fvwzgaq9eeakz474tzak6d998yu7xxtzqd3tng3/history/VSWATCH-805ac3-0a/count -> should return 1
- accounts/erd19wkhfgs2glf97chl926fvwzgaq9eeakz474tzak6d998yu7xxtzqd3tng3/history/VSWATCH-805ac3/count -> return collection history count
