### PR TITLE
Improve ttl for extended attributes activation nonce

### DIFF
--- a/src/common/locked-asset/locked-asset.service.ts
+++ b/src/common/locked-asset/locked-asset.service.ts
@@ -60,8 +60,7 @@ export class LockedAssetService {
     return await this.cachingService.getOrSetCache(
       CacheInfo.ExtendedAttributesActivationNonce.key,
       async () => await this.getExtendedAttributesActivationNonceRaw(),
-      Constants.oneWeek(),
-      CacheInfo.ExtendedAttributesActivationNonce.ttl
+      CacheInfo.ExtendedAttributesActivationNonce.ttl,
     );
   }
 

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -337,8 +337,8 @@ export class CacheInfo {
   };
 
   static ExtendedAttributesActivationNonce: CacheInfo = {
-    key: "extendedAttributesActivationNonce",
-    ttl: Constants.oneDay(),
+    key: "extendedAttributesActivationNonce2",
+    ttl: Constants.oneHour(),
   };
 
   static InitEpoch: CacheInfo = {


### PR DESCRIPTION
## Proposed Changes
- Implement a more robust functionality for fetching the activation nonce in the cache

## How to test 
- Make sure ttl for `extendedAttributesActivationNonce2` in cache is less than 1h after setting
