### PR TITLE
support for provider avatar

### DIFF
--- a/src/endpoints/identities/identities.controller.ts
+++ b/src/endpoints/identities/identities.controller.ts
@@ -41,7 +41,7 @@ export class IdentitiesController {
   ): Promise<void> {
     const url = await this.identitiesService.getIdentityAvatar(identifier);
 
-    if (url === undefined) {
+    if (!url) {
       throw new HttpException('Identity avatar not found', HttpStatus.NOT_FOUND);
     }
     response.redirect(url);

--- a/src/endpoints/identities/identities.controller.ts
+++ b/src/endpoints/identities/identities.controller.ts
@@ -1,8 +1,9 @@
 import { ParseArrayPipe } from "@multiversx/sdk-nestjs";
-import { Controller, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
+import { Controller, Get, HttpException, HttpStatus, Param, Query, Res } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { Identity } from "./entities/identity";
 import { IdentitiesService } from "./identities.service";
+import { Response } from "express";
 
 @Controller()
 @ApiTags('identities')
@@ -28,7 +29,21 @@ export class IdentitiesController {
     if (identity === undefined) {
       throw new HttpException('Identity not found', HttpStatus.NOT_FOUND);
     }
-
     return identity;
+  }
+
+  @Get('/identities/:identifier/avatar')
+  @ApiOperation({ summary: 'Identity avatar', description: 'Returns the avatar of a specific identity' })
+  @ApiNotFoundResponse({ description: 'Identity not found' })
+  async getIdentityAvatar(
+    @Param('identifier') identifier: string,
+    @Res() response: Response
+  ): Promise<void> {
+    const url = await this.identitiesService.getIdentityAvatar(identifier);
+
+    if (url === undefined) {
+      throw new HttpException('Identity avatar not found', HttpStatus.NOT_FOUND);
+    }
+    response.redirect(url);
   }
 }

--- a/src/endpoints/identities/identities.service.ts
+++ b/src/endpoints/identities/identities.service.ts
@@ -31,6 +31,11 @@ export class IdentitiesService {
     return identities.find(x => x.identity === identifier);
   }
 
+  async getIdentityAvatar(identifier: string): Promise<string | undefined> {
+    const identity = await this.getIdentity(identifier);
+    return identity ? identity.avatar : undefined;
+  }
+
   async getIdentities(ids: string[]): Promise<Identity[]> {
     let identities = await this.getAllIdentities();
     if (ids.length > 0) {

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
+import { Controller, Get, HttpException, HttpStatus, Param, Query, Res } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { ProviderService } from "./provider.service";
 import { Provider } from "./entities/provider";
 import { ParseAddressArrayPipe, ParseAddressPipe } from "@multiversx/sdk-nestjs";
 import { ProviderFilter } from "./entities/provider.filter";
+import { Response } from "express";
 
 @Controller()
 @ApiTags('providers')
@@ -33,5 +34,20 @@ export class ProviderController {
     }
 
     return provider;
+  }
+
+  @Get('/providers/:address/avatar')
+  @ApiOperation({ summary: 'Provider avatar', description: 'Returns the avatar for a specific provider address' })
+  @ApiNotFoundResponse({ description: 'Provider avatar not found' })
+  async getIdentityAvatar(
+    @Param('address') address: string,
+    @Res() response: Response
+  ): Promise<void> {
+    const url = await this.providerService.getProviderAvatar(address);
+
+    if (url === undefined) {
+      throw new HttpException('Provider avatar not found', HttpStatus.NOT_FOUND);
+    }
+    response.redirect(url);
   }
 }

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -45,7 +45,7 @@ export class ProviderController {
   ): Promise<void> {
     const url = await this.providerService.getProviderAvatar(address);
 
-    if (url === undefined) {
+    if (!url) {
       throw new HttpException('Provider avatar not found', HttpStatus.NOT_FOUND);
     }
     response.redirect(url);

--- a/src/endpoints/providers/provider.module.ts
+++ b/src/endpoints/providers/provider.module.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Module } from "@nestjs/common";
 import { KeybaseModule } from "src/common/keybase/keybase.module";
+import { IdentitiesModule } from "../identities/identities.module";
 import { NodeModule } from "../nodes/node.module";
 import { VmQueryModule } from "../vm.query/vm.query.module";
 import { ProviderService } from "./provider.service";
@@ -9,6 +10,7 @@ import { ProviderService } from "./provider.service";
     forwardRef(() => KeybaseModule),
     forwardRef(() => NodeModule),
     VmQueryModule,
+    IdentitiesModule,
   ],
   providers: [
     ProviderService,

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -11,6 +11,7 @@ import { ProviderFilter } from "./entities/provider.filter";
 import { Provider } from "./entities/provider";
 import { AddressUtils, Constants, CachingService, ApiService } from "@multiversx/sdk-nestjs";
 import { OriginLogger } from "@multiversx/sdk-nestjs";
+import { IdentitiesService } from "../identities/identities.service";
 
 @Injectable()
 export class ProviderService {
@@ -25,6 +26,8 @@ export class ProviderService {
     private readonly apiService: ApiService,
     @Inject(forwardRef(() => KeybaseService))
     private readonly keybaseService: KeybaseService,
+    @Inject(forwardRef(() => IdentitiesService))
+    private readonly identitiesService: IdentitiesService
   ) { }
 
   async getProvider(address: string): Promise<Provider | undefined> {
@@ -49,6 +52,11 @@ export class ProviderService {
     }
 
     return provider;
+  }
+
+  async getProviderAvatar(address: string): Promise<string | undefined> {
+    const providerIdentity = await this.getProviderIdentity(address);
+    return providerIdentity ? this.identitiesService.getIdentityAvatar(providerIdentity) : undefined;
   }
 
   private getNodesInfosForProvider(providerNodes: any[]): NodesInfos {
@@ -393,5 +401,10 @@ export class ProviderService {
     }
 
     return providers;
+  }
+
+  private async getProviderIdentity(address: string): Promise<string | undefined> {
+    const providerDetails = await this.getProvider(address);
+    return providerDetails && providerDetails.identity ? providerDetails.identity : undefined;
   }
 }

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -9,7 +9,8 @@ import { AccountKey } from 'src/endpoints/accounts/entities/account.key';
 import { AccountEsdtHistory } from 'src/endpoints/accounts/entities/account.esdt.history';
 import { AccountFilter } from 'src/endpoints/accounts/entities/account.filter';
 import { AccountHistoryFilter } from 'src/endpoints/accounts/entities/account.history.filter';
-import { GuardianData } from 'src/common/gateway/entities/guardian.data';
+import { Guardian } from 'src/common/gateway/entities/guardian';
+import { GuardianResult } from 'src/common/gateway/entities/guardian.result';
 
 describe('Account Service', () => {
   let accountService: AccountService;
@@ -59,7 +60,7 @@ describe('Account Service', () => {
     });
   });
 
-  describe("getAccount", () => {
+  describe.only("getAccount", () => {
     it("should return null because test simulates that address is not valid ", async () => {
       const mock_isAddressValid = jest.spyOn(AddressUtils, 'isAddressValid');
       mock_isAddressValid.mockImplementation(() => false);
@@ -87,18 +88,20 @@ describe('Account Service', () => {
     it('should return account details with isGuarded = true and guardian data extra fields when isGuarded is true in codeAttributes', async () => {
       const address = 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx';
 
-      const mockGuardianData: GuardianData = {
-        activeGuardian: {
-          activationEpoch: 9,
-          address: 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx',
-          serviceUID: 'ServiceID',
+      const mockGuardianData: GuardianResult = {
+        guardianData: {
+          activeGuardian: new Guardian({
+            activationEpoch: 9,
+            address: 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx',
+            serviceUID: 'ServiceID',
+          }),
+          pendingGuardian: new Guardian({
+            activationEpoch: 13,
+            address: 'erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8',
+            serviceUID: 'serviceUID',
+          }),
+          guarded: true,
         },
-        pendingGuardian: {
-          activationEpoch: 13,
-          address: 'erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8',
-          serviceUID: 'serviceUID',
-        },
-        guarded: true,
       };
 
       const mock_decodeCodeMetadata = jest.spyOn(AddressUtils, 'decodeCodeMetadata');
@@ -113,7 +116,7 @@ describe('Account Service', () => {
       });
 
       jest.spyOn(accountService['gatewayService'], 'getGuardianData').mockResolvedValue(mockGuardianData);
-      const result = await accountService.getAccount(address);
+      const result = await accountService.getAccount(address, undefined, true);
 
       expect(result?.isGuarded).toStrictEqual(true);
       expect(result?.activeGuardianActivationEpoch).toStrictEqual(9);
@@ -126,10 +129,12 @@ describe('Account Service', () => {
 
     it('should return account details with isGuarded = false when isGuarded is false in codeAttributes', async () => {
       const address = 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx';
-      const mockGuardianData: GuardianData = {
-        activeGuardian: undefined,
-        pendingGuardian: undefined,
-        guarded: false,
+      const mockGuardianData: GuardianResult = {
+        guardianData: {
+          activeGuardian: undefined,
+          pendingGuardian: undefined,
+          guarded: false,
+        },
       };
 
       const mock_decodeCodeMetadata = jest.spyOn(AddressUtils, 'decodeCodeMetadata');
@@ -389,79 +394,6 @@ describe('Account Service', () => {
       const results = await accountService.getAccountTokenHistory(address, token, { from: 0, size: 1 }, new AccountHistoryFilter({}));
 
       expect(results).toStrictEqual([]);
-    });
-  });
-
-  describe('getAccountRaw', () => {
-    it('should return accountRaw details with isGuarded = true and guardian data extra fields when isGuarded is true in codeAttributes', async () => {
-      const address = 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx';
-
-      const mockGuardianData: GuardianData = {
-        activeGuardian: {
-          activationEpoch: 9,
-          address: 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx',
-          serviceUID: 'ServiceID',
-        },
-        pendingGuardian: {
-          activationEpoch: 13,
-          address: 'erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8',
-          serviceUID: 'serviceUID',
-        },
-        guarded: true,
-      };
-
-      const mock_decodeCodeMetadata = jest.spyOn(AddressUtils, 'decodeCodeMetadata');
-      mock_decodeCodeMetadata.mockImplementation((_codeMetadata: string) => {
-        return {
-          isUpgradeable: false,
-          isReadable: true,
-          isGuarded: true,
-          isPayable: false,
-          isPayableBySmartContract: false,
-        };
-      });
-
-      jest.spyOn(accountService['gatewayService'], 'getGuardianData').mockResolvedValue(mockGuardianData);
-      const result = await accountService.getAccountRaw(address);
-
-      expect(result?.isGuarded).toStrictEqual(true);
-      expect(result?.activeGuardianActivationEpoch).toStrictEqual(9);
-      expect(result?.activeGuardianAddress).toStrictEqual('erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx');
-      expect(result?.activeGuardianServiceUid).toStrictEqual('ServiceID');
-      expect(result?.pendingGuardianActivationEpoch).toStrictEqual(13);
-      expect(result?.pendingGuardianAddress).toStrictEqual('erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8');
-      expect(result?.pendingGuardianServiceUid).toStrictEqual('serviceUID');
-    });
-
-    it('should return accountRaw details with isGuarded = false when isGuarded is false in codeAttributes', async () => {
-      const address = 'erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx';
-      const mockGuardianData: GuardianData = {
-        activeGuardian: undefined,
-        pendingGuardian: undefined,
-        guarded: false,
-      };
-
-      const mock_decodeCodeMetadata = jest.spyOn(AddressUtils, 'decodeCodeMetadata');
-      mock_decodeCodeMetadata.mockImplementation((_codeMetadata: string) => {
-        return {
-          isUpgradeable: false,
-          isReadable: true,
-          isGuarded: false,
-          isPayable: false,
-          isPayableBySmartContract: false,
-        };
-      });
-
-      jest.spyOn(accountService['gatewayService'], 'getGuardianData').mockResolvedValue(mockGuardianData);
-      const result = await accountService.getAccountRaw(address);
-
-      expect(result?.isGuarded).toStrictEqual(false);
-      expect(result?.activeGuardianActivationEpoch).toBeUndefined();
-      expect(result?.activeGuardianAddress).toBeUndefined();
-      expect(result?.activeGuardianServiceUid).toBeUndefined();
-      expect(result?.pendingGuardianActivationEpoch).toBeUndefined();
-      expect(result?.pendingGuardianAddress).toBeUndefined();
-      expect(result?.pendingGuardianServiceUid).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Reasoning
- Adding a GET endpoint to expose the functionality to return the avatar for an specified identity.
  
## Proposed Changes
### Identity
-  Add a new method `getIdentityAvatar`  that only returns the avatar URL for a specified identity.
-  Utilize the existing `getIdentity(identifier)`  method to find the identity based on the provided identifier.
-  Implement a new GET endpoint ` /identities/:identifier/avatar ` that returns the avatar for a specified identity.

### Provider
- Add a new method `getProviderAvatar` that only return the avatar URL for a specific provider else, return undefined
-  Implement a new GET endpoint ` /providers/:address/avatar ` that returns the avatar for a specified provider

## How to test ( TESTNET )
#### Query Parameters: N/A
-  GET identities/middlestakingfr/avatar
- GET providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrlllllsyprnh6/avatar

### Response:
- 200 OK: Returns the avatar for a specified identity.
- 404 Not Found: If the requested identity avatar is not found.
