### PR TITLE
Changed cache key for identity profile

### DIFF
--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -92,7 +92,7 @@ export class CacheInfo {
 
   static IdentityProfile(key: string): CacheInfo {
     return {
-      key: `identityProfile:${key}`,
+      key: `identityProfile_v2:${key}`,
       ttl: Constants.oneMonth() * 6,
     };
   }


### PR DESCRIPTION
## Proposed Changes
- changed name for cache key for identity profiles, since some of them were not stored correctly

## How to test (mainnet)
- check that all identity profiles are correctly re-fetched
