### PR TITLE
update swagger account endpoint

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -112,7 +112,7 @@ export class AccountController {
 
   @Get("/accounts/:address")
   @ApiOperation({ summary: 'Account details', description: 'Returns account details for a given address' })
-  @ApiQuery({ name: 'withGuardianInfo', description: 'Return guardian data for a given address', required: false })
+  @ApiQuery({ name: 'withGuardianInfo', description: 'Returns guardian data for a given address', required: false })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiOkResponse({ type: AccountDetailed })
   async getAccountDetails(

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -112,6 +112,8 @@ export class AccountController {
 
   @Get("/accounts/:address")
   @ApiOperation({ summary: 'Account details', description: 'Returns account details for a given address' })
+  @ApiQuery({ name: 'withGuardianInfo', description: 'Return guardian data for a given address', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiOkResponse({ type: AccountDetailed })
   async getAccountDetails(
     @Param('address', ParseAddressPipe) address: string,


### PR DESCRIPTION
## Reasoning
- On swagger, `withGuardianInfo` and `fields` was required.
  
## Proposed Changes
- Add `@ApiQuery` to each field + specific description.

GET accounts/:address?withGuardianInfo=true&fields=isGuarded.

![image](https://user-images.githubusercontent.com/52102171/229856539-15a7a4cc-d085-4a4e-87df-089121b5f8d3.png)

## How to test
- Check swagger docs on accounts tag and check if `withGuardianInfo` and `fields` params are not longer required.
