### PR TITLE
add support for function filter on tokens transfers route

### DIFF
--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -351,6 +351,7 @@ export class TokenController {
   @ApiQuery({ name: 'miniBlockHash', description: 'Filter by miniblock hash', required: false })
   @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of transfer hashes', required: false })
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
+  @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
@@ -369,6 +370,7 @@ export class TokenController {
     @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
     @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
+    @Query('function', ParseArrayPipe) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('fields', ParseArrayPipe) fields?: string[],
@@ -392,6 +394,7 @@ export class TokenController {
       sender,
       receivers: receiver,
       token: identifier,
+      functions,
       senderShard,
       receiverShard,
       miniBlockHash,


### PR DESCRIPTION
## Reasoning
-  On `tokens/:identifier/transfers`, function filter was missing
  
## Proposed Changes
### Tokens Controller
- Update` getTokenTransfers `method to accept `functions` filter
- Update swagger docs

### Endpoint
GET tokens/:identifier/transfers?function=[" "]
## How to test
- GET `tokens/WEGLD-bd4d79/transfers?function=swapTokensFixedInput` -> should return 25 transfers with function = swapTokensFixedInput
- GET `tokens/WEGLD-bd4d79/transfers?function=invalidFunction` -> should return [ ] 
