### PR TITLE
Case insensitive search for collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
         "@multiversx/sdk-data-api-client": "^0.4.4",
-        "@multiversx/sdk-nestjs": "^0.5.1",
+        "@multiversx/sdk-nestjs": "^0.5.2",
         "@nestjs/apollo": "^10.1.3",
         "@nestjs/common": "^9.1.4",
         "@nestjs/config": "^2.2.0",
@@ -3519,9 +3519,9 @@
       }
     },
     "node_modules/@multiversx/sdk-nestjs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.5.1.tgz",
-      "integrity": "sha512-G5p58WnPRG429KP/Z+bpaQQ0U88SiQM/mxL8bSZHYzXDJKoP4wTehFu3HsQiFoJ6oCVA8wV17sz1Ui84ykWG7w==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.5.2.tgz",
+      "integrity": "sha512-7CbpAu00pMAeYBk2q35FoAfOrLbh/mxT5AB5vWJ+V8RDwJg0rFjpL7wER0D+n3u2bQN+sg9NORtSU2nafsxSuQ==",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",
@@ -18224,9 +18224,9 @@
       }
     },
     "@multiversx/sdk-nestjs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.5.1.tgz",
-      "integrity": "sha512-G5p58WnPRG429KP/Z+bpaQQ0U88SiQM/mxL8bSZHYzXDJKoP4wTehFu3HsQiFoJ6oCVA8wV17sz1Ui84ykWG7w==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-nestjs/-/sdk-nestjs-0.5.2.tgz",
+      "integrity": "sha512-7CbpAu00pMAeYBk2q35FoAfOrLbh/mxT5AB5vWJ+V8RDwJg0rFjpL7wER0D+n3u2bQN+sg9NORtSU2nafsxSuQ==",
       "requires": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",
     "@multiversx/sdk-data-api-client": "^0.4.4",
-    "@multiversx/sdk-nestjs": "^0.5.1",
+    "@multiversx/sdk-nestjs": "^0.5.2",
     "@nestjs/apollo": "^10.1.3",
     "@nestjs/common": "^9.1.4",
     "@nestjs/config": "^2.2.0",

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -118,9 +118,15 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMultiShouldCondition([NftType.NonFungibleESDT, NftType.SemiFungibleESDT], type => QueryType.Match('type', type));
     }
 
+    if (filter.search) {
+      elasticQuery = elasticQuery.withShouldCondition([
+        QueryType.Term('token', filter.search, true),
+        QueryType.Term('name', filter.search, true),
+      ]);
+    }
+
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
-      .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
   }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -118,15 +118,9 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMultiShouldCondition([NftType.NonFungibleESDT, NftType.SemiFungibleESDT], type => QueryType.Match('type', type));
     }
 
-    if (filter.search) {
-      elasticQuery = elasticQuery.withShouldCondition([
-        QueryType.Term('token', filter.search, true),
-        QueryType.Term('name', filter.search, true),
-      ]);
-    }
-
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
+      .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
   }


### PR DESCRIPTION
## Reasoning
- When searching by collections with wildcard, such as xmex, because of the latest elasticsearch index changes, no more results are returned
  
## Proposed Changes
- use an updated version of sdk-nestjs which supports out-of-the-box case insensitive wildcard searches

## How to test (mainnet)
- `/collection?search=xmex` should return results
- `accounts/erd1ff377y7qdldtsahvt28ec45zkyu0pepuup33adhr8wr2yuelwv7qpevs9e/collections?search=WEG` -> should return results
-`accounts/erd1ff377y7qdldtsahvt28ec45zkyu0pepuup33adhr8wr2yuelwv7qpevs9e/collections?search=WEG` -> should return [ ]
- `accounts/erd1n5sfjwyqstmvykhcppcsvwx96m9ladwsxsv6h248mpznwd6g590q2837gh/tokens?search=FOO` -> should return results
- `accounts/erd1n5sfjwyqstmvykhcppcsvwx96m9ladwsxsv6h248mpznwd6g590q2837gh/tokens?search=TESTS` -> should return [ ]
