### PR TITLE
support for guardian data in transaction details

### DIFF
--- a/src/common/gateway/entities/transaction.ts
+++ b/src/common/gateway/entities/transaction.ts
@@ -36,6 +36,8 @@ export class Transaction {
   miniblockHash: string = '';
   hyperblockNonce: number = 0;
   timestamp: number = 0;
+  guardian: string = '';
+  guardianSignature: string = '';
   logs: TransactionLog | undefined = undefined;
   receipt: TransactionReceipt | undefined = undefined;
   smartContractResults: GatewaySmartContractResults[] | undefined = undefined;

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -118,6 +118,14 @@ export class Transaction {
   @ApiProperty({ type: Boolean, nullable: true })
   pendingResults: boolean | undefined = undefined;
 
+  @Field(() => String, { description: "Guardian address for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  guardianAddress: string | undefined = undefined;
+
+  @Field(() => String, { description: "Guardian signature for the given transaction.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  guardianSignature: string | undefined = undefined;
+
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -190,6 +190,8 @@ export class TransactionGetService {
         scResults: transaction.smartContractResults ? transaction.smartContractResults.map((scResult: any) => ApiUtils.mergeObjects(new SmartContractResult(), scResult)) : [],
         receipt: transaction.receipt ? ApiUtils.mergeObjects(new TransactionReceipt(), transaction.receipt) : undefined,
         logs: transaction.logs,
+        guardianAddress: transaction.guardian,
+        guardianSignature: transaction.guardianSignature,
       };
 
       return ApiUtils.mergeObjects(new TransactionDetailed(), result);


### PR DESCRIPTION
## Reasoning
- New fields was added in gateway transaction response body.

`guardian`
 `guardianSignature`
  
## Proposed Changes
### Transaction Service
- in tryGetTransactionFromGateway method return the guardian data extra fields

## Endpoint
- /transactions/:txHash

## How to test
- GET transactions/b8b3ed9f888c75264a0fced5d7531bd737ec7afb903984ce2964092457f20b08 -> `guardianAddress` and `guardianSignature` are defined
