### PR TITLE
Elasticsearch fallback when trie timeout

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -19,6 +19,8 @@ import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { AddressUtils, ApiUtils, BinaryUtils, ElrondCachingService, MetricsService } from "@multiversx/sdk-nestjs";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { OriginLogger } from "@multiversx/sdk-nestjs";
+import { TrieOperationsTimeoutError } from "./exceptions/trie.operations.timeout.error";
+import { CacheInfo } from "src/utils/cache.info";
 
 @Injectable()
 export class EsdtAddressService {
@@ -42,14 +44,14 @@ export class EsdtAddressService {
 
   async getNftsForAddress(address: string, filter: NftFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftAccount[]> {
     if (filter.identifiers && filter.identifiers.length === 1) {
-      return await this.getNftsForAddressFromGateway(address, filter, pagination);
+      return await this.getNftsForAddressFromGatewayWithElasticFallback(address, filter, pagination);
     }
 
     if (source === EsdtDataSource.elastic || AddressUtils.isSmartContractAddress(address)) {
       return await this.getNftsForAddressFromElastic(address, filter, pagination);
     }
 
-    return await this.getNftsForAddressFromGateway(address, filter, pagination);
+    return await this.getNftsForAddressFromGatewayWithElasticFallback(address, filter, pagination);
   }
 
   async getNftCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
@@ -193,6 +195,24 @@ export class EsdtAddressService {
     }
   }
 
+  private async getNftsForAddressFromGatewayWithElasticFallback(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
+    const isTrieTimeout = await this.cachingService.get<boolean>(CacheInfo.AddressEsdtTrieTimeout(address).key);
+    if (isTrieTimeout) {
+      return await this.getNftsForAddressFromElastic(address, filter, pagination);
+    }
+
+    try {
+      return await this.getNftsForAddressFromGateway(address, filter, pagination);
+    } catch (error) {
+      if (error instanceof TrieOperationsTimeoutError) {
+        await this.cachingService.set(CacheInfo.AddressEsdtTrieTimeout(address).key, true, CacheInfo.AddressEsdtTrieTimeout(address).ttl);
+        return await this.getNftsForAddressFromElastic(address, filter, pagination);
+      }
+
+      throw error;
+    }
+  }
+
   private async getNftsForAddressFromGateway(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
     let esdts: Record<string, any> = {};
 
@@ -296,9 +316,17 @@ export class EsdtAddressService {
     // eslint-disable-next-line require-await
     const esdtResult = await this.gatewayService.get(`address/${address}/esdt`, GatewayComponentRequest.addressEsdt, async (error) => {
       const errorMessage = error?.response?.data?.error;
-      if (errorMessage && errorMessage.includes('account was not found')) {
-        return true;
+      if (errorMessage) {
+        if (errorMessage.includes('account was not found')) {
+          return true;
+        }
+
+        if (errorMessage.includes('trie operations timeout')) {
+          throw new TrieOperationsTimeoutError();
+        }
       }
+
+
 
       return false;
     });

--- a/src/endpoints/esdt/exceptions/trie.operations.timeout.error.ts
+++ b/src/endpoints/esdt/exceptions/trie.operations.timeout.error.ts
@@ -1,0 +1,7 @@
+export class TrieOperationsTimeoutError extends Error {
+  constructor() {
+    super('Trie operations timeout');
+
+    Object.setPrototypeOf(this, TrieOperationsTimeoutError.prototype);
+  }
+}

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -34,6 +34,7 @@ import { NftType } from "../nfts/entities/nft.type";
 import { TokenType } from "src/common/indexer/entities";
 import { TokenAssetsPriceSourceType } from "src/common/assets/entities/token.assets.price.source.type";
 import { DataApiService } from "src/common/data-api/data-api.service";
+import { TrieOperationsTimeoutError } from "../esdt/exceptions/trie.operations.timeout.error";
 
 @Injectable()
 export class TokenService {
@@ -213,7 +214,7 @@ export class TokenService {
     if (AddressUtils.isSmartContractAddress(address)) {
       tokens = await this.getTokensForAddressFromElastic(address, queryPagination, filter);
     } else {
-      tokens = await this.getTokensForAddressFromGateway(address, queryPagination, filter);
+      tokens = await this.getTokensForAddressFromGatewayWithElasticFallback(address, queryPagination, filter);
     }
 
     for (const token of tokens) {
@@ -257,6 +258,24 @@ export class TokenService {
   applyValueUsd(tokenWithBalance: TokenWithBalance) {
     if (tokenWithBalance.price) {
       tokenWithBalance.valueUsd = tokenWithBalance.price * NumberUtils.denominateString(tokenWithBalance.balance, tokenWithBalance.decimals);
+    }
+  }
+
+  async getTokensForAddressFromGatewayWithElasticFallback(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
+    const isTrieTimeout = await this.cachingService.get<boolean>(CacheInfo.AddressEsdtTrieTimeout(address).key);
+    if (isTrieTimeout) {
+      return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
+    }
+
+    try {
+      return await this.getTokensForAddressFromGateway(address, queryPagination, filter);
+    } catch (error) {
+      if (error instanceof TrieOperationsTimeoutError) {
+        await this.cachingService.set(CacheInfo.AddressEsdtTrieTimeout(address).key, true, CacheInfo.AddressEsdtTrieTimeout(address).ttl);
+        return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
+      }
+
+      throw error;
     }
   }
 

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -51,6 +51,7 @@ describe('Token Service', () => {
           useValue:
           {
             getOrSet: jest.fn(),
+            get: jest.fn(),
           },
         },
         {

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -556,6 +556,13 @@ export class CacheInfo {
     ttl: Constants.oneMinute() * 10,
   };
 
+  static AddressEsdtTrieTimeout(address: string): CacheInfo {
+    return {
+      key: `addressEsdtTrieTimeout:${address}`,
+      ttl: Constants.oneHour(),
+    };
+  }
+
   static DataApiTokenPrice(identifier: string, timestamp?: number): CacheInfo {
     const priceDate = timestamp ? new Date(timestamp * 1000) : new Date();
     const isCurrentDate = priceDate.toISODateString() === new Date().toISODateString();


### PR DESCRIPTION
## Reasoning
- For certain accounts that have a lot of esdts, the address esdt route from the gateway might throw trie timeout error, and thus not allowing data to be returned, although it is available in the Elasticsearch
  
## Proposed Changes
- Handle the trie timeout error specifically to determine whether to fetch data from Elasticsearch also for user accounts (not just for smart contracts)

## How to test (devnet)
- `/accounts/erd1a2g46tj6lxjf0fhy760awqej4g5040kcfcuzjkfqx7g8fydr03as92g0q2/tokens` should return data after 10s the first time, near instant each subsequent time
- `/accounts/erd1a2g46tj6lxjf0fhy760awqej4g5040kcfcuzjkfqx7g8fydr03as92g0q2/nfts` should return data after 10s the first time, near instant each subsequent time
