### PR TITLE
Trim url when generating thumbnail

### DIFF
--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -153,7 +153,7 @@ export class NftQueueController {
   private async generateThumbnail(nft: Nft, media: NftMedia, forceRefresh: boolean = false): Promise<void> {
     let result: GenerateThumbnailResult;
     try {
-      result = await this.nftThumbnailService.generateThumbnail(nft, media.url, media.fileType, forceRefresh);
+      result = await this.nftThumbnailService.generateThumbnail(nft, media.url.trim(), media.fileType, forceRefresh);
     } catch (error) {
       this.logger.error(`An unhandled exception occurred when generating thumbnail for nft with identifier '${nft.identifier}' and url '${media.url}'`);
       this.logger.error(error);


### PR DESCRIPTION
## Proposed Changes
- Take into account that urls can contain spaces at the beginning and/or at the end of the url

## How to test (mainnet)
- force refresh thumbnail for `TAVERN-e9b9d6-01` then check that it actually works
