### PR TITLE
support for egld token filter in transfers endpoint

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -268,8 +268,10 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Should(queries));
     }
 
-    if (filter.token) {
-      elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('tokens', filter.token, QueryOperator.AND));
+    if (filter.token === 'EGLD') {
+      elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('value', '0'));
+    } else {
+      elasticQuery = elasticQuery.withMustMatchCondition('tokens', filter.token, QueryOperator.AND);
     }
 
     if (filter.functions && filter.functions.length > 0 && this.apiConfigService.getIsIndexerV3FlagActive()) {


### PR DESCRIPTION
## Reasoning
- Adding elastic query support to return details of transfers for EGLD.
  
## Proposed Changes
- In `buildTransferFilterQuery` for `filter.token` add the possibility to filter by EGLD.

###  Endpoints
- GET accounts/:address/transfers?token=EGLD
- GET transfers?token=EGLD
- GET transfers/count?token=EGLD

## How to test  ( Mainnet )
-  `transfers?token=EGLD`
-  `transfers/count?token=EGLD`
- `accounts/erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz/transfers?token=EGLD`
