### PR TITLE
Owner invalidation in case of makeNewContractFromValidatorData function

### DIFF
--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -99,7 +99,7 @@ export class TransactionProcessorService {
 
   async tryInvalidateOwner(transaction: ShardTransaction): Promise<string[]> {
     const transactionFuncName = transaction.getDataFunctionName();
-    if (transactionFuncName !== 'mergeValidatorToDelegationWithWhitelist') {
+    if (transactionFuncName !== 'mergeValidatorToDelegationWithWhitelist' && transactionFuncName !== 'makeNewContractFromValidatorData') {
       return [];
     }
 

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -125,7 +125,7 @@ export class CacheInfo {
 
   static OwnerByEpochAndBls(epoch: number, bls: string): CacheInfo {
     return {
-      key: `owner:${epoch}:${bls}`,
+      key: `nodeOwner:${epoch}:${bls}`,
       ttl: Constants.oneDay(),
     };
   }


### PR DESCRIPTION
## Proposed Changes
- Support for `makeNewContractFromValidatorData` for invalidating node owner
- change cache key for owner for instant invalidation

## How to test (mainnet)
- use `makeNewContractFromValidatorData` function call to change owner, make sure the owner is reflected in the `/nodes` endpoint
