### PR TITLE
add support for miniblock type filter

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -344,6 +344,10 @@ export class ElasticIndexerService implements IndexerInterface {
       query = query.withShouldCondition(filter.hashes.map(hash => QueryType.Match('_id', hash)));
     }
 
+    if (filter.type) {
+      query = query.withCondition(QueryConditionOptions.must, [QueryType.Match("type", filter.type)]);
+    }
+
     return await this.elasticService.getList('miniblocks', 'miniBlockHash', query);
   }
 

--- a/src/endpoints/miniblocks/entities/mini.block.filter.ts
+++ b/src/endpoints/miniblocks/entities/mini.block.filter.ts
@@ -1,7 +1,10 @@
+import { MiniBlockType } from "./mini.block.type";
 
 export class MiniBlockFilter {
   constructor(init?: Partial<MiniBlockFilter>) {
     Object.assign(this, init);
   }
+
   hashes?: string[];
+  type?: MiniBlockType;
 }

--- a/src/endpoints/miniblocks/entities/mini.block.type.ts
+++ b/src/endpoints/miniblocks/entities/mini.block.type.ts
@@ -1,0 +1,19 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum MiniBlockType {
+  SmartContractResultBlock = 'SmartContractResultBlock',
+  TxBlock = 'TxBlock',
+}
+
+registerEnumType(MiniBlockType, {
+  name: 'MiniBlockType',
+  description: 'MiniBlock Type object.',
+  valuesMap: {
+    SmartContractResultBlock: {
+      description: 'SmartContractResultBlock.',
+    },
+    TxBlock: {
+      description: 'TxBlock.',
+    },
+  },
+});

--- a/src/endpoints/miniblocks/mini.block.controller.ts
+++ b/src/endpoints/miniblocks/mini.block.controller.ts
@@ -5,6 +5,8 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { MiniBlockDetailed } from "./entities/mini.block.detailed";
 import { MiniBlockFilter } from "./entities/mini.block.filter";
 import { MiniBlockService } from "./mini.block.service";
+import { ParseEnumPipe } from "@multiversx/sdk-nestjs/lib/src/pipes/parse.enum.pipe";
+import { MiniBlockType } from "./entities/mini.block.type";
 
 @Controller()
 @ApiTags('miniblocks')
@@ -17,12 +19,14 @@ export class MiniBlockController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of miniblocks hashes', required: false })
+  @ApiQuery({ name: 'type', description: 'Sorting criteria by type', required: false, enum: MiniBlockType })
   async getMiniBlocks(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('hashes', ParseArrayPipe) hashes?: string[],
+    @Query('type', new ParseEnumPipe(MiniBlockType)) type?: MiniBlockType,
   ): Promise<MiniBlockDetailed[]> {
-    return await this.miniBlockService.getMiniBlocks(new QueryPagination({ from, size }), new MiniBlockFilter({ hashes }));
+    return await this.miniBlockService.getMiniBlocks(new QueryPagination({ from, size }), new MiniBlockFilter({ hashes, type }));
   }
 
   @Get("/miniblocks/:miniBlockHash")


### PR DESCRIPTION
## Reasoning
-  To be able to return miniblocks of a specific type, we need to add a new filter ( MiniBlockType )
  
## Proposed Changes
- Create new MiniBlockType enum where we have two values: `SmartContractResultBlock` and `TxBlock`
- Add in getMiniBlocks method from elastic service new condition to filter by type.
- Add in miniblocks.controller new query
- Update swagger docs

## How to test
### SmartContractResultBlock
- miniblocks?type=SmartContractResultBlock -> return 25 miniblocks of type `SmartContractResultBlock`

### TxBlock
- miniblocks?type=TxBlock -> return 25 miniblocks of type `TxBlock`
