### PR TITLE
Expose Websocket port only on public api instances

### DIFF
--- a/src/common/pubsub/pub.sub.listener.controller.ts
+++ b/src/common/pubsub/pub.sub.listener.controller.ts
@@ -1,9 +1,7 @@
 import { OriginLogger } from "@multiversx/sdk-nestjs";
 import { ElrondCachingService } from "@multiversx/sdk-nestjs";
-import { ShardTransaction } from "@elrondnetwork/transaction-processor";
 import { Controller } from "@nestjs/common";
 import { EventPattern } from "@nestjs/microservices";
-import { WebSocketPublisherService } from "src/common/websockets/web-socket-publisher-service";
 
 @Controller()
 export class PubSubListenerController {
@@ -11,7 +9,6 @@ export class PubSubListenerController {
 
   constructor(
     private readonly cachingService: ElrondCachingService,
-    private readonly webSocketPublisherService: WebSocketPublisherService,
   ) { }
 
   @EventPattern('deleteCacheKeys')
@@ -26,25 +23,5 @@ export class PubSubListenerController {
   async refreshCacheKey(info: { key: string, ttl: number }) {
     this.logger.log(`Refreshing local cache key ${info.key} with ttl ${info.ttl}`);
     await this.cachingService.refreshLocal(info.key, info.ttl);
-  }
-
-  @EventPattern('transactionsCompleted')
-  async transactionsCompleted(transactions: ShardTransaction[]) {
-    for (const transaction of transactions) {
-      await this.webSocketPublisherService.onTransactionCompleted(transaction);
-    }
-  }
-
-  @EventPattern('transactionsPendingResults')
-  async transactionsPendingResults(transactions: ShardTransaction[]) {
-    for (const transaction of transactions) {
-      await this.webSocketPublisherService.onTransactionPendingResults(transaction);
-    }
-  }
-
-  @EventPattern('onBatchUpdated')
-  async onBatchUpdated(payload: { address: string, batchId: string, txHashes: string[] }) {
-    this.logger.log(`Notifying batch updated for address ${payload.address}, batch id '${payload.batchId}', hashes ${payload.txHashes}`);
-    await this.webSocketPublisherService.onBatchUpdated(payload.address, payload.batchId, payload.txHashes);
   }
 }

--- a/src/common/pubsub/pub.sub.listener.module.ts
+++ b/src/common/pubsub/pub.sub.listener.module.ts
@@ -1,12 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
-import { WebSocketPublisherModule } from 'src/common/websockets/web-socket-publisher-module';
 import { PubSubListenerController } from './pub.sub.listener.controller';
 
 @Module({
   imports: [
     DynamicModuleUtils.getCachingModule(),
-    WebSocketPublisherModule,
   ],
   controllers: [
     PubSubListenerController,

--- a/src/common/websockets/web-socket-publisher-controller.ts
+++ b/src/common/websockets/web-socket-publisher-controller.ts
@@ -1,0 +1,34 @@
+import { OriginLogger } from "@multiversx/sdk-nestjs";
+import { ShardTransaction } from "@elrondnetwork/transaction-processor";
+import { Controller } from "@nestjs/common";
+import { EventPattern } from "@nestjs/microservices";
+import { WebSocketPublisherService } from "src/common/websockets/web-socket-publisher-service";
+
+@Controller()
+export class WebSocketPublisherController {
+  private logger = new OriginLogger(WebSocketPublisherController.name);
+
+  constructor(
+    private readonly webSocketPublisherService: WebSocketPublisherService,
+  ) { }
+
+  @EventPattern('transactionsCompleted')
+  async transactionsCompleted(transactions: ShardTransaction[]) {
+    for (const transaction of transactions) {
+      await this.webSocketPublisherService.onTransactionCompleted(transaction);
+    }
+  }
+
+  @EventPattern('transactionsPendingResults')
+  async transactionsPendingResults(transactions: ShardTransaction[]) {
+    for (const transaction of transactions) {
+      await this.webSocketPublisherService.onTransactionPendingResults(transaction);
+    }
+  }
+
+  @EventPattern('onBatchUpdated')
+  onBatchUpdated(payload: { address: string, batchId: string, txHashes: string[] }) {
+    this.logger.log(`Notifying batch updated for address ${payload.address}, batch id '${payload.batchId}', hashes ${payload.txHashes} `);
+    this.webSocketPublisherService.onBatchUpdated(payload.address, payload.batchId, payload.txHashes);
+  }
+}

--- a/src/common/websockets/web-socket-publisher-module.ts
+++ b/src/common/websockets/web-socket-publisher-module.ts
@@ -1,16 +1,23 @@
 import { Module } from "@nestjs/common";
 import { TransactionActionModule } from "src/endpoints/transactions/transaction-action/transaction.action.module";
 import { WebSocketPublisherService } from "./web-socket-publisher-service";
+import { WebSocketPublisherController } from "./web-socket-publisher-controller";
+import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 
 @Module({
   imports: [
     TransactionActionModule,
   ],
+  controllers: [
+    WebSocketPublisherController,
+  ],
   providers: [
     WebSocketPublisherService,
+    DynamicModuleUtils.getPubSubService(),
   ],
   exports: [
     WebSocketPublisherService,
+    'PUBSUB_SERVICE',
   ],
 })
 export class WebSocketPublisherModule { }


### PR DESCRIPTION
## Reasoning
- Port 3099 for websockets was initialized for all types of machines: cachewarmer, queueworker, transaction processor, public api but should only have been enabled for the instances that run public api
  
## Proposed Changes
- Reconfigure import of modules in such as way that the websocket publisher will only activate itself for the public api instances

## How to test
- Run in parallel an instance with cache warmer, another with transaction processor, another with public api. All should start successfully
