### PR TITLE
 add exchange filter 

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.exchange.type.ts
+++ b/src/endpoints/mex/entities/mex.pair.exchange.type.ts
@@ -1,0 +1,23 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum MexPairExchangeType {
+  xexchange = 'xexchange',
+  jungledex = 'jungledex',
+  none = 'none'
+}
+
+registerEnumType(MexPairExchangeType, {
+  name: 'MexPairExchangeType',
+  description: 'MexPairExchangeType object type.',
+  valuesMap: {
+    xexchange: {
+      description: 'xexchange',
+    },
+    jungledex: {
+      description: 'jungledex',
+    },
+    none: {
+      description: 'none',
+    },
+  },
+});

--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { MexPairState } from "./mex.pair.state";
 import { MexPairType } from "./mex.pair.type";
+import { MexPairExchangeType } from "./mex.pair.exchange.type";
 
 @ObjectType("MexPair", { description: "MexPair object type." })
 export class MexPair {
@@ -76,4 +77,8 @@ export class MexPair {
   @Field(() => MexPairType, { description: "Mex pair type details." })
   @ApiProperty({ enum: MexPairType })
   type: MexPairType = MexPairType.experimental;
+
+  @Field(() => String, { description: "Mex pair exchange details.", nullable: true })
+  @ApiProperty({ type: String, example: 'jungledex' })
+  exchange: MexPairExchangeType | undefined;
 }

--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -11,7 +11,8 @@ import { MexTokenService } from "./mex.token.service";
 import { MexFarmService } from './mex.farm.service';
 import { MexFarm } from './entities/mex.farm';
 import { QueryPagination } from 'src/common/entities/query.pagination';
-import { ParseIntPipe, ParseTokenPipe } from '@multiversx/sdk-nestjs';
+import { ParseEnumPipe, ParseIntPipe, ParseTokenPipe } from '@multiversx/sdk-nestjs';
+import { MexPairExchangeType } from './entities/mex.pair.exchange.type';
 
 @Controller()
 @ApiTags('xexchange')
@@ -50,18 +51,23 @@ export class MexController {
   @ApiOkResponse({ type: [MexPair] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'exchange', description: 'Sorting criteria by exchange', required: false, enum: MexPairExchangeType })
   async getMexPairs(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
-    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('exchange', new ParseEnumPipe(MexPairExchangeType)) exchange?: MexPairExchangeType,
+
   ): Promise<any> {
-    return await this.mexPairsService.getMexPairs(from, size);
+    return await this.mexPairsService.getMexPairs(from, size, exchange);
   }
 
   @Get("/mex/pairs/count")
   @ApiOperation({ summary: 'Maiar Exchange pairs count', description: 'Returns active liquidity pools count available on Maiar Exchange' })
+  @ApiQuery({ name: 'exchange', description: 'Sorting criteria by exchange', required: false, enum: MexPairExchangeType })
   async getMexPairsCount(
+    @Query('exchange', new ParseEnumPipe(MexPairExchangeType)) exchange?: MexPairExchangeType,
   ): Promise<number> {
-    return await this.mexPairsService.getMexPairsCount();
+    return await this.mexPairsService.getMexPairsCount(exchange);
   }
 
   @Get("/mex/tokens")


### PR DESCRIPTION
## Reasoning
- To improve accessibility and filtering of Mex pairs based on the exchange, we have added a new attribute, `exchange`, and introduced an `enum` to represent the possible exchange types.
- This implementation allows users to easily filter Mex pairs by their respective` exchange` and provides a more structured way to handle the data.
  
## Proposed Changes
- Added a new `exchange` attribute to the `MexPair` object
- Introduced the `MexPairExchangeType` enum to represent possible exchange types.
- Modified the `getPairInfo` method to assign the appropriate `exchange` value based on the pair type.
- Updated the `getMexPairs` and `getMexPairsCount` methods to accept an optional filter parameter of type `MexPairExchangeType`
- Implemented filtering logic in the `getMexPairs` and `getMexPairsCoun`t methods to return filtered results based on the provided filter value.
- Add new `ApiQuery` in `mex.controller.ts` to be able to apply the new exchange optional filter

## How to test
- `/mex/pairs?exchange=jungledex` -> should return ~21 mex pairs details with `exchange: "jungledex"` defined
- `/mex/pairs?exchange=xexchange` -> should return ~16 mex pairs details with `exchange: "xexchange"` defined
- `/mex/pairs/count?exchange=jungledex` -> should return ~21 mex pairs count
- `/mex/pairs/count?exchange=xexchange` -> should return ~16 mex pairs count
