### PR TITLE
add inTransit transaction field

### DIFF
--- a/src/endpoints/transactions/entities/transaction.detailed.ts
+++ b/src/endpoints/transactions/entities/transaction.detailed.ts
@@ -56,5 +56,9 @@ export class TransactionDetailed extends Transaction {
   @ApiProperty({ type: Number, nullable: true })
   @ComplexityEstimation({ group: "blockInfo", value: 200, alternatives: ["withBlockInfo"] })
   receiverBlockNonce: number | undefined = undefined;
+
+  @Field(() => Boolean, { description: "InTransit transaction details.", nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  inTransit: boolean | undefined = undefined;
 }
 

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -194,6 +194,7 @@ export class TransactionGetService {
         logs: transaction.logs,
         guardianAddress: transaction.guardian,
         guardianSignature: transaction.guardianSignature,
+        inTransit: transaction.miniblockHash !== undefined && transaction.status === 'pending',
       };
 
       return ApiUtils.mergeObjects(new TransactionDetailed(), result);

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -13,6 +13,7 @@ import { TransactionUtils } from "./transaction.utils";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { MiniBlockType } from "../miniblocks/entities/mini.block.type";
+import { TransactionStatus } from "./entities/transaction.status";
 
 @Injectable()
 export class TransactionGetService {
@@ -194,7 +195,7 @@ export class TransactionGetService {
         logs: transaction.logs,
         guardianAddress: transaction.guardian,
         guardianSignature: transaction.guardianSignature,
-        inTransit: transaction.miniblockHash !== undefined && transaction.status === 'pending',
+        inTransit: transaction.miniblockHash !== undefined && transaction.status === TransactionStatus.pending,
       };
 
       return ApiUtils.mergeObjects(new TransactionDetailed(), result);


### PR DESCRIPTION
## Reasoning
- The current implementation of the getTransaction method does not provide information about whether a transaction is in transit or not.
- In transit transactions are those with a miniBlockHash and a status of "pending".
 - Including this information can be helpful for users to better understand the state of their transactions.
  
## Proposed Changes
- Add a new field inTransit to the TransactionDetailed class as a boolean.
- Modify the tryGetTransactionFromGateway method to set the inTransit field to true if miniBlockHash is not undefined and status is "pending".

## How to test ( devnet )
- Make a new transaction ( ESDT Transfer ) and within 5 seconds make a request to /transactions/:txHash and see if `inTransit` fields is defined as true, but check if miniblockHash is defined and status: pending
