### PR TITLE
Support for guardian in transaction batch endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
-        "@multiversx/sdk-core": "^12.2.0",
+        "@multiversx/sdk-core": "^12.2.1",
         "@multiversx/sdk-data-api-client": "^0.4.4",
         "@multiversx/sdk-nestjs-auth": "^1.0.0",
         "@multiversx/sdk-nestjs-cache": "^1.0.0",
@@ -3341,9 +3341,9 @@
       }
     },
     "node_modules/@multiversx/sdk-core": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-12.2.0.tgz",
-      "integrity": "sha512-PbHLlG9+UWiYY71NGPZ5bjrvaxFvwYU6NQxeU2Pnp99Csm1O42pySq5NVqaKhcZh3F6JDkUiNhvcjnKI3Lt+EQ==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-12.2.1.tgz",
+      "integrity": "sha512-jnVwr7ljZ3AD5rN/lifrNq5uZU7CenNVqnCzu8Ks1fVJ/TOZM6VUkVXoSvceweXY0vw7FyH6FBVRUQqWPWbZzg==",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",
         "bech32": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.54.0",
-        "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.2.12-alpha",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
+        "@multiversx/sdk-core": "^12.2.0",
         "@multiversx/sdk-data-api-client": "^0.4.4",
         "@multiversx/sdk-nestjs-auth": "^1.0.0",
         "@multiversx/sdk-nestjs-cache": "^1.0.0",
@@ -3341,9 +3341,9 @@
       }
     },
     "node_modules/@multiversx/sdk-core": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
-      "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-12.2.0.tgz",
+      "integrity": "sha512-PbHLlG9+UWiYY71NGPZ5bjrvaxFvwYU6NQxeU2Pnp99Csm1O42pySq5NVqaKhcZh3F6JDkUiNhvcjnKI3Lt+EQ==",
       "dependencies": {
         "@multiversx/sdk-transaction-decoder": "1.0.2",
         "bech32": "1.1.4",
@@ -3376,6 +3376,43 @@
         "bignumber.js": "^9.1.1",
         "moment": "^2.29.4",
         "prettier": "^2.8.1"
+      }
+    },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/@multiversx/sdk-core": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+      "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
+      "dependencies": {
+        "@multiversx/sdk-transaction-decoder": "1.0.2",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "blake2b": "2.1.3",
+        "buffer": "6.0.3",
+        "json-duplicate-key-handle": "1.0.0",
+        "keccak": "3.0.2",
+        "protobufjs": "6.11.3"
+      }
+    },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/@multiversx/sdk-core/node_modules/bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/@multiversx/sdk-core/node_modules/keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@multiversx/sdk-data-api-client/node_modules/@multiversx/sdk-wallet": {
@@ -3418,6 +3455,46 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/@multiversx/sdk-data-api-client/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/@multiversx/sdk-native-auth-client": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-0.1.8.tgz",
@@ -3435,6 +3512,40 @@
         "@multiversx/sdk-wallet": "^2.1.1",
         "axios": "^0.27.2",
         "bech32": "^2.0.0"
+      }
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/@multiversx/sdk-core": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+      "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
+      "dependencies": {
+        "@multiversx/sdk-transaction-decoder": "1.0.2",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "blake2b": "2.1.3",
+        "buffer": "6.0.3",
+        "json-duplicate-key-handle": "1.0.0",
+        "keccak": "3.0.2",
+        "protobufjs": "6.11.3"
+      }
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/@multiversx/sdk-core/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/@multiversx/sdk-core/node_modules/keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@multiversx/sdk-native-auth-server/node_modules/@multiversx/sdk-wallet": {
@@ -3464,6 +3575,14 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@multiversx/sdk-native-auth-server/node_modules/keccak": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
@@ -3485,6 +3604,46 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/@multiversx/sdk-native-auth-server/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/@multiversx/sdk-nestjs-auth": {
@@ -3598,12 +3757,35 @@
         "@nestjs/swagger": "^6.x"
       }
     },
+    "node_modules/@multiversx/sdk-nestjs-common/node_modules/@multiversx/sdk-core": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-core/-/sdk-core-11.6.0.tgz",
+      "integrity": "sha512-bP1fmp84iEAJEdaprvw8M9FeqJVOWTmv8vhhiaYW6YTV/ztlB+niv1CFsYk0dWFWIfKzn+eT4CvQjl8OTwBC/A==",
+      "dependencies": {
+        "@multiversx/sdk-transaction-decoder": "1.0.2",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "blake2b": "2.1.3",
+        "buffer": "6.0.3",
+        "json-duplicate-key-handle": "1.0.0",
+        "keccak": "3.0.2",
+        "protobufjs": "6.11.3"
+      }
+    },
     "node_modules/@multiversx/sdk-nestjs-common/node_modules/@multiversx/sdk-native-auth-client": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-1.0.2.tgz",
       "integrity": "sha512-2y5XCi09Zfgo5fNuQPaSEfOVJoZB8OrAiEtjQy3RDzm44j83E/bByFWDE2CWHV1aRWsn9JwOSQdYWtMO9RMF/Q==",
       "dependencies": {
         "axios": "^0.27.2"
+      }
+    },
+    "node_modules/@multiversx/sdk-nestjs-common/node_modules/bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@multiversx/sdk-nestjs-elastic": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
-    "@multiversx/sdk-core": "^12.2.0",
+    "@multiversx/sdk-core": "^12.2.1",
     "@elrondnetwork/erdjs-dex": "^0.2.12-alpha",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
-    "@elrondnetwork/erdjs": "^11.0.0",
+    "@multiversx/sdk-core": "^12.2.0",
     "@elrondnetwork/erdjs-dex": "^0.2.12-alpha",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -31,7 +31,6 @@ import { AccountVerification } from './entities/account.verification';
 import { AccountFilter } from './entities/account.filter';
 import { AccountHistoryFilter } from './entities/account.history.filter';
 import { ProtocolService } from 'src/common/protocol/protocol.service';
-import { Address } from "@elrondnetwork/erdjs/out";
 
 @Injectable()
 export class AccountService {
@@ -332,7 +331,7 @@ export class AccountService {
   async getDeferredAccount(address: string): Promise<AccountDeferred[]> {
     const publicKey = AddressUtils.bech32Decode(address);
     const delegationContractAddress = this.apiConfigService.getDelegationContractAddress();
-    const delegationContractShardId = AddressUtils.computeShard(Address.fromString(delegationContractAddress).hex(), await this.protocolService.getShardCount());
+    const delegationContractShardId = AddressUtils.computeShard(AddressUtils.bech32Decode(delegationContractAddress), await this.protocolService.getShardCount());
 
     const [
       encodedUserDeferredPaymentList,

--- a/src/endpoints/transactions.batch/entities/transaction.details.ts
+++ b/src/endpoints/transactions.batch/entities/transaction.details.ts
@@ -10,4 +10,6 @@ export class TransactionDetails {
   value: string = '';
   version: number = 0;
   options?: number;
+  guardian?: string;
+  guardianSignature?: string;
 }

--- a/src/endpoints/transactions.batch/transactions.batch.service.ts
+++ b/src/endpoints/transactions.batch/transactions.batch.service.ts
@@ -1,5 +1,5 @@
-import { Address, Transaction as ErdJsTransaction, TransactionHash, TransactionOptions, TransactionPayload, TransactionVersion } from "@elrondnetwork/erdjs/out";
-import { Signature } from "@elrondnetwork/erdjs/out/signature";
+import { Address, Transaction as ErdJsTransaction, TransactionHash, TransactionOptions, TransactionPayload, TransactionVersion } from "@multiversx/sdk-core/out";
+import { Signature } from "@multiversx/sdk-core/out/signature";
 import { BinaryUtils } from "@multiversx/sdk-nestjs-common";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { Injectable, Logger } from "@nestjs/common";
@@ -46,10 +46,15 @@ export class TransactionsBatchService {
           chainID: tx.chainID,
           version: new TransactionVersion(tx.version),
           options: tx.options ? new TransactionOptions(tx.options) : undefined,
+          guardian: tx.guardian ? new Address(tx.guardian) : undefined,
           sender: new Address(tx.sender),
         });
 
-        trans.applySignature(new Signature(tx.signature), new Address(tx.sender));
+        if (tx.guardianSignature) {
+          trans.applyGuardianSignature(new Signature(tx.guardianSignature));
+        }
+
+        trans.applySignature(new Signature(tx.signature));
 
         item.transaction.hash = TransactionHash.compute(trans).toString();
       }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1965,6 +1965,9 @@ type MexPair {
   """Base symbol details."""
   baseSymbol: String!
 
+  """Mex pair exchange details."""
+  exchange: String
+
   """Id details."""
   id: String!
 
@@ -3878,6 +3881,9 @@ type TransactionDetailed {
 
   """Guardian signature for the given transaction."""
   guardianSignature: String
+
+  """InTransit transaction details."""
+  inTransit: Boolean
 
   """Transaction log for the given detailed transaction."""
   logs: TransactionLog


### PR DESCRIPTION
## Proposed Changes
- Add support for `guardian` & `guardianSignature` fields in the transaction batch endpoint

## How to test
- trigger transaction batch with a guarded transaction, which should be sent with all of its available fields
