### PR TITLE
 identity data in provider details

### DIFF
--- a/src/endpoints/providers/entities/provider.ts
+++ b/src/endpoints/providers/entities/provider.ts
@@ -3,6 +3,7 @@ import { SwaggerUtils } from "@multiversx/sdk-nestjs-common";
 import { Field, Float, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { NodesInfos } from "./nodes.infos";
+import { Identity } from "src/endpoints/identities/entities/identity";
 
 @ObjectType("Provider", { description: "Provider object type." })
 export class Provider extends NodesInfos {
@@ -73,4 +74,7 @@ export class Provider extends NodesInfos {
 
   @ApiProperty({ type: String, nullable: true })
   githubKeysValidatedAt: string | undefined = undefined;
+
+  @ApiProperty({ type: Identity, nullable: true })
+  identityInfo?: Identity | undefined = undefined;
 }

--- a/src/endpoints/providers/entities/provider.ts
+++ b/src/endpoints/providers/entities/provider.ts
@@ -76,5 +76,5 @@ export class Provider extends NodesInfos {
   githubKeysValidatedAt: string | undefined = undefined;
 
   @ApiProperty({ type: Identity, nullable: true })
-  identityInfo?: Identity | undefined = undefined;
+  identityInfo?: Identity;
 }

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, HttpException, HttpStatus, Param, Query, Res } from "@
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { ProviderService } from "./provider.service";
 import { Provider } from "./entities/provider";
-import { ParseAddressArrayPipe, ParseAddressPipe } from "@multiversx/sdk-nestjs-common";
+import { ParseAddressArrayPipe, ParseAddressPipe, ParseBoolPipe } from "@multiversx/sdk-nestjs-common";
 import { ProviderFilter } from "./entities/provider.filter";
 import { Response } from "express";
 
@@ -16,11 +16,15 @@ export class ProviderController {
   @ApiOkResponse({ type: [Provider] })
   @ApiQuery({ name: 'identity', description: 'Search by identity', required: false })
   @ApiQuery({ name: 'providers', description: 'Search by multiple providers address', required: false })
+  @ApiQuery({ name: 'withIdentityInfo', description: 'Returns identity data for providers', required: false })
   async getProviders(
     @Query('identity') identity?: string,
     @Query('providers', ParseAddressArrayPipe) providers?: string[],
+    @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
   ): Promise<Provider[]> {
-    return await this.providerService.getProviders(new ProviderFilter({ identity, providers }));
+    return await this.providerService.getProviders(
+      new ProviderFilter({ identity, providers }),
+      withIdentityInfo);
   }
 
   @Get('/providers/:address')

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -164,8 +164,23 @@ export class ProviderService {
     return /^[\w]*$/g.test(identity ?? '');
   }
 
-  async getProviders(filter: ProviderFilter): Promise<Provider[]> {
-    return await this.getFilteredProviders(filter);
+  async getProviders(filter: ProviderFilter, withIdentityInfo?: boolean): Promise<Provider[]> {
+    const providers = await this.getFilteredProviders(filter);
+
+    if (withIdentityInfo === true) {
+      for (const provider of providers) {
+        if (provider.identity) {
+          const identityInfo = await this.identitiesService.getIdentity(provider.identity);
+          provider.identityInfo = identityInfo;
+        }
+      }
+    } else {
+      for (const provider of providers) {
+        delete provider.identityInfo;
+      }
+    }
+
+    return providers;
   }
 
   async getDelegationProviders(): Promise<DelegationData[]> {


### PR DESCRIPTION
## Reasoning
- To provide more information's about providers , we wanted to fetch provider identity data only when necessary.
  
## Proposed Changes
- We added an optional boolean parameter `withIdentityInfo` to the `getProviders` endpoint to include or exclude identity data.

### GET
- `/providers?withIdentityInfo=boolean`

## How to test
- `providers?withIdentityInfo=true` -> should return identity data for each providers
- `providers?withIdentityInfo=false` -> should return only provider details without identity data
-`providers?providers=erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu,erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85&withIdentityInfo=true` -> should return providers identity data even when `providers` filter is applied
- `providers?identity=binance_staking&withIdentityInfo=true` -> should return identity data even when `identity` filter is applied
