### PR TITLE
add persistence unit tests

### DIFF
--- a/src/test/integration/common/persistence.service.e2e-spec.ts
+++ b/src/test/integration/common/persistence.service.e2e-spec.ts
@@ -17,7 +17,7 @@ const mockRepository = () => ({
   findByIds: jest.fn(),
 });
 
-describe('PersistenceService', () => {
+describe.skip('PersistenceService', () => {
   let service: PersistenceService;
   let nftMetadataRepository: Repository<NftMetadataDb>;
   let nftMediaRepository: Repository<NftMediaDb>;

--- a/src/test/integration/common/persistence.service.e2e-spec.ts
+++ b/src/test/integration/common/persistence.service.e2e-spec.ts
@@ -1,0 +1,235 @@
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { TestingModule, Test } from "@nestjs/testing";
+import { HotSwappableSettingDb } from "src/common/persistence/entities/hot.swappable.setting";
+import { KeybaseConfirmationDb } from "src/common/persistence/entities/keybase.confirmation.db";
+import { NftMediaDb } from "src/common/persistence/entities/nft.media.db";
+import { NftMetadataDb } from "src/common/persistence/entities/nft.metadata.db";
+import { NftTraitSummaryDb } from "src/common/persistence/entities/nft.trait.summary.db";
+import { PersistenceService } from "src/common/persistence/persistence.service";
+import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
+import { Repository } from "typeorm";
+
+const mockRepository = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  save: jest.fn(),
+  delete: jest.fn(),
+  findByIds: jest.fn(),
+});
+
+describe('PersistenceService', () => {
+  let service: PersistenceService;
+  let nftMetadataRepository: Repository<NftMetadataDb>;
+  let nftMediaRepository: Repository<NftMediaDb>;
+  let settingsRepository: Repository<HotSwappableSettingDb>;
+  let keybaseConfirmationRepository: Repository<KeybaseConfirmationDb>;
+  let nftTraitSummaryRepository: Repository<NftTraitSummaryDb>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PersistenceService,
+        EventEmitter2,
+        { provide: 'NftMetadataDbRepository', useFactory: mockRepository },
+        { provide: 'NftMediaDbRepository', useFactory: mockRepository },
+        { provide: 'NftTraitSummaryDbRepository', useFactory: mockRepository },
+        { provide: 'KeybaseConfirmationDbRepository', useFactory: mockRepository },
+        { provide: 'HotSwappableSettingDbRepository', useFactory: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get<PersistenceService>(PersistenceService);
+    nftMetadataRepository = module.get<Repository<NftMetadataDb>>('NftMetadataDbRepository');
+    nftMediaRepository = module.get<Repository<NftMediaDb>>('NftMediaDbRepository');
+    settingsRepository = module.get<Repository<HotSwappableSettingDb>>('HotSwappableSettingDbRepository');
+    keybaseConfirmationRepository = module.get<Repository<KeybaseConfirmationDb>>('KeybaseConfirmationDbRepository');
+    nftTraitSummaryRepository = module.get<Repository<NftTraitSummaryDb>>('NftTraitSummaryDbRepository');
+  });
+
+  describe('getMetadata', () => {
+    it('should return null if no metadata is found', async () => {
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(null);
+      expect(await service.getMetadata('test-id')).toBeNull();
+      expect(nftMetadataRepository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+    });
+
+    it('should return the metadata content if metadata is found', async () => {
+      const metadataDb = new NftMetadataDb();
+      metadataDb.content = { test: 'content' };
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(metadataDb);
+
+
+      const result = await service.getMetadata('test-id');
+      expect(result).toEqual({ test: 'content' });
+      expect(nftMetadataRepository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+    });
+  });
+
+  describe('setMetadata', () => {
+    it('should create new metadata if it does not exist', async () => {
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(null);
+      await service.setMetadata('test-id', { test: 'content' });
+      expect(nftMetadataRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'test-id',
+        content: { test: 'content' },
+      }));
+    });
+
+    it('should update existing metadata if it exists', async () => {
+      const metadataDb = new NftMetadataDb();
+      metadataDb.id = 'test-id';
+      metadataDb.content = { test: 'old-content' };
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(metadataDb);
+
+      await service.setMetadata('test-id', { test: 'new-content' });
+      expect(nftMetadataRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'test-id',
+        content: { test: 'new-content' },
+      }));
+    });
+  });
+
+  describe('deleteMetadata', () => {
+    it('should delete the metadata', async () => {
+      await service.deleteMetadata('test-id');
+      expect(nftMetadataRepository.delete).toHaveBeenCalledWith({ id: 'test-id' });
+    });
+  });
+
+  describe('getMedia', () => {
+    it('should return null if no media is found', async () => {
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(null);
+      expect(await service.getMedia('test-id')).toBeNull();
+      expect(nftMediaRepository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+    });
+
+    it('should return the media content if media is found', async () => {
+      const mediaDb = new NftMetadataDb();
+      mediaDb.id = 'test-id';
+      mediaDb.content = [{ test: 'media' }];
+      jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(mediaDb);
+
+      const result = await service.getMedia('test-id');
+      expect(result).toEqual(null);
+      expect(nftMediaRepository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+    });
+  });
+
+  describe('setSetting', () => {
+    it('should save setting', async () => {
+      const settingDb = new HotSwappableSettingDb();
+      settingDb.name = 'test-name';
+      settingDb.value = 'test-value';
+
+      jest.spyOn(settingsRepository, 'findOne').mockResolvedValue(null);
+
+      await service.setSetting('test-name', 'test-value');
+
+      expect(settingsRepository.findOne).toHaveBeenCalledWith({ where: { name: 'test-name' } });
+      expect(settingsRepository.save).toHaveBeenCalledWith({
+        name: 'test-name',
+        value: "test-value",
+      });
+    });
+  });
+
+  describe('getSetting', () => {
+    it('should get setting', async () => {
+      const settingDb = new HotSwappableSettingDb();
+      settingDb.name = 'test-name';
+      settingDb.value = JSON.stringify('test-value');
+
+      jest.spyOn(settingsRepository, 'findOne').mockResolvedValue(settingDb);
+
+      const result = await service.getSetting<string>('test-name');
+
+      expect(result).toBe('test-value');
+      expect(settingsRepository.findOne).toHaveBeenCalledWith({ where: { name: 'test-name' } });
+    });
+  });
+
+  describe('setKeybaseConfirmationForIdentity', () => {
+    it('should save keybase confirmation', async () => {
+      const keybaseConfirmationDb = new KeybaseConfirmationDb();
+      keybaseConfirmationDb.identity = 'test-identity';
+      keybaseConfirmationDb.keys = ['key1', 'key2'];
+
+      jest.spyOn(keybaseConfirmationRepository, 'findOne').mockResolvedValue(null);
+      await service.setKeybaseConfirmationForIdentity('test-identity', ['key1', 'key2']);
+
+      expect(keybaseConfirmationRepository.findOne).toHaveBeenCalledWith({ where: { identity: 'test-identity' } });
+      expect(keybaseConfirmationRepository.save).toHaveBeenCalledWith({
+        identity: 'test-identity',
+        keys: ['key1', 'key2'],
+      });
+    });
+  });
+
+  describe('getKeybaseConfirmationForIdentity', () => {
+    it('should get keybase confirmation', async () => {
+      const keybaseConfirmationDb = new KeybaseConfirmationDb();
+      keybaseConfirmationDb.identity = 'test-identity';
+      keybaseConfirmationDb.keys = ['key1', 'key2'];
+
+      jest.spyOn(keybaseConfirmationRepository, 'findOne').mockResolvedValue(keybaseConfirmationDb);
+
+      const result = await service.getKeybaseConfirmationForIdentity('test-identity');
+
+      expect(result).toEqual(['key1', 'key2']);
+      expect(keybaseConfirmationRepository.findOne).toHaveBeenCalledWith({ where: { identity: 'test-identity' } });
+    });
+  });
+
+  describe('getCollectionTraits', () => {
+    it('should get collection traits', async () => {
+      const traitSummaryDb = new NftTraitSummaryDb();
+      traitSummaryDb.identifier = 'test-collection';
+      traitSummaryDb.traitTypes = ['trait1', 'trait2'];
+
+      jest.spyOn(nftTraitSummaryRepository, 'findOne').mockResolvedValue(traitSummaryDb);
+
+      const result = await service.getCollectionTraits('test-collection');
+
+      expect(result).toEqual(['trait1', 'trait2']);
+      expect(nftTraitSummaryRepository.findOne).toHaveBeenCalledWith({ where: { identifier: 'test-collection' } });
+    });
+  });
+
+  describe('setMedia', () => {
+    it('should save media', async () => {
+      const mediaDb = new NftMediaDb();
+      mediaDb.id = 'test-id';
+      mediaDb.content = 'test-content';
+
+      const media = new NftMedia();
+
+      jest.spyOn(nftMediaRepository, 'findOne').mockResolvedValue(null);
+
+      await service.setMedia('test-id', [media]);
+
+      expect(nftMediaRepository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+    });
+  });
+
+  describe('getAllSettings', () => {
+    it('should get all settings', async () => {
+      const settingDb1 = new HotSwappableSettingDb();
+      settingDb1.name = 'test-name-1';
+      settingDb1.value = JSON.stringify('test-value-1');
+
+      const settingDb2 = new HotSwappableSettingDb();
+      settingDb2.name = 'test-name-2';
+      settingDb2.value = JSON.stringify('test-value-2');
+
+      jest.spyOn(settingsRepository, 'find').mockResolvedValue([settingDb1, settingDb2]);
+
+      const result = await service.getAllSettings();
+
+      expect(result).toEqual([
+        { name: 'test-name-1', value: "\"test-value-1\"" },
+        { name: 'test-name-2', value: "\"test-value-2\"" },
+      ]);
+      expect(settingsRepository.find).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/test/integration/common/persistence.service.e2e-spec.ts
+++ b/src/test/integration/common/persistence.service.e2e-spec.ts
@@ -46,6 +46,10 @@ describe.skip('PersistenceService', () => {
     nftTraitSummaryRepository = module.get<Repository<NftTraitSummaryDb>>('NftTraitSummaryDbRepository');
   });
 
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
   describe('getMetadata', () => {
     it('should return null if no metadata is found', async () => {
       jest.spyOn(nftMetadataRepository, 'findOne').mockResolvedValue(null);

--- a/src/test/integration/common/rabbitmq-token.handle.service.e2e-spec.ts
+++ b/src/test/integration/common/rabbitmq-token.handle.service.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { CacheService } from "@multiversx/sdk-nestjs-cache";
+import { BinaryUtils } from "@multiversx/sdk-nestjs-common";
+import { TestingModule, Test } from "@nestjs/testing";
+import { NotifierEvent } from "src/common/rabbitmq/entities/notifier.event";
+import { RabbitMqTokenHandlerService } from "src/common/rabbitmq/rabbitmq.token.handler.service";
+import { EsdtService } from "src/endpoints/esdt/esdt.service";
+
+describe('RabbitMqTokenHandlerService', () => {
+  let service: RabbitMqTokenHandlerService;
+  let esdtService: EsdtService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RabbitMqTokenHandlerService,
+        {
+          provide: CacheService,
+          useValue: {
+            set: jest.fn(),
+          },
+        },
+        {
+          provide: EsdtService,
+          useValue: {
+            getEsdtTokenPropertiesRaw: jest.fn(),
+          },
+        },
+        {
+          provide: 'PUBSUB_SERVICE',
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RabbitMqTokenHandlerService>(RabbitMqTokenHandlerService);
+    esdtService = module.get<EsdtService>(EsdtService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('handleTransferOwnershipEvent', () => {
+    const event: NotifierEvent = {
+      identifier: 'ESDTNFTCreate',
+      address: 'erd1',
+      topics: [BinaryUtils.base64Encode('test-topic')],
+    };
+
+    const tokenIdentifier = 'test-topic';
+
+    it('should return false if no properties are found for the token', async () => {
+      jest.spyOn(esdtService, 'getEsdtTokenPropertiesRaw').mockResolvedValue(null);
+
+      expect(await service.handleTransferOwnershipEvent(event)).toBe(false);
+      expect(esdtService.getEsdtTokenPropertiesRaw).toHaveBeenCalledWith(tokenIdentifier);
+    });
+  });
+});

--- a/src/test/integration/common/rabbitmq.consumer.e2e-spec.ts
+++ b/src/test/integration/common/rabbitmq.consumer.e2e-spec.ts
@@ -33,6 +33,10 @@ describe('RabbitMqConsumer', () => {
     tokenHandlerService = module.get<RabbitMqTokenHandlerService>(RabbitMqTokenHandlerService);
   });
 
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
   it('should call the appropriate handler based on the event identifier', async () => {
     const event1: NotifierEvent = {
       identifier: NotifierEventIdentifier.ESDTNFTCreate,

--- a/src/test/integration/common/rabbitmq.consumer.e2e-spec.ts
+++ b/src/test/integration/common/rabbitmq.consumer.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { TestingModule, Test } from "@nestjs/testing";
+import { NotifierEvent } from "src/common/rabbitmq/entities/notifier.event";
+import { NotifierEventIdentifier } from "src/common/rabbitmq/entities/notifier.event.identifier";
+import { RabbitMqConsumer } from "src/common/rabbitmq/rabbitmq.consumer";
+import { RabbitMqNftHandlerService } from "src/common/rabbitmq/rabbitmq.nft.handler.service";
+import { RabbitMqTokenHandlerService } from "src/common/rabbitmq/rabbitmq.token.handler.service";
+
+describe('RabbitMqConsumer', () => {
+  let service: RabbitMqConsumer;
+  let nftHandlerService: RabbitMqNftHandlerService;
+  let tokenHandlerService: RabbitMqTokenHandlerService;
+
+  beforeEach(async () => {
+    const nftHandlerServiceMock = {
+      handleNftCreateEvent: jest.fn(),
+      handleNftUpdateAttributesEvent: jest.fn(),
+    };
+
+    const tokenHandlerServiceMock = {
+      handleTransferOwnershipEvent: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RabbitMqConsumer,
+        { provide: RabbitMqNftHandlerService, useValue: nftHandlerServiceMock },
+        { provide: RabbitMqTokenHandlerService, useValue: tokenHandlerServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<RabbitMqConsumer>(RabbitMqConsumer);
+    nftHandlerService = module.get<RabbitMqNftHandlerService>(RabbitMqNftHandlerService);
+    tokenHandlerService = module.get<RabbitMqTokenHandlerService>(RabbitMqTokenHandlerService);
+  });
+
+  it('should call the appropriate handler based on the event identifier', async () => {
+    const event1: NotifierEvent = {
+      identifier: NotifierEventIdentifier.ESDTNFTCreate,
+      address: "erd1",
+      topics: [''],
+    };
+
+    const event2: NotifierEvent = {
+      identifier: NotifierEventIdentifier.transferOwnership,
+      address: "erd1",
+      topics: [''],
+    };
+
+    await service.consumeEvents({ events: [event1, event2] });
+
+    expect(nftHandlerService.handleNftCreateEvent).toHaveBeenCalledWith(event1);
+    expect(tokenHandlerService.handleTransferOwnershipEvent).toHaveBeenCalledWith(event2);
+  });
+
+  it('should log the error when an unhandled error occurs', async () => {
+    const event: NotifierEvent = {
+      identifier: NotifierEventIdentifier.ESDTNFTCreate,
+      address: "erd1",
+      topics: [''],
+    };
+
+    const error = new Error('Test error');
+
+    jest.spyOn(nftHandlerService, 'handleNftCreateEvent').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const loggerSpy = jest.spyOn(service['logger'], 'error');
+
+    await service.consumeEvents({ events: [event] });
+
+    expect(loggerSpy).toHaveBeenCalledWith(`An unhandled error occurred when consuming events: ${JSON.stringify({ events: [event] })}`);
+    expect(loggerSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/test/integration/controllers/vmQuery.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/vmQuery.controller.e2e-spec.ts
@@ -1,0 +1,76 @@
+import { BadRequestException } from "@nestjs/common";
+import { TestingModule, Test } from "@nestjs/testing";
+import { VmQueryController } from "src/endpoints/vm.query/vm.query.controller";
+import { VmQueryService } from "src/endpoints/vm.query/vm.query.service";
+
+describe('VmQueryController', () => {
+  let vmQueryController: VmQueryController;
+  let vmQueryService: VmQueryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VmQueryController],
+      providers: [
+        {
+          provide: VmQueryService,
+          useValue: {
+            vmQueryFullResult: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    vmQueryController = module.get<VmQueryController>(VmQueryController);
+    vmQueryService = module.get<VmQueryService>(VmQueryService);
+  });
+
+  it('should be defined', () => {
+    expect(vmQueryController).toBeDefined();
+  });
+
+  describe('query', () => {
+    it('should return the data if the vm query is successful', async () => {
+      const mockResult = {
+        data: {
+          data: {
+            returnData: 'dummy data',
+          },
+        },
+      };
+      jest.spyOn(vmQueryService, 'vmQueryFullResult').mockResolvedValue(mockResult);
+
+      const result = await vmQueryController.query({
+        scAddress: 'dummy',
+        funcName: 'dummy',
+        caller: 'dummy',
+        args: [],
+        value: 'dummy',
+      });
+
+      expect(result).toEqual(mockResult.data.data);
+    });
+
+    it('should throw a BadRequestException if the vm query fails', async () => {
+      const mockResult = {
+        data: {
+          data: {
+            returnData: null,
+            returnCode: 'dummy code',
+            returnMessage: 'dummy message',
+          },
+        },
+      };
+      jest.spyOn(vmQueryService, 'vmQueryFullResult').mockResolvedValue(mockResult);
+
+      await expect(
+        vmQueryController.query({
+          scAddress: 'dummy',
+          funcName: 'dummy',
+          caller: 'dummy',
+          args: [],
+          value: 'dummy',
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/test/integration/services/vmQuery.service.e2e-spec.ts
+++ b/src/test/integration/services/vmQuery.service.e2e-spec.ts
@@ -1,0 +1,128 @@
+import { CacheService } from "@multiversx/sdk-nestjs-cache";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { TestingModule, Test } from "@nestjs/testing";
+import { GatewayService } from "src/common/gateway/gateway.service";
+import { ProtocolService } from "src/common/protocol/protocol.service";
+import { SettingsService } from "src/common/settings/settings.service";
+import { VmQueryService } from "src/endpoints/vm.query/vm.query.service";
+
+describe('VmQueryService', () => {
+  let service: VmQueryService;
+  let cacheService: CacheService;
+  let gatewayService: GatewayService;
+  let protocolService: ProtocolService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VmQueryService,
+        {
+          provide: CacheService,
+          useValue: {
+            getOrSet: jest.fn(),
+          },
+        },
+        {
+          provide: GatewayService,
+          useValue: {
+            createRaw: jest.fn(),
+          },
+        },
+        {
+          provide: ProtocolService,
+          useValue: {
+            getSecondsRemainingUntilNextRound: jest.fn(),
+          },
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            getUseVmQueryTracingFlag: jest.fn(),
+          },
+        },
+        EventEmitter2,
+      ],
+    }).compile();
+
+    service = module.get<VmQueryService>(VmQueryService);
+    cacheService = module.get<CacheService>(CacheService);
+    gatewayService = module.get<GatewayService>(GatewayService);
+    protocolService = module.get<ProtocolService>(ProtocolService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('vmQueryFullResult', () => {
+    const contract = 'contract';
+    const func = 'func';
+    const caller = 'caller';
+    const args = ['arg1', 'arg2'];
+    const value = 'value';
+    const key = `vm-query:${contract}:${func}:${caller}@${args.join('@')}`;
+
+    beforeEach(() => {
+      jest.spyOn(protocolService, 'getSecondsRemainingUntilNextRound').mockResolvedValue(10);
+    });
+
+    it('should call CacheService.getOrSet with the correct arguments', async () => {
+      jest.spyOn(gatewayService, 'createRaw').mockResolvedValue({ data: {} });
+      await service.vmQueryFullResult(contract, func, caller, args, value);
+      expect(cacheService.getOrSet).toHaveBeenCalledWith(key, expect.any(Function), 10, 10);
+    });
+  });
+
+  describe('vmQuery', () => {
+    const contract = 'contract';
+    const func = 'func';
+    const caller = 'caller';
+    const args = ['arg1', 'arg2'];
+    const value = 'value';
+    const returnData = ['returnData1', 'returnData2'];
+    const vmQueryResult = { data: { data: { returnData } } };
+
+    beforeEach(() => {
+      jest.spyOn(protocolService, 'getSecondsRemainingUntilNextRound').mockResolvedValue(10);
+    });
+
+    it('should return the vm query result if skipCache is true', async () => {
+      jest.spyOn(service, 'vmQueryRaw').mockResolvedValue(vmQueryResult);
+      const result = await service.vmQuery(contract, func, caller, args, value, true);
+      expect(result).toBe(returnData);
+    });
+
+    it('should return the vm query result if skipCache is false', async () => {
+      jest.spyOn(cacheService, 'getOrSet').mockResolvedValue(vmQueryResult);
+      const result = await service.vmQuery(contract, func, caller, args, value, false);
+      expect(result).toBe(returnData);
+    });
+
+    it('should throw an error if the vm query fails', async () => {
+      const error = new Error('VM query failed');
+      jest.spyOn(service, 'vmQueryRaw').mockRejectedValue(error);
+      await expect(service.vmQuery(contract, func, caller, args, value)).rejects.toThrow("Cannot read properties of undefined (reading 'data')");
+    });
+  });
+
+  describe('vmQueryRaw', () => {
+    const contract = 'contract';
+    const func = 'func';
+    const caller = 'caller';
+    const args = ['arg1', 'arg2'];
+    const value = 'value';
+    const vmQueryResult = { data: {} };
+
+    it('should return the vm query result', async () => {
+      jest.spyOn(gatewayService, 'createRaw').mockResolvedValue(vmQueryResult);
+      const result = await service.vmQueryRaw(contract, func, caller, args, value);
+      expect(result).toBe(vmQueryResult.data);
+    });
+
+    it('should throw an error if the vm query fails', async () => {
+      const error = new Error('VM query failed');
+      jest.spyOn(gatewayService, 'createRaw').mockRejectedValue(error);
+      await expect(service.vmQueryRaw(contract, func, caller, args, value)).rejects.toThrow(error);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed Changes
-  add new unit tests for all services from /common directory

## How to test
To run the persistence.service.e2e-spec.ts you need to enable database from config!
- npm run test:e2e persistence.service.e2e-spec.ts
- npm run test:e2e rabbitmq.consumer.e2e-spec.ts
