### PR TITLE
return if no upgrades are available for address

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -933,14 +933,8 @@ export class AccountController {
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-  ): Promise<ContractUpgrades[] | null> {
-    const upgrades = this.accountService.getContractUpgrades(new QueryPagination({ from, size }), address);
-
-    if (!upgrades) {
-      throw new NotFoundException();
-    }
-
-    return upgrades;
+  ): Promise<ContractUpgrades[]> {
+    return this.accountService.getContractUpgrades(new QueryPagination({ from, size }), address);
   }
 
   @Get("/accounts/:address/results")

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -494,10 +494,10 @@ export class AccountService {
     return await this.indexerService.getAccountContractsCount(address);
   }
 
-  async getContractUpgrades(queryPagination: QueryPagination, address: string): Promise<ContractUpgrades[] | null> {
+  async getContractUpgrades(queryPagination: QueryPagination, address: string): Promise<ContractUpgrades[]> {
     const details = await this.indexerService.getScDeploy(address);
     if (!details) {
-      return null;
+      return [];
     }
 
     const upgrades = details.upgrades.map(item => ApiUtils.mergeObjects(new ContractUpgrades(), {


### PR DESCRIPTION
## Reasoning
-  When there were no upgrades for an address, the correct status code is not returned
  
## Proposed Changes
- When there were no upgrades, return empty array

## How to test
- `accounts/erd1qqqqqqqqqqqqqpgqeel2kumf0r8ffyhth7pqdujjat9nx0862jpsg2pqaq/upgrades` ->should return upgrades details
- `accounts/erd1rf4hv70arudgzus0ymnnsnc4pml0jkywg2xjvzslg0mz4nn2tg7q7k0t6p/upgrades` -> should return [ ]
