### PR TITLE
sort upgrades descending by timestamp

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -506,6 +506,8 @@ export class AccountService {
       timestamp: item.timestamp,
     }));
 
+    upgrades.sort((a, b) => b.timestamp - a.timestamp);
+
     return upgrades.slice(queryPagination.from, queryPagination.from + queryPagination.size);
   }
 

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -702,6 +702,8 @@ describe('Account Service', () => {
         }),
       );
 
+      upgrades.sort((a, b) => b.timestamp - a.timestamp);
+
       const expectedResult = upgrades.slice(queryPagination.from, queryPagination.from + queryPagination.size);
       expect(result).toEqual(expectedResult);
     });


### PR DESCRIPTION
 
## Proposed Changes
- Sort contracts that have recently been upgraded descending

## How to test
- /accounts/erd1qqqqqqqqqqqqqpgq96n4gxvmw8nxgxud8nv8qmms5namspc5vmusg930sh/upgrades -> first upgrade should be
` {
        "address": "erd1rzv9c5wps2e78lpdq6pf9qkx5wlkr2yceuynmsd98hm3gtp8vmuse6y69m",
        "txHash": "2f64732685a8c04e1eaa6d446a643c5eb6a29247a194525bfaa790ce83f08689",
        "timestamp": 1685392872
 } `
