### PR TITLE
get collection properties from gateway

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -23,6 +23,7 @@ flags:
   useVmQueryTracing: false
   processNfts: true
   indexer-v3: true
+  collectionPropertiesFromGateway: false
 features:
   eventsNotifier:
     enabled: false

--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -22,6 +22,7 @@ flags:
   useKeepAliveAgent: true
   useTracing: false
   indexer-v3: true
+  collectionPropertiesFromGateway: false
 urls:
   self: 'https://api.multiversx.com'
   api:

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -22,6 +22,7 @@ flags:
   useKeepAliveAgent: true
   useTracing: false
   indexer-v3: true
+  collectionPropertiesFromGateway: false
 urls:
   self: 'https://api.multiversx.com'
   api:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -23,6 +23,7 @@ flags:
   useVmQueryTracing: false
   processNfts: true
   indexer-v3: false
+  collectionPropertiesFromGateway: false
 features:
   eventsNotifier:
     enabled: false

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -23,6 +23,7 @@ flags:
   useVmQueryTracing: false
   processNfts: true
   indexer-v3: true
+  collectionPropertiesFromGateway: false
 features:
   eventsNotifier:
     enabled: false

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -224,6 +224,10 @@ export class ApiConfigService {
     return this.configService.get<boolean>('flags.useVmQueryTracing') ?? false;
   }
 
+  getCollectionPropertiesFromGateway(): boolean {
+    return this.configService.get<boolean>('flags.collectionPropertiesFromGateway') ?? false;
+  }
+
   getProvidersUrl(): string {
     const providerUrl = this.configService.get<string>('urls.providers');
     if (providerUrl) {

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -137,10 +137,10 @@ export class CollectionService {
     const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
     await this.cachingService.batchApplyAll(
       identifiers,
-      identifier => CacheInfo.EsdtProperties(identifier).key,
-      identifier => this.esdtService.getEsdtTokenProperties(identifier),
+      identifier => CacheInfo.CollectionProperties(identifier).key,
+      identifier => this.esdtService.getCollectionProperties(identifier),
       (identifier, properties) => collectionsProperties[identifier] = properties,
-      CacheInfo.EsdtProperties('').ttl
+      CacheInfo.CollectionProperties('').ttl
     );
 
     return collectionsProperties;
@@ -217,7 +217,7 @@ export class CollectionService {
   }
 
   async applyCollectionRoles(collection: NftCollectionDetailed | TokenDetailed, elasticCollection: any) {
-    collection.roles = await this.getNftCollectionRoles(elasticCollection);
+    collection.roles = await this.getNftCollectionRolesFromGateway(elasticCollection);
     const isTransferProhibitedByDefault = collection.roles?.some(x => x.canTransfer === true) === true;
     collection.canTransfer = !isTransferProhibitedByDefault;
     if (collection.canTransfer) {
@@ -233,6 +233,10 @@ export class CollectionService {
     }
 
     return this.getNftCollectionRolesFromElasticResponse(elasticCollection);
+  }
+
+  async getNftCollectionRolesFromGateway(elasticCollection: any): Promise<CollectionRoles[]> {
+    return await this.getNftCollectionRolesFromEsdtContract(elasticCollection.token);
   }
 
   private getNftCollectionRolesFromElasticResponse(elasticCollection: any): CollectionRoles[] {

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -134,15 +134,11 @@ export class CollectionService {
   }
 
   async batchGetCollectionsProperties(identifiers: string[]): Promise<{ [key: string]: TokenProperties | undefined }> {
-    const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
-
     if (this.apiConfigService.getCollectionPropertiesFromGateway()) {
-      await this.getCollectionProperties(identifiers, collectionsProperties);
-    } else {
-      await this.getEsdtProperties(identifiers, collectionsProperties);
+      return await this.getCollectionProperties(identifiers);
     }
 
-    return collectionsProperties;
+    return await this.getEsdtProperties(identifiers);
   }
 
   async batchGetCollectionsAssets(identifiers: string[]): Promise<{ [key: string]: TokenAssets | undefined }> {
@@ -386,23 +382,31 @@ export class CollectionService {
     return collectionLogo.svgUrl;
   }
 
-  private async getCollectionProperties(identifiers: string[], collectionsProperties: { [key: string]: TokenProperties | undefined }) {
-    return await this.cachingService.batchApplyAll(
+  private async getCollectionProperties(identifiers: string[]): Promise<{ [key: string]: TokenProperties | undefined }> {
+    const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
+
+    await this.cachingService.batchApplyAll(
       identifiers,
       identifier => CacheInfo.CollectionProperties(identifier).key,
       identifier => this.esdtService.getCollectionProperties(identifier),
       (identifier, properties) => collectionsProperties[identifier] = properties,
       CacheInfo.CollectionProperties('').ttl
     );
+
+    return collectionsProperties;
   }
 
-  private async getEsdtProperties(identifiers: string[], collectionsProperties: { [key: string]: TokenProperties | undefined }) {
-    return await this.cachingService.batchApplyAll(
+  private async getEsdtProperties(identifiers: string[]): Promise<{ [key: string]: TokenProperties | undefined }> {
+    const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
+
+    await this.cachingService.batchApplyAll(
       identifiers,
       identifier => CacheInfo.EsdtProperties(identifier).key,
       identifier => this.esdtService.getEsdtTokenProperties(identifier),
       (identifier, properties) => collectionsProperties[identifier] = properties,
       CacheInfo.EsdtProperties('').ttl
     );
+
+    return collectionsProperties;
   }
 }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -135,13 +135,24 @@ export class CollectionService {
 
   async batchGetCollectionsProperties(identifiers: string[]): Promise<{ [key: string]: TokenProperties | undefined }> {
     const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
-    await this.cachingService.batchApplyAll(
-      identifiers,
-      identifier => CacheInfo.CollectionProperties(identifier).key,
-      identifier => this.esdtService.getCollectionProperties(identifier),
-      (identifier, properties) => collectionsProperties[identifier] = properties,
-      CacheInfo.CollectionProperties('').ttl
-    );
+
+    if (this.apiConfigService.getCollectionPropertiesFromGateway()) {
+      await this.cachingService.batchApplyAll(
+        identifiers,
+        identifier => CacheInfo.CollectionProperties(identifier).key,
+        identifier => this.esdtService.getCollectionProperties(identifier),
+        (identifier, properties) => collectionsProperties[identifier] = properties,
+        CacheInfo.CollectionProperties('').ttl
+      );
+    } else {
+      await this.cachingService.batchApplyAll(
+        identifiers,
+        identifier => CacheInfo.EsdtProperties(identifier).key,
+        identifier => this.esdtService.getEsdtTokenProperties(identifier),
+        (identifier, properties) => collectionsProperties[identifier] = properties,
+        CacheInfo.EsdtProperties('').ttl
+      );
+    }
 
     return collectionsProperties;
   }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -137,21 +137,9 @@ export class CollectionService {
     const collectionsProperties: { [key: string]: TokenProperties | undefined } = {};
 
     if (this.apiConfigService.getCollectionPropertiesFromGateway()) {
-      await this.cachingService.batchApplyAll(
-        identifiers,
-        identifier => CacheInfo.CollectionProperties(identifier).key,
-        identifier => this.esdtService.getCollectionProperties(identifier),
-        (identifier, properties) => collectionsProperties[identifier] = properties,
-        CacheInfo.CollectionProperties('').ttl
-      );
+      await this.getCollectionProperties(identifiers, collectionsProperties);
     } else {
-      await this.cachingService.batchApplyAll(
-        identifiers,
-        identifier => CacheInfo.EsdtProperties(identifier).key,
-        identifier => this.esdtService.getEsdtTokenProperties(identifier),
-        (identifier, properties) => collectionsProperties[identifier] = properties,
-        CacheInfo.EsdtProperties('').ttl
-      );
+      await this.getEsdtProperties(identifiers, collectionsProperties);
     }
 
     return collectionsProperties;
@@ -396,5 +384,25 @@ export class CollectionService {
     }
 
     return collectionLogo.svgUrl;
+  }
+
+  private async getCollectionProperties(identifiers: string[], collectionsProperties: { [key: string]: TokenProperties | undefined }) {
+    return await this.cachingService.batchApplyAll(
+      identifiers,
+      identifier => CacheInfo.CollectionProperties(identifier).key,
+      identifier => this.esdtService.getCollectionProperties(identifier),
+      (identifier, properties) => collectionsProperties[identifier] = properties,
+      CacheInfo.CollectionProperties('').ttl
+    );
+  }
+
+  private async getEsdtProperties(identifiers: string[], collectionsProperties: { [key: string]: TokenProperties | undefined }) {
+    return await this.cachingService.batchApplyAll(
+      identifiers,
+      identifier => CacheInfo.EsdtProperties(identifier).key,
+      identifier => this.esdtService.getEsdtTokenProperties(identifier),
+      (identifier, properties) => collectionsProperties[identifier] = properties,
+      CacheInfo.EsdtProperties('').ttl
+    );
   }
 }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -168,7 +168,7 @@ export class EsdtService {
 
   async getAllFungibleTokenProperties(): Promise<TokenProperties[]> {
     const isIndexerV5Active = await this.elasticIndexerService.isIndexerV5Active();
-    if (isIndexerV5Active) {
+    if (isIndexerV5Active && !this.apiConfigService.getCollectionPropertiesFromGateway()) {
       return await this.getAllFungibleTokenPropertiesFromElastic();
     } else {
       return await this.getAllFungibleTokenPropertiesFromGateway();

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -46,6 +46,21 @@ export class EsdtService {
     return properties;
   }
 
+  async getCollectionProperties(identifier: string): Promise<TokenProperties | undefined> {
+    const properties = await this.cachingService.getOrSet(
+      CacheInfo.CollectionProperties(identifier).key,
+      async () => await this.getEsdtTokenPropertiesRawFromGateway(identifier),
+      Constants.oneWeek(),
+      CacheInfo.CollectionProperties(identifier).ttl
+    );
+
+    if (!properties) {
+      return undefined;
+    }
+
+    return properties;
+  }
+
   async getEsdtAddressesRoles(identifier: string): Promise<TokenRoles[] | undefined> {
     const addressesRoles = await this.cachingService.getOrSet(
       CacheInfo.EsdtAddressesRoles(identifier).key,

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -77,8 +77,9 @@ export class EsdtService {
   }
 
   async getEsdtTokenPropertiesRaw(identifier: string): Promise<TokenProperties | null> {
+    const getCollectionPropertiesFromGateway = this.apiConfigService.getCollectionPropertiesFromGateway();
     const isIndexerV5Active = await this.elasticIndexerService.isIndexerV5Active();
-    if (isIndexerV5Active) {
+    if (isIndexerV5Active && !getCollectionPropertiesFromGateway) {
       return await this.getEsdtTokenPropertiesRawFromElastic(identifier);
     } else {
       return await this.getEsdtTokenPropertiesRawFromGateway(identifier);

--- a/src/test/integration/controllers/collections.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/collections.controller.e2e-spec.ts
@@ -59,8 +59,8 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             traits: [],
           }];
 
@@ -91,8 +91,8 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: true,
-            canAddSpecialRoles: true,
+            canUpgrade: false,
+            canAddSpecialRoles: false,
             traits: [],
           },
           {
@@ -264,8 +264,8 @@ describe("collections Controller", () => {
         canTransfer: true,
         canTransferNftCreateRole: false,
         canChangeOwner: false,
-        canUpgrade: true,
-        canAddSpecialRoles: true,
+        canUpgrade: false,
+        canAddSpecialRoles: false,
         roles: [
           {
             address: "erd1qqqqqqqqqqqqqpgq8ne37ed06034qxfhm09f03ykjfqwx8s7hvrqackmzt",

--- a/src/test/integration/controllers/collections.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/collections.controller.e2e-spec.ts
@@ -59,7 +59,7 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: true,
+            canUpgrade: false,
             canAddSpecialRoles: true,
             traits: [],
           }];

--- a/src/test/integration/controllers/collections.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/collections.controller.e2e-spec.ts
@@ -59,7 +59,7 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: false,
+            canUpgrade: true,
             canAddSpecialRoles: true,
             traits: [],
           }];

--- a/src/test/integration/controllers/collections.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/collections.controller.e2e-spec.ts
@@ -59,8 +59,8 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: false,
-            canAddSpecialRoles: false,
+            canUpgrade: true,
+            canAddSpecialRoles: true,
             traits: [],
           }];
 
@@ -91,8 +91,8 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             canChangeOwner: false,
-            canUpgrade: false,
-            canAddSpecialRoles: false,
+            canUpgrade: true,
+            canAddSpecialRoles: true,
             traits: [],
           },
           {
@@ -264,8 +264,8 @@ describe("collections Controller", () => {
         canTransfer: true,
         canTransferNftCreateRole: false,
         canChangeOwner: false,
-        canUpgrade: false,
-        canAddSpecialRoles: false,
+        canUpgrade: true,
+        canAddSpecialRoles: true,
         roles: [
           {
             address: "erd1qqqqqqqqqqqqqpgq8ne37ed06034qxfhm09f03ykjfqwx8s7hvrqackmzt",

--- a/src/test/integration/services/api.config.e2e-spec.ts
+++ b/src/test/integration/services/api.config.e2e-spec.ts
@@ -843,6 +843,17 @@ describe('API Config', () => {
     });
   });
 
+  describe("getCollectionPropertiesFromGateway", () => {
+    it("should return collection properties from gateway flag", () => {
+      jest
+        .spyOn(ConfigService.prototype, "get")
+        .mockImplementation(jest.fn(() => true));
+
+      const results = apiConfigService.getCollectionPropertiesFromGateway();
+      expect(results).toEqual(true);
+    });
+  });
+
   describe("getIsAuthActive", () => {
     it("should return is auth active flag", () => {
       jest

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -190,6 +190,13 @@ export class CacheInfo {
     };
   }
 
+  static CollectionProperties(identifier: string): CacheInfo {
+    return {
+      key: `collection:${identifier}`,
+      ttl: Constants.oneDay(),
+    };
+  }
+
   static EsdtAddressesRoles(identifier: string): CacheInfo {
     return {
       key: `esdt:roles:${identifier}`,


### PR DESCRIPTION

## Proposed Changes
-  For the GatewayService, we need to retrieve the NFT collection properties roles from Gateway

## How to test
-  collections/SHIBAX-7baf9d 

- `before changes`:
 "canUpgrade": false,
 "canAddSpecialRoles": false,

- ` after changes`:
  "canUpgrade": true,
  "canAddSpecialRoles": true