### PR TITLE
add remainingUnbondPeriod

### DIFF
--- a/src/endpoints/nodes/entities/node.ts
+++ b/src/endpoints/nodes/entities/node.ts
@@ -133,4 +133,8 @@ export class Node {
   @Field(() => Number, { description: "Sync progress in case the node is currently in sync mode. If specified, the value can be between 0 and 1.", nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   syncProgress: number | undefined = undefined;
+
+  @Field(() => Number, { description: "Remaining UnBond Period for node with status leaving.", nullable: true })
+  @ApiProperty({ type: Number, example: 10 })
+  remainingUnBondPeriod: number | undefined = 0;
 }

--- a/src/endpoints/nodes/node.module.ts
+++ b/src/endpoints/nodes/node.module.ts
@@ -5,6 +5,7 @@ import { ProviderModule } from "../providers/provider.module";
 import { StakeModule } from "../stake/stake.module";
 import { VmQueryModule } from "../vm.query/vm.query.module";
 import { NodeService } from "./node.service";
+import { KeysModule } from "../keys/keys.module";
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { NodeService } from "./node.service";
     VmQueryModule,
     forwardRef(() => BlockModule),
     forwardRef(() => StakeModule),
+    forwardRef(() => KeysModule),
   ],
   providers: [
     NodeService,

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -272,14 +272,18 @@ export class NodeService {
   }
 
   private async applyNodeUnbondingPeriods(nodes: Node[]): Promise<void> {
-    await Promise.all(nodes.map(async node => {
-      if (node.status === NodeStatus.leaving) {
-        const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.bls);
-        node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;
-      } else {
+    const leavingNodes = nodes.filter(node => node.status === NodeStatus.leaving);
+
+    await Promise.all(leavingNodes.map(async node => {
+      const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.bls);
+      node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;
+    }));
+
+    for (const node of nodes) {
+      if (node.status !== NodeStatus.leaving) {
         node.remainingUnBondPeriod = undefined;
       }
-    }));
+    }
   }
 
   private async applyNodeStakeInfo(nodes: Node[]) {

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -19,6 +19,7 @@ import { AddressUtils } from "@multiversx/sdk-nestjs-common";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { NodeSort } from "./entities/node.sort";
 import { ProtocolService } from "src/common/protocol/protocol.service";
+import { KeysService } from "../keys/keys.service";
 
 @Injectable()
 export class NodeService {
@@ -32,6 +33,7 @@ export class NodeService {
     @Inject(forwardRef(() => BlockService))
     private readonly blockService: BlockService,
     private readonly protocolService: ProtocolService,
+    private readonly keysService: KeysService
   ) { }
 
   private getIssues(node: Node, version: string | undefined): string[] {
@@ -269,6 +271,17 @@ export class NodeService {
     }
   }
 
+  private async applyNodeUnbondingPeriods(nodes: Node[]): Promise<void> {
+    await Promise.all(nodes.map(async node => {
+      if (node.status === NodeStatus.leaving) {
+        const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.bls);
+        node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;
+      } else {
+        node.remainingUnBondPeriod = undefined;
+      }
+    }));
+  }
+
   private async applyNodeStakeInfo(nodes: Node[]) {
     let addresses = nodes
       .filter(({ type }) => type === NodeType.validator)
@@ -319,6 +332,8 @@ export class NodeService {
       const auctions = await this.gatewayService.getValidatorAuctions();
       this.processAuctions(nodes, auctions);
     }
+
+    await this.applyNodeUnbondingPeriods(nodes);
 
     return nodes;
   }

--- a/src/test/integration/services/nodes.e2e-spec.ts
+++ b/src/test/integration/services/nodes.e2e-spec.ts
@@ -14,6 +14,7 @@ import { NodeStatus } from "src/endpoints/nodes/entities/node.status";
 import { NodeType } from "src/endpoints/nodes/entities/node.type";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { NodeSort } from "src/endpoints/nodes/entities/node.sort";
+import { KeysService } from "src/endpoints/keys/keys.service";
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -85,6 +86,13 @@ describe('NodeService', () => {
             getShardIds: jest.fn(),
           },
         },
+        {
+          provide: KeysService,
+          useValue: {
+            getKeyUnbondPeriod: jest.fn(),
+          },
+        },
+
       ],
     }).compile();
 


### PR DESCRIPTION
## Reasoning
- Not all nodes should have the `remainingUnBondPeriod` attribute, only those with the status `NodeStatus.leaving`. For other nodes, this attribute should be undefined, not 0.
  
## Proposed Changes
- Added a function `applyNodeUnbondingPeriods` in the NodeService. This function assigns each node's `remainingUnBondPeriod` attribute by calling `keysService.getKeyUnbondPeriod` if the node status is NodeStatus.leaving. If not, `remainingUnBondPeriod` is set to undefined.
- Updated the `getAllNodesRaw()` function in `NodeService` to call the new `applyNodeUnbondingPeriods` function, adding remainingUnBondPeriod to all nodes with the status NodeStatus.leaving in the process.

## How to test ( DEVNET)
- Add node -> Stake node -> Unstake node -> all from web wallet
- After this stepts, take the bls key and add it to nodes/:bls
- Response body should contains `remainingUnbondPeriod`

example:
- `nodes/204ee6c9a68a6a0d5a4af5426d5a34b1ff0a5c62d0f93ee09aabbc54ad7f864b1f7c69d6d832d98425ce8626884cb611248e1004c02bb95acb821231195f388c8cc2dd7cb79c4f35d77bfb814dc5e5e297013252622320374eb744beb26a4794` -> should contains `remainingUnbondPeriod`