### PR TITLE
add support for remainingUnbondPeriod for account keys

### DIFF
--- a/src/endpoints/accounts/account.module.ts
+++ b/src/endpoints/accounts/account.module.ts
@@ -14,6 +14,7 @@ import { VmQueryModule } from "../vm.query/vm.query.module";
 import { WaitingListModule } from "../waiting-list/waiting.list.module";
 import { AccountService } from "./account.service";
 import { ProviderModule } from "../providers/provider.module";
+import { KeysModule } from "../keys/keys.module";
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { ProviderModule } from "../providers/provider.module";
     forwardRef(() => AssetsModule),
     forwardRef(() => ProviderModule),
     UsernameModule,
+    forwardRef(() => KeysModule),
   ],
   providers: [
     AccountService,

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -533,7 +533,7 @@ export class AccountService {
   }
 
   private async applyNodeUnbondingPeriods(nodes: AccountKey[]): Promise<void> {
-    const leavingNodes = nodes.filter(node => node.status === 'leaving');
+    const leavingNodes = nodes.filter(node => node.status === 'unStaked');
     await Promise.all(leavingNodes.map(async node => {
       const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.blsKey);
       node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -421,7 +421,7 @@ export class AccountService {
 
       const accountKey: AccountKey = new AccountKey;
       accountKey.blsKey = BinaryUtils.padHex(Buffer.from(encodedBlsKey, 'base64').toString('hex'));
-      accountKey.status = Buffer.from(encodedStatus, 'base64').toString();
+      accountKey.status = Buffer.from(encodedStatus, 'base64').toString() === 'unStaked' ? 'leaving' : Buffer.from(encodedStatus, 'base64').toString();
       accountKey.stake = '2500000000000000000000';
 
       nodes.push(accountKey);
@@ -533,7 +533,7 @@ export class AccountService {
   }
 
   private async applyNodeUnbondingPeriods(nodes: AccountKey[]): Promise<void> {
-    const leavingNodes = nodes.filter(node => node.status === 'unStaked');
+    const leavingNodes = nodes.filter(node => node.status === 'leaving');
     await Promise.all(leavingNodes.map(async node => {
       const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.blsKey);
       node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -421,7 +421,7 @@ export class AccountService {
 
       const accountKey: AccountKey = new AccountKey;
       accountKey.blsKey = BinaryUtils.padHex(Buffer.from(encodedBlsKey, 'base64').toString('hex'));
-      accountKey.status = Buffer.from(encodedStatus, 'base64').toString() === 'unStaked' ? 'leaving' : Buffer.from(encodedStatus, 'base64').toString();
+      accountKey.status = Buffer.from(encodedStatus, 'base64').toString();
       accountKey.stake = '2500000000000000000000';
 
       nodes.push(accountKey);

--- a/src/endpoints/accounts/entities/account.key.ts
+++ b/src/endpoints/accounts/entities/account.key.ts
@@ -36,4 +36,8 @@ export class AccountKey {
   @Field(() => String, { description: 'Queue size for the given provider account.', nullable: true })
   @ApiProperty({ type: String, nullable: true, example: '100' })
   queueSize: string | undefined = undefined;
+
+  @Field(() => Number, { description: "Remaining UnBond Period for node with status leaving.", nullable: true })
+  @ApiProperty({ type: Number, example: 10 })
+  remainingUnBondPeriod: number | undefined = 0;
 }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -606,7 +606,7 @@ export class NodeService {
         }
       }
 
-      if (node.status === NodeStatus.inactive && node.remainingUnBondPeriod === 0) {
+      if (node.remainingUnBondPeriod !== undefined && node.remainingUnBondPeriod >= 0) {
         node.status = NodeStatus.leaving;
       }
 

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -606,6 +606,10 @@ export class NodeService {
         }
       }
 
+      if (node.status === NodeStatus.inactive && node.remainingUnBondPeriod === 0) {
+        node.status = NodeStatus.leaving;
+      }
+
       node.issues = this.getIssues(node, config.erd_latest_tag_software_version);
 
       nodes.push(node);

--- a/src/endpoints/providers/entities/provider.filter.ts
+++ b/src/endpoints/providers/entities/provider.filter.ts
@@ -6,4 +6,6 @@ export class ProviderFilter {
   identity: string | undefined = undefined;
 
   providers: string[] | undefined = undefined;
+
+  owner: string | undefined = undefined;
 } 

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -15,15 +15,17 @@ export class ProviderController {
   @ApiOperation({ summary: 'Providers', description: 'Returns a list of all providers' })
   @ApiOkResponse({ type: [Provider] })
   @ApiQuery({ name: 'identity', description: 'Search by identity', required: false })
+  @ApiQuery({ name: 'owner', description: 'Search by owner', required: false })
   @ApiQuery({ name: 'providers', description: 'Search by multiple providers address', required: false })
   @ApiQuery({ name: 'withIdentityInfo', description: 'Returns identity data for providers', required: false })
   async getProviders(
     @Query('identity') identity?: string,
+    @Query('owner', ParseAddressPipe) owner?: string,
     @Query('providers', ParseAddressArrayPipe) providers?: string[],
     @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
   ): Promise<Provider[]> {
     return await this.providerService.getProviders(
-      new ProviderFilter({ identity, providers }),
+      new ProviderFilter({ identity, providers, owner }),
       withIdentityInfo);
   }
 

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -429,6 +429,10 @@ export class ProviderService {
       providers = providers.filter(x => x.provider && filter.providers?.includes(x.provider));
     }
 
+    if (filter.owner) {
+      providers = providers.filter((provider) => provider.owner === filter.owner);
+    }
+
     return providers;
   }
 

--- a/src/test/integration/services/accounts.e2e-spec.ts
+++ b/src/test/integration/services/accounts.e2e-spec.ts
@@ -17,6 +17,7 @@ import { AccountFilter } from "src/endpoints/accounts/entities/account.filter";
 import { AccountHistory } from "src/endpoints/accounts/entities/account.history";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { ContractUpgrades } from "src/endpoints/accounts/entities/contract.upgrades";
+import { KeysService } from "src/endpoints/keys/keys.service";
 import { ProviderService } from "src/endpoints/providers/provider.service";
 import { SmartContractResultService } from "src/endpoints/sc-results/scresult.service";
 import { StakeService } from "src/endpoints/stake/stake.service";
@@ -147,6 +148,12 @@ describe('Account Service', () => {
           provide: ProviderService,
           useValue: {
             getProvider: jest.fn(),
+          },
+        },
+        {
+          provide: KeysService,
+          useValue: {
+            getKeyUnbondPeriod: jest.fn(),
           },
         },
       ],

--- a/src/test/integration/services/delegation.e2e-spec.ts
+++ b/src/test/integration/services/delegation.e2e-spec.ts
@@ -107,6 +107,7 @@ describe('Delegation Service', () => {
         fullHistory: undefined,
         issues: [],
         syncProgress: undefined,
+        remainingUnBondPeriod: undefined,
       },
     ];
   });


### PR DESCRIPTION
## Reasoning
-  Same as PR ( https://github.com/multiversx/mx-api-service/pull/1078 ), we added the remainingUnbondPeriod field for accounts/:address/keys
  
## Proposed Changes
- Added a function `applyNodeUnbondingPeriods` in the `AccountService`. This function assigns each node's `remainingUnBondPeriod` attribute by calling `keysService.getKeyUnbondPeriod` if the node status is `NodeStatus.leaving`. If not, `remainingUnBondPeriod` is set to undefined.

- Add new provider filter ( owner ) to be able to search providers via owner address
- Fix delegation.e2e-spec.ts

## How to test
- On DEVNET -> `accounts/erd14wxx9p9kld06w66n6lcxcchv976n7crzma8w7s3tkaqcme8hr7fqdhhfdg/keys` -> `remainingUnbondPeriod` field
- On MAINNET -> `providers?owner=erd1p3423t9rj5nxnqnyz2hzr43xrddxvzggwhp0amjgyhr4v939vstsmh6vtc&withIdentityInfo=true` -> should return provider details with owner `erd1p3423t9rj5nxnqnyz2hzr43xrddxvzggwhp0amjgyhr4v939vstsmh6vtc` and if `withIdentityInfo` filter is defined, should return `identityInfo` object
