### PR TITLE
Collection name fallback in transaction operation

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -153,7 +153,7 @@ export class TokenTransferService {
 
       for (const operation of operations) {
         if (elasticNftsDict[operation.identifier]) {
-          operation.name = operation.name ?? elasticNftsDict[operation.identifier].data?.name;
+          operation.name = elasticNftsDict[operation.identifier].data?.name ?? operation.name;
         }
       }
     }

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -153,7 +153,7 @@ export class TokenTransferService {
 
       for (const operation of operations) {
         if (elasticNftsDict[operation.identifier]) {
-          operation.name = elasticNftsDict[operation.identifier].data?.name;
+          operation.name = operation.name ?? elasticNftsDict[operation.identifier].data?.name;
         }
       }
     }


### PR DESCRIPTION
## Reasoning
- If NFT does not have a name indexed, nothing is returned in the operation name field, although we have the collection name in memory
  
## Proposed Changes
- Use collection name as a fallback in transaction operation

## How to test (devnet)
- `/transactions/5d09e2bb17fa0ee3a5e8e9d40523cd25f9f449f5eb7aae62e29a4f20a7c395ab` should return collection name in operation
