### PR TITLE
Account token identifier fix if smart contract

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -243,7 +243,7 @@ export class TokenService {
 
         const tokenWithBalance: TokenWithBalance = {
           ...token,
-          identifier: elasticToken.identifier,
+          identifier: elasticToken.identifier ?? elasticToken.token,
           ticker: elasticToken.identifier,
           balance: elasticToken.balance,
           attributes: elasticToken.data?.attributes,


### PR DESCRIPTION
## Reasoning
- FungibleESDT Token identifiers are not returned if they are fetched from elasticsearch for a given account
  
## Proposed Changes
- fall back to the `token` field if no `identifier` is present

## How to test
- `/accounts/:smart-contract-account/tokens` should return identifiers for fungible tokens
