### PR TITLE
add support for notStaked nodes and add support for multiple keys filter

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -34,7 +34,7 @@ import { ProtocolService } from 'src/common/protocol/protocol.service';
 import { ProviderService } from '../providers/provider.service';
 import { Provider } from '../providers/entities/provider';
 import { KeysService } from '../keys/keys.service';
-import { NodeGatewayStatus } from '../nodes/entities/node.status';
+import { NodeStatusRaw } from '../nodes/entities/node.status';
 
 @Injectable()
 export class AccountService {
@@ -414,8 +414,8 @@ export class AccountService {
     let notStakedNodes: AccountKey[] = [];
 
     const checkIfCurrentItemIsStatus = (currentNodeData: string) =>
-      Object.values(NodeGatewayStatus).includes(
-        currentNodeData as NodeGatewayStatus
+      Object.values(NodeStatusRaw).includes(
+        currentNodeData as NodeStatusRaw
       );
 
     if (isStakingProvider) {
@@ -428,7 +428,7 @@ export class AccountService {
         (totalNodes: string[], currentNodeState, nodeIndex, allNodesDataArray) => {
           const decodedData = Buffer.from(currentNodeState, 'base64').toString();
           const isNotStakedStatus =
-            decodedData === NodeGatewayStatus.notStaked;
+            decodedData === NodeStatusRaw.notStaked;
 
           const isCurrentItemTheStatus = checkIfCurrentItemIsStatus(decodedData);
 
@@ -455,7 +455,7 @@ export class AccountService {
       notStakedNodes = inactiveNodesBuffers.map((inactiveNodeBuffer) => {
         const accountKey: AccountKey = new AccountKey();
         accountKey.blsKey = BinaryUtils.padHex(Buffer.from(inactiveNodeBuffer, 'base64').toString('hex'));
-        accountKey.status = NodeGatewayStatus.notStaked;
+        accountKey.status = NodeStatusRaw.notStaked;
         accountKey.stake = '2500000000000000000000';
         return accountKey;
       });

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -441,6 +441,10 @@ export class AccountService {
   }
 
   getInactiveNodesBuffers(allNodeStates: string[]): string[] {
+    if (!allNodeStates) {
+      return [];
+    }
+
     const checkIfCurrentItemIsStatus = (currentNodeData: string) =>
       Object.values(NodeStatusRaw).includes(
         currentNodeData as NodeStatusRaw

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -408,6 +408,13 @@ export class AccountService {
     return AddressUtils.bech32Encode(rewardsPublicKey);
   }
 
+  private async getAllNodeStates(address: string) {
+    return await this.vmQueryService.vmQuery(
+      address,
+      'getAllNodeStates'
+    );
+  }
+
   async getKeys(address: string): Promise<AccountKey[]> {
     const publicKey = AddressUtils.bech32Decode(address);
     const isStakingProvider = await this.providerService.isProvider(address);
@@ -415,11 +422,7 @@ export class AccountService {
     let notStakedNodes: AccountKey[] = [];
 
     if (isStakingProvider) {
-      const allNodeStates = await this.vmQueryService.vmQuery(
-        address,
-        'getAllNodeStates'
-      );
-
+      const allNodeStates = await this.getAllNodeStates(address);
       const inactiveNodesBuffers = this.getInactiveNodesBuffers(allNodeStates);
       notStakedNodes = this.createNotStakedNodes(inactiveNodesBuffers);
     }

--- a/src/endpoints/nodes/entities/node.filter.ts
+++ b/src/endpoints/nodes/entities/node.filter.ts
@@ -48,4 +48,7 @@ export class NodeFilter {
 
   @Field(() => SortOrder, { description: "Node order filter .", nullable: true })
   order: SortOrder | undefined;
+
+  @Field(() => [String], { description: "Search by multiple keys, comma-separated.", nullable: true })
+  keys: string[] | undefined;
 } 

--- a/src/endpoints/nodes/entities/node.status.ts
+++ b/src/endpoints/nodes/entities/node.status.ts
@@ -11,6 +11,14 @@ export enum NodeStatus {
   inactive = 'inactive'
 }
 
+export enum NodeGatewayStatus {
+  staked = 'staked',
+  jailed = 'jailed',
+  queued = 'queued',
+  unStaked = 'unStaked',
+  notStaked = 'notStaked'
+}
+
 registerEnumType(NodeStatus, {
   name: 'NodeStatus',
   description: 'Node status object type.',

--- a/src/endpoints/nodes/entities/node.status.ts
+++ b/src/endpoints/nodes/entities/node.status.ts
@@ -55,20 +55,19 @@ registerEnumType(NodeStatusRaw, {
   description: 'Node status raw object type.',
   valuesMap: {
     staked: {
-      description: 'New status.',
+      description: 'Staked raw status.',
     },
     jailed: {
-      description: 'Jailed status.',
+      description: 'Jailed raw status.',
     },
     queued: {
-      description: 'Queued status.',
+      description: 'Queued raw status.',
     },
-
     unStaked: {
-      description: 'UnStaked status.',
+      description: 'UnStaked raw status.',
     },
     notStaked: {
-      description: 'NotStaked status.',
+      description: 'NotStaked raw status.',
     },
   },
 });

--- a/src/endpoints/nodes/entities/node.status.ts
+++ b/src/endpoints/nodes/entities/node.status.ts
@@ -11,7 +11,7 @@ export enum NodeStatus {
   inactive = 'inactive'
 }
 
-export enum NodeGatewayStatus {
+export enum NodeStatusRaw {
   staked = 'staked',
   jailed = 'jailed',
   queued = 'queued',
@@ -46,6 +46,29 @@ registerEnumType(NodeStatus, {
     },
     inactive: {
       description: 'Inactive status.',
+    },
+  },
+});
+
+registerEnumType(NodeStatusRaw, {
+  name: 'NodeStatusRaw',
+  description: 'Node status raw object type.',
+  valuesMap: {
+    staked: {
+      description: 'New status.',
+    },
+    jailed: {
+      description: 'Jailed status.',
+    },
+    queued: {
+      description: 'Queued status.',
+    },
+
+    unStaked: {
+      description: 'UnStaked status.',
+    },
+    notStaked: {
+      description: 'NotStaked status.',
     },
   },
 });

--- a/src/endpoints/nodes/node.controller.ts
+++ b/src/endpoints/nodes/node.controller.ts
@@ -21,6 +21,7 @@ export class NodeController {
   @ApiOkResponse({ type: [Node] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'keys', description: 'Search by multiple keys, comma-separated', required: false })
   @ApiQuery({ name: 'search', description: 'Search by name, bls or version', required: false })
   @ApiQuery({ name: 'online', description: 'Whether node is online or not', required: false, type: 'boolean' })
   @ApiQuery({ name: 'type', description: 'Type of node', required: false, enum: NodeType })
@@ -38,6 +39,7 @@ export class NodeController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
+    @Query('keys') keys?: string[],
     @Query('online', ParseBoolPipe) online?: boolean,
     @Query('type', new ParseEnumPipe(NodeType)) type?: NodeType,
     @Query('status', new ParseEnumPipe(NodeStatus)) status?: NodeStatus,
@@ -51,7 +53,7 @@ export class NodeController {
     @Query('sort', new ParseEnumPipe(NodeSort)) sort?: NodeSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Node[]> {
-    return await this.nodeService.getNodes(new QueryPagination({ from, size }), new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, fullHistory, sort, order }));
+    return await this.nodeService.getNodes(new QueryPagination({ from, size }), new NodeFilter({ search, keys, online, type, status, shard, issues, identity, provider, owner, auctioned, fullHistory, sort, order }));
   }
 
   @Get("/nodes/versions")

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -171,6 +171,10 @@ export class NodeService {
         }
       }
 
+      if (query.keys !== undefined && !query.keys.includes(node.bls)) {
+        return false;
+      }
+
       return true;
     });
 

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -49,7 +49,6 @@ export class ProviderService {
 
       return modifiedProvider;
     }
-
     return provider;
   }
 
@@ -434,6 +433,11 @@ export class ProviderService {
     }
 
     return providers;
+  }
+
+  async isProvider(address: string): Promise<boolean> {
+    const provider = await this.getProvider(address);
+    return !!provider;
   }
 
   private async getProviderIdentity(address: string): Promise<string | undefined> {


### PR DESCRIPTION
## Reasoning
- To be able to return the `notStaked` status for staking providers, we need to add a new vmQuery call.
- In the current implementation, `notStaked` status is not defined
  
## Proposed Changes
- Introduced a conditional check to identify if an address is a `staking provider`. For such addresses, we now fetch all node states using the `getAllNodeStates` vmQuery.
- Implemented a new method getInactiveNodes which extracts nodes in `notStaked` status from the fetched data.
- The `notStaked` nodes are transformed into `AccountKey` objects and appended to the existing `nodes` array which is returned by the getKeys method.
- For non-staking provider addresses, the original logic is maintained to retrieve the `blsKeysStatus` via `getBlsKeysStatusForPublicKey` vmQuery.
- Introduced new nodes filter `keys` to be able to search for multiple nodes keys

## How to test ( DEVNET )
### notStaked
-  Create new delegation manager contract 
-  Add 2 nodes ( 1 staked, 1 leave inactive )
- `accounts/:address/keys` -> should return 1 node with status = Staked, and 1 node with status = notStaked
-  this contract can be used to see different statuses ( `erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqthllllsy5r6rh` )

### multiple keys filter
- `nodes?keys=5eb750c36a86d7b94643f7a685a3fcfa23b27cae38c9bf8c48989df511fa58c25a206e9c061e8569f8ec1ad5ea624b0f8f974be8c3de5d029b8966983758fb6d52c9d2b9fee0ef7f4e8bcd68b63c6fc2cd8a042528526b893ba7eb4989145d8f,775e48fb06a02e838ae3baa2fe57c439585a417b5d93c3e1778d02568a23558c5b2fcbca0dbb90924d62bee814826e007462cbe454657467f5b5efc2640d9ebdd513282c2f82046929872f9473968bee4b96d3a02eaf91d446a672a2068fc10f` -> should return 2 nodes details
