### PR TITLE
 add support for automaticActivation and checkCapOnRedelegate for providers

### DIFF
--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -120,6 +120,14 @@ export class ProviderService {
         if (delegationData.owner) {
           element.owner = delegationData.owner;
         }
+
+        if (delegationData.automaticActivation) {
+          element.automaticActivation = delegationData.automaticActivation;
+        }
+
+        if (delegationData.checkCapOnRedelegate) {
+          element.checkCapOnRedelegate = delegationData.checkCapOnRedelegate;
+        }
       }
 
       // Add Nodes details for provider

--- a/src/test/integration/services/providers.e2e-spec.ts
+++ b/src/test/integration/services/providers.e2e-spec.ts
@@ -283,6 +283,18 @@ describe('Provider Service', () => {
       expect(providerResults.includes("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85")).toBeTruthy();
     });
 
+    it(`should return automaticActivation and checkCapOnRedelegate fields for provider`, async () => {
+      const filter = new ProviderFilter();
+      filter.providers = ["erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu"];
+
+      const results = await providerService.getProviders(filter);
+
+      for (const result of results) {
+        expect(result.automaticActivation).toBeDefined();
+        expect(result.checkCapOnRedelegate).toBeDefined();
+      }
+    });
+
     it("should return providers with stake information", async () => {
       const results = await providerService.getProvidersWithStakeInformation();
 


### PR DESCRIPTION
 
## Proposed Changes
- For `/providers`, all providers should have `automaticActivation` & `checkCapOnRedelegate` fields

## How to test
- `/providers` -> `erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85` -> should contain both fields
- `/providers?providers=erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85` -> should contain both fields 
- `providers?owner=erd1p3423t9rj5nxnqnyz2hzr43xrddxvzggwhp0amjgyhr4v939vstsmh6vtc` -> should contain both fields
