### PR TITLE
add support for operation search

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -432,7 +432,12 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
-        elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.functions, func => QueryType.Match('function', func));
+        for (const field of filter.functions) {
+          elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
+            QueryType.Match('function', field),
+            QueryType.Match('operation', field),
+          ]));
+        }
       }
     }
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -196,7 +196,11 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getTransaction(txHash: string): Promise<any> {
-    return await this.elasticService.getItem('transactions', 'txHash', txHash);
+    const transaction = await this.elasticService.getItem('transactions', 'txHash', txHash);
+
+    this.processTransaction(transaction);
+
+    return transaction;
   }
 
   async getScDeploy(address: string): Promise<any> {
@@ -436,7 +440,19 @@ export class ElasticIndexerService implements IndexerInterface {
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
 
-    return await this.elasticService.getList('transactions', 'txHash', elasticQuery);
+    const transactions = await this.elasticService.getList('transactions', 'txHash', elasticQuery);
+
+    for (const transaction of transactions) {
+      this.processTransaction(transaction);
+    }
+
+    return transactions;
+  }
+
+  private processTransaction(transaction: any) {
+    if (!transaction.function) {
+      transaction.function = transaction.operation;
+    }
   }
 
   private buildTokenFilter(query: ElasticQuery, filter: TokenFilter): ElasticQuery {


### PR DESCRIPTION
## Reasoning
- To be able to search for SetGuardian, UnGuardAccount and GuardAccount, we need to make search in Elastic with operation
  
## Proposed Changes
- Modified the existing filter condition in the ElasticSearch query to support dual-field matching. Now, the query can match values against both `function` and `operation` fields.

## How to test ( TESTNET )
-  `/transactions?function=SetGuardian` -> Should return an array of SetGuardian transactions
-  `/transactions?function=UnGuardAccount` -> Should return an array of UnGuardAccount transactions
-  `/transactions?function=GuardAccount` -> Should return an array of UnGuardAccount transactions
-  `transactions?function=SetGuardian&size=25&sender=erd1v9g8l0dvqhr8aj6df4s3ln3m396qe8yhuj0du546lx0tp8tckgcq9x08k4&receiver=erd1v9g8l0dvqhr8aj6df4s3ln3m396qe8yhuj0du546lx0tp8tckgcq9x08k4` -> should return 3 SetGuardian transactions
