### PR TITLE
Return prices for experimental DEX tokens

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.exchange.ts
+++ b/src/endpoints/mex/entities/mex.pair.exchange.ts
@@ -2,7 +2,6 @@ import { registerEnumType } from "@nestjs/graphql";
 
 export enum MexPairExchange {
   xexchange = 'xexchange',
-  jungledex = 'jungledex',
   unknown = 'unknown'
 }
 
@@ -12,9 +11,6 @@ registerEnumType(MexPairExchange, {
   valuesMap: {
     xexchange: {
       description: 'xexchange',
-    },
-    jungledex: {
-      description: 'jungledex',
     },
     unknown: {
       description: 'unknown',

--- a/src/endpoints/mex/entities/mex.pair.type.ts
+++ b/src/endpoints/mex/entities/mex.pair.type.ts
@@ -5,7 +5,6 @@ export enum MexPairType {
   community = 'community',
   ecosystem = 'ecosystem',
   experimental = 'experimental',
-  jungle = 'jungle',
   unlisted = 'unlisted',
 }
 
@@ -24,9 +23,6 @@ registerEnumType(MexPairType, {
     },
     experimental: {
       description: 'Experimental Type.',
-    },
-    jungle: {
-      description: 'Jungle Type.',
     },
     unlisted: {
       description: 'Unlisted Type.',

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -150,8 +150,6 @@ export class MexPairService {
 
     if (xexchangeTypes.includes(type)) {
       exchange = MexPairExchange.xexchange;
-    } else if (type === MexPairType.jungle) {
-      exchange = MexPairExchange.jungledex;
     } else {
       exchange = MexPairExchange.unknown;
     }
@@ -224,10 +222,6 @@ export class MexPairService {
         return MexPairType.ecosystem;
       case 'Experimental':
         return MexPairType.experimental;
-      case 'Jungle':
-      case 'Jungle-Experimental':
-      case 'Jungle-Community':
-        return MexPairType.jungle;
       case 'Unlisted':
         return MexPairType.unlisted;
       default:

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -9,7 +9,6 @@ import { MexFarmService } from "./mex.farm.service";
 import { MexSettingsService } from "./mex.settings.service";
 import { Constants } from "@multiversx/sdk-nestjs-common";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
-import { MexPairType } from "./entities/mex.pair.type";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { QueryPagination } from "src/common/entities/query.pagination";
 
@@ -187,12 +186,11 @@ export class MexTokenService {
       mexTokens.push(mexToken);
     }
 
-    return mexTokens;
+    return mexTokens.distinct(x => x.id);
   }
 
   private getMexToken(pair: MexPair): MexToken | null {
-    if ((pair.type !== MexPairType.jungle && pair.quoteSymbol === 'WEGLD') ||
-      (pair.type === MexPairType.jungle && pair.quoteSymbol === 'USDC')) {
+    if (['WEGLD', 'USDC'].includes(pair.quoteSymbol)) {
       return {
         id: pair.baseId,
         symbol: pair.baseSymbol,
@@ -201,8 +199,7 @@ export class MexTokenService {
       };
     }
 
-    if ((pair.type !== MexPairType.jungle && pair.baseSymbol === 'WEGLD') ||
-      (pair.type === MexPairType.jungle && pair.baseSymbol === 'USDC')) {
+    if (['WEGLD', 'USDC'].includes(pair.baseSymbol)) {
       return {
         id: pair.quoteId,
         symbol: pair.quoteSymbol,

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -2034,9 +2034,6 @@ enum MexPairType {
   """Experimental Type."""
   experimental
 
-  """Jungle Type."""
-  jungle
-
   """Unlisted Type."""
   unlisted
 }


### PR DESCRIPTION
## Reasoning
- Since the jungle dex has been merged into the main dex as `experimental` and experimental tokens were not returned on purpose by the api, all tokens merged from jungle to experimental have no associated price
  
## Proposed Changes
- Return price for all experimental token types
- Remove support for jungle token types

## How to test (mainnet)
- make sure `RARE` token is listed in the `mex/tokens` endpoint
