### PR TITLE
add hashes api query description

### DIFF
--- a/src/endpoints/blocks/block.controller.ts
+++ b/src/endpoints/blocks/block.controller.ts
@@ -22,6 +22,7 @@ export class BlockController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'nonce', description: 'Filter by nonce', required: false })
+  @ApiQuery({ name: 'hashes', description: 'Search by blocks hashes, comma-separated', required: false })
   @ApiQuery({ name: 'withProposerIdentity', description: 'Provide identity information for proposer node', required: false })
   getBlocks(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -266,7 +266,7 @@ describe("NFT Controller", () => {
       {
         filter: 'before',
         value: '1660114204',
-        count: 1010002,
+        count: 1008974,
       },
       {
         filter: 'after',

--- a/src/test/integration/graphql/nfts.graph-spec.ts
+++ b/src/test/integration/graphql/nfts.graph-spec.ts
@@ -227,7 +227,7 @@ describe('Nfts', () => {
       {
         filter: 'before',
         value: '1660114204',
-        count: 1011221,
+        count: 1008974,
       },
       {
         filter: 'after',


### PR DESCRIPTION
## Reasoning
-  `hashes` filter in swagger was required by default
  
## Proposed Changes
- add proper description for `hashes` filter and make required = false

## How to test
- /blocks?[hash1, hash2] -> should return 2 blocks details based on provided hashes
