### PR TITLE
remove withProcessStatus for transaction details

### DIFF
--- a/src/endpoints/transactions/entities/transaction.detailed.ts
+++ b/src/endpoints/transactions/entities/transaction.detailed.ts
@@ -60,9 +60,5 @@ export class TransactionDetailed extends Transaction {
   @Field(() => Boolean, { description: "InTransit transaction details.", nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   inTransit: boolean | undefined = undefined;
-
-  @Field(() => String, { description: 'Process status for the given detailed transaction.', nullable: true })
-  @ApiProperty({ type: String, nullable: true })
-  processStatus: string | undefined = undefined;
 }
 

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -176,14 +176,11 @@ export class TransactionController {
   @ApiOkResponse({ type: TransactionDetailed })
   @ApiNotFoundResponse({ description: 'Transaction not found' })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
-  @ApiQuery({ name: 'withProcessStatus', description: 'Returns process status for transaction', required: false })
   async getTransaction(
     @Param('txHash', ParseTransactionHashPipe) txHash: string,
     @Query('fields', ParseArrayPipe) fields?: string[],
-    @Query('withProcessStatus', ParseBoolPipe) withProcessStatus?: boolean,
   ): Promise<TransactionDetailed> {
-    const options = { withProcessStatus };
-    const transaction = await this.transactionService.getTransaction(txHash, fields, options);
+    const transaction = await this.transactionService.getTransaction(txHash, fields);
 
     if (transaction === null) {
       throw new NotFoundException('Transaction not found');

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -195,16 +195,11 @@ export class TransactionService {
     });
   }
 
-  async getTransaction(txHash: string, fields?: string[], options?: { withProcessStatus?: boolean }): Promise<TransactionDetailed | null> {
+  async getTransaction(txHash: string, fields?: string[]): Promise<TransactionDetailed | null> {
     let transaction = await this.transactionGetService.tryGetTransactionFromElastic(txHash, fields);
 
     if (transaction === null) {
       transaction = await this.transactionGetService.tryGetTransactionFromGateway(txHash);
-    }
-
-    if (transaction && options && options.withProcessStatus) {
-      const processStatus = await this.gatewayService.getTransactionProcessStatus(transaction.txHash);
-      transaction.processStatus = processStatus.status;
     }
 
     if (transaction !== null) {

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -188,30 +188,6 @@ describe('Transaction Service', () => {
         ]),
       }));
     });
-
-    it('should return processStatus with value "success" if withProcessStatus flag is true', async () => {
-      const txHash: string = "ee2d9d8b282c840c9c20f1480e027f9f6aa5a375340b75f147ff683185bf740f";
-      const options = { withProcessStatus: true };
-      const result = await transactionService.getTransaction(txHash, undefined, options);
-
-      expect(result?.processStatus).toStrictEqual("success");
-    });
-
-    it('should return processStatus with value "fail" if withProcessStatus flag is true', async () => {
-      const txHash: string = "2a70f9b0197a0c579ec3d787d940e1184e8f9bedc8a0f88697ee4d0faa60586c";
-      const options = { withProcessStatus: true };
-      const result = await transactionService.getTransaction(txHash, undefined, options);
-
-      expect(result?.processStatus).toStrictEqual("fail");
-    });
-
-    it('should return processStatus undefined if withProcessStatus flag is false', async () => {
-      const txHash: string = "b01fece9628091094889832e935603f9c1d12e259d0f7feab6f744a69b51a7e5";
-      const options = { withProcessStatus: false };
-      const result = await transactionService.getTransaction(txHash, undefined, options);
-
-      expect(result?.processStatus).toBeUndefined();
-    });
   });
 
   it(`should return a list of transfers between two accounts (first address is always sender and seconds adress is always receiver)`, async () => {


### PR DESCRIPTION
## Reasoning
- Because the processStatus for transaction can be take from gateway, no additional changes should be made on api.multiversx.com
  
## Proposed Changes
- Remove withProcessStatus optional parameter to remove the possibility of retrieving process status details from the gateway service

## How to test
- `/transaction/:txHash`-> processStatus field should not be defined if optional parameter `withProcessStatus` is true
-  verify on swagger to be sure that `withProcessStatus` paramater is not defined
