### PR TITLE
Node status leaving fix

### DIFF
--- a/src/endpoints/nodes/entities/node.ts
+++ b/src/endpoints/nodes/entities/node.ts
@@ -136,5 +136,5 @@ export class Node {
 
   @Field(() => Number, { description: "Remaining UnBond Period for node with status leaving.", nullable: true })
   @ApiProperty({ type: Number, example: 10 })
-  remainingUnBondPeriod: number | undefined = 0;
+  remainingUnBondPeriod: number | undefined = undefined;
 }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -272,18 +272,12 @@ export class NodeService {
   }
 
   private async applyNodeUnbondingPeriods(nodes: Node[]): Promise<void> {
-    const leavingNodes = nodes.filter(node => node.status === NodeStatus.leaving);
+    const leavingNodes = nodes.filter(node => node.status === NodeStatus.leaving || node.status === NodeStatus.inactive);
 
     await Promise.all(leavingNodes.map(async node => {
       const keyUnbondPeriod = await this.keysService.getKeyUnbondPeriod(node.bls);
       node.remainingUnBondPeriod = keyUnbondPeriod?.remainingUnBondPeriod;
     }));
-
-    for (const node of nodes) {
-      if (node.status !== NodeStatus.leaving) {
-        node.remainingUnBondPeriod = undefined;
-      }
-    }
   }
 
   private async applyNodeStakeInfo(nodes: Node[]) {
@@ -604,10 +598,6 @@ export class NodeService {
         if (node.syncProgress > 1) {
           node.syncProgress = 1;
         }
-      }
-
-      if (node.status === NodeStatus.inactive && node.remainingUnBondPeriod === 0) {
-        node.status = NodeStatus.leaving;
       }
 
       node.issues = this.getIssues(node, config.erd_latest_tag_software_version);

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3909,6 +3909,9 @@ type TransactionDetailed {
   """Price for the given detailed transaction."""
   price: Float
 
+  """Process status for the given detailed transaction."""
+  processStatus: String
+
   """Transaction receipt for the given detailed transaction."""
   receipt: TransactionReceipt
 


### PR DESCRIPTION
## Reasoning
- Inactive nodes are incorrectly marked as leaving
  
## Proposed Changes
- Mark nodes as leaving only where applicable

## How to test
- `/nodes/3e79c969102742f86dccd17ee1a34cecc238cd701e507c9ef4ad6f8da2f97a6386ca9d7644a70f3436d4219d2c14af10d3c802a9ca84718165ed7cd8b7bc2e4745ff903ea533433dca6458ee71ba7d056e6a10b4cc0e55bffdf130dcc867a793` should have status `inactive`
