### PR TITLE
apply denominate to supply for token identifier

### DIFF
--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -190,6 +190,15 @@ export class MexTokenService {
   }
 
   private getMexToken(pair: MexPair): MexToken | null {
+    if (pair.baseSymbol === 'WEGLD' && pair.quoteSymbol === "USDC") {
+      return {
+        id: pair.quoteId,
+        symbol: pair.quoteSymbol,
+        name: pair.quoteName,
+        price: pair.quotePrice,
+      };
+    }
+
     if (['WEGLD', 'USDC'].includes(pair.quoteSymbol)) {
       return {
         id: pair.baseId,


### PR DESCRIPTION
## Reasoning
- For the USDC-c76f1f token, supply and circulatingSupply was missing
- When mex/tokens request was made, USDC-c76f1f was missing from list
  
## Proposed Changes
- Added in mex.tokens.service.ts, new condition in `getMexToken` to be able to return the `USDC-c76f1`token details

## How to test
- `tokens?identifiers=USDC-c76f1f` -> make sure that `supply` and circulatingSupply are defined for `USDC-c76f1f`
- `mex/tokens?size=60 -> make sure `USDC-c76f1f` is defined
