### PR TITLE
Trim NFT url when hashing

### DIFF
--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3909,9 +3909,6 @@ type TransactionDetailed {
   """Price for the given detailed transaction."""
   price: Float
 
-  """Process status for the given detailed transaction."""
-  processStatus: String
-
   """Transaction receipt for the given detailed transaction."""
   receipt: TransactionReceipt
 

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -28,7 +28,7 @@ export class TokenHelpers {
   }
 
   static getUrlHash(url: string) {
-    return crypto.SHA256(url).toString().slice(0, 8);
+    return crypto.SHA256(url.trim()).toString().slice(0, 8);
   }
 
   static getThumbnailUrlIdentifier(nftIdentifier: string, fileUrl: string) {


### PR DESCRIPTION
## Proposed Changes
- When calculating url hash for media, trim the url first to account for urls that start or end with whitespace

## How to test
- for NFT with identifier `TAVERN-e9b9d6-01`, computed url hash should be `fb18a758`
