### PR TITLE
Apply ticker for contract address tokens

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -107,6 +107,7 @@ export class TokenService {
   }
 
   applyTickerFromAssets(token: Token) {
+    console.log({ token });
     if (token.assets) {
       token.ticker = token.identifier.split('-')[0];
     } else {
@@ -251,6 +252,8 @@ export class TokenService {
         };
 
         this.applyValueUsd(tokenWithBalance);
+
+        this.applyTickerFromAssets(tokenWithBalance);
 
         result.push(tokenWithBalance);
       }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -107,7 +107,6 @@ export class TokenService {
   }
 
   applyTickerFromAssets(token: Token) {
-    console.log({ token });
     if (token.assets) {
       token.ticker = token.identifier.split('-')[0];
     } else {


### PR DESCRIPTION
## Proposed Changes
- Apply ticker also when retrieving tokens for contracts

## How to test
- `/accounts/erd1qqqqqqqqqqqqqpgqgulmfcu8prrv2pmx3nqn5stqu3c42fsz4fvsa9rwdl/tokens` should contain the `ticker` attribute
