### PR TITLE
add partial active state case

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.state.ts
+++ b/src/endpoints/mex/entities/mex.pair.state.ts
@@ -4,6 +4,7 @@ export enum MexPairState {
   active = 'active',
   inactive = 'inactive',
   paused = 'paused',
+  partial = 'partial'
 }
 
 registerEnumType(MexPairState, {
@@ -18,6 +19,9 @@ registerEnumType(MexPairState, {
     },
     paused: {
       description: 'Pause state.',
+    },
+    partial: {
+      description: 'Partial state.',
     },
   },
 });

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -207,6 +207,8 @@ export class MexPairService {
         return MexPairState.inactive;
       case 'ActiveNoSwaps':
         return MexPairState.paused;
+      case 'PartialActive':
+        return MexPairState.partial;
       default:
         throw new Error(`Unsupported pair state '${state}'`);
     }


### PR DESCRIPTION
## Reasoning
- New MexPairState was added in DEX API
  
## Proposed Changes
- Add PartialActive case in `getPairState` method to be able to return mex pairs with status partial active

## How to test
- `/mex/pairs` -> should return mex pairs
