### PR TITLE
apply marketCap for Hatom tokens

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -726,13 +726,11 @@ export class TokenService {
     for (const token of tokens) {
       if (token.assets?.priceSource?.type === TokenAssetsPriceSourceType.dataApi) {
         token.price = await this.dataApiService.getEsdtTokenPrice(token.identifier);
-
-        const supply = await this.esdtService.getTokenSupply(token.identifier);
-        token.supply = supply.totalSupply;
-        token.circulatingSupply = supply.circulatingSupply;
-
-        if (token.price && token.circulatingSupply) {
-          token.marketCap = token.price * NumberUtils.denominateString(token.circulatingSupply, token.decimals);
+        if (token.price) {
+          const supply = await this.esdtService.getTokenSupply(token.identifier);
+          if (supply.circulatingSupply) {
+            token.marketCap = token.price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
+          }
         }
       }
     }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -726,11 +726,13 @@ export class TokenService {
     for (const token of tokens) {
       if (token.assets?.priceSource?.type === TokenAssetsPriceSourceType.dataApi) {
         token.price = await this.dataApiService.getEsdtTokenPrice(token.identifier);
-        if (token.price) {
-          const supply = await this.esdtService.getTokenSupply(token.identifier);
-          if (supply.circulatingSupply) {
-            token.marketCap = token.price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
-          }
+
+        const supply = await this.esdtService.getTokenSupply(token.identifier);
+        token.supply = supply.totalSupply;
+        token.circulatingSupply = supply.circulatingSupply;
+
+        if (token.price && token.circulatingSupply) {
+          token.marketCap = token.price * NumberUtils.denominateString(token.circulatingSupply, token.decimals);
         }
       }
     }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -726,6 +726,14 @@ export class TokenService {
     for (const token of tokens) {
       if (token.assets?.priceSource?.type === TokenAssetsPriceSourceType.dataApi) {
         token.price = await this.dataApiService.getEsdtTokenPrice(token.identifier);
+
+        const supply = await this.esdtService.getTokenSupply(token.identifier);
+        token.supply = supply.totalSupply;
+        token.circulatingSupply = supply.circulatingSupply;
+
+        if (token.price && token.circulatingSupply) {
+          token.marketCap = token.price * NumberUtils.denominateString(token.circulatingSupply, token.decimals);
+        }
       }
     }
 


### PR DESCRIPTION
## Reasoning
- For Hatom tokens, marketCap value was not calculated
  
## Proposed Changes
- Add marketCap value for each Hatom token

## How to test
- tokens/SEGLD-3ad2d0 - `marketCap` should be defined
- tokens/HEGLD-d61095 -> `marketCap` should be defined
