### PR TITLE
add operation search for transfers and add processTransaction

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -279,7 +279,12 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
-        elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.functions, func => QueryType.Match('function', func));
+        for (const field of filter.functions) {
+          elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
+            QueryType.Match('function', field),
+            QueryType.Match('operation', field),
+          ]));
+        }
       }
     }
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -234,6 +234,11 @@ export class ElasticIndexerService implements IndexerInterface {
       .withSort([timestamp, nonce]);
 
     const elasticOperations = await this.elasticService.getList('operations', 'txHash', elasticQuery);
+
+    for (const operation of elasticOperations) {
+      this.processTransaction(operation);
+    }
+
     return elasticOperations;
   }
 


### PR DESCRIPTION
## Reasoning
- To be able to search for `SetGuardian`, `UnGuardAccount` and `GuardAccount`, we need to make search in `Elastic` with operation for transfers
  
## Proposed Changes
- Modified the existing filter condition in the `ElasticSearch` query to support dual-field matching. Now, the query can match values against both function and operation fields.

## How to test
- `accounts/erd19k4alvl0mg2fwhrp8jck3aucj0xmgczy28v4u0gmfunkhyjh7wmq0nmhas/transfers` -> one of the returned transfers results should have `function: SetGuardian` defined ( e7299ea221163784a5dd6499f10183736c7e320302d2199fff5cd6a23b93bdeb )
- `accounts/erd19k4alvl0mg2fwhrp8jck3aucj0xmgczy28v4u0gmfunkhyjh7wmq0nmhas/transfers?function=SetGuardian` -> should return only the transfers where `function: SetGuardian`
- `transfers?function=SetGuardian` -> all transfers results should have `function: SetGuardian`
