### PR TITLE
add withLatestInfo parameter

### DIFF
--- a/src/endpoints/providers/entities/provider.config.ts
+++ b/src/endpoints/providers/entities/provider.config.ts
@@ -7,4 +7,6 @@ export class ProviderConfig {
   serviceFee: number = 0;
   delegationCap: string = '';
   apr: number = 0;
+  automaticActivation: boolean = false;
+  checkCapOnRedelegate: boolean = false;
 }

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -23,10 +23,14 @@ export class ProviderController {
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('providers', ParseAddressArrayPipe) providers?: string[],
     @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
+    @Query('withLatestInfo', new ParseBoolPipe) withLatestInfo?: boolean,
   ): Promise<Provider[]> {
+    const options = {
+      withIdentityInfo: withIdentityInfo ?? false,
+      withLatestInfo: withLatestInfo ?? false,
+    };
     return await this.providerService.getProviders(
-      new ProviderFilter({ identity, providers, owner }),
-      withIdentityInfo);
+      new ProviderFilter({ identity, providers, owner }), options);
   }
 
   @Get('/providers/:address')

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -146,10 +146,6 @@ export class ProviderService {
       return bSort - aSort;
     });
 
-
-
-    // providers = providers.filter(provider => provider.numNodes > 0);
-
     for (const provider of providers) {
       if (!provider.identity) {
         continue;
@@ -172,10 +168,10 @@ export class ProviderService {
     return /^[\w]*$/g.test(identity ?? '');
   }
 
-  async getProviders(filter: ProviderFilter, withIdentityInfo?: boolean): Promise<Provider[]> {
+  async getProviders(filter: ProviderFilter, options?: { withIdentityInfo?: boolean, withLatestInfo?: boolean }): Promise<Provider[]> {
     const providers = await this.getFilteredProviders(filter);
 
-    if (withIdentityInfo === true) {
+    if (options && options.withIdentityInfo === true) {
       for (const provider of providers) {
         if (provider.identity) {
           const identityInfo = await this.identitiesService.getIdentity(provider.identity);
@@ -185,6 +181,37 @@ export class ProviderService {
     } else {
       for (const provider of providers) {
         delete provider.identityInfo;
+      }
+    }
+
+    if (options && options.withLatestInfo) {
+      for (const provider of providers) {
+        const contractConfig = await this.getProviderConfig(provider.provider);
+        const contractTotalActiveStake = await this.getTotalActiveStake(provider.provider);
+
+        if (contractConfig) {
+          if (provider.serviceFee !== undefined) {
+            provider.serviceFee = contractConfig.serviceFee;
+          }
+
+          if (provider.automaticActivation !== undefined) {
+            provider.automaticActivation = contractConfig.automaticActivation;
+          }
+
+          if (provider.checkCapOnRedelegate !== undefined) {
+            provider.checkCapOnRedelegate = contractConfig.checkCapOnRedelegate;
+          }
+
+          if (provider.delegationCap !== undefined) {
+            provider.delegationCap = contractConfig.delegationCap;
+          }
+
+          if (contractTotalActiveStake !== undefined) {
+            if (provider.locked !== undefined) {
+              provider.locked = contractTotalActiveStake;
+            }
+          }
+        }
       }
     }
 
@@ -318,39 +345,37 @@ export class ProviderService {
     }
 
     try {
-      const [
-        ownerBase64,
-        serviceFeeBase64,
-        delegationCapBase64,
-        // initialOwnerFundsBase64,
-        // automaticActivationBase64,
-        // changeableServiceFeeBase64,
-        // checkCapOnredelegateBase64,
-        // unBondPeriodBase64,
-        // createdNonceBase64,
-      ] = await this.vmQueryService.vmQuery(
+      const ownerAddressIndex = 0;
+      const serviceFeeIndex = 1;
+      const delegationCapIndex = 2;
+      const automaticActivationIndex = 4;
+      const redelegationCapIndex = 7;
+
+      const response = await this.vmQueryService.vmQuery(
         address,
         'getContractConfig',
       );
 
-      const owner = AddressUtils.bech32Encode(Buffer.from(ownerBase64, 'base64').toString('hex'));
+      const ownerAddress = response[ownerAddressIndex];
+      const serviceFeeBase64 = response[serviceFeeIndex];
+      const delegationCapBase64 = response[delegationCapIndex];
+      const automaticActivationBase64 = response[automaticActivationIndex];
+      const checkCapOnRedelegateBase64 = response[redelegationCapIndex];
+
+      const owner = AddressUtils.bech32Encode(Buffer.from(ownerAddress, 'base64').toString('hex'));
 
       const [serviceFee, delegationCap] = [
-        // , initialOwnerFunds, createdNonce
         serviceFeeBase64,
         delegationCapBase64,
-        // initialOwnerFundsBase64,
-        // createdNonceBase64,
       ].map((base64) => {
         const hex = base64 ? Buffer.from(base64, 'base64').toString('hex') : base64;
         return hex === null ? null : BigInt(hex ? '0x' + hex : hex).toString();
       });
 
-      // const [automaticActivation, changeableServiceFee, checkCapOnredelegate] = [
-      //   automaticActivationBase64,
-      //   changeableServiceFeeBase64,
-      //   checkCapOnredelegateBase64,
-      // ].map((base64) => (Buffer.from(base64, 'base64').toString() === 'true' ? true : false));
+      const [automaticActivation, checkCapOnRedelegate] = [
+        automaticActivationBase64,
+        checkCapOnRedelegateBase64,
+      ].map((base64) => (Buffer.from(base64, 'base64').toString() === 'true' ? true : false));
 
       const serviceFeeString = String(parseInt(serviceFee ?? '0') / 10000);
 
@@ -360,9 +385,9 @@ export class ProviderService {
         delegationCap: delegationCap ?? '0',
         apr: 0,
         // initialOwnerFunds,
-        // automaticActivation,
+        automaticActivation,
         // changeableServiceFee,
-        // checkCapOnredelegate,
+        checkCapOnRedelegate,
         // createdNonce: parseInt(createdNonce),
       };
     } catch (error) {
@@ -447,5 +472,18 @@ export class ProviderService {
   private async getProviderIdentity(address: string): Promise<string | undefined> {
     const providerDetails = await this.getProvider(address);
     return providerDetails && providerDetails.identity ? providerDetails.identity : undefined;
+  }
+
+  private async getTotalActiveStake(address: string): Promise<string> {
+    const [activeStake] = await this.vmQueryService.vmQuery(
+      address,
+      'getTotalActiveStake',
+    );
+    return this.numberDecode(activeStake);
+  }
+
+  numberDecode(encoded: string): string {
+    const hex = Buffer.from(encoded, 'base64').toString('hex');
+    return BigInt(hex ? '0x' + hex : hex).toString();
   }
 }


### PR DESCRIPTION
## Reasoning
- In the current implementation, for the provider service, the information is cached, not being able to see the values ​​of certain fields in real time 
  
## Proposed Changes
1. Adding a flag called `withLatestInfo` which, when `true`, calls will be made to 2 `vm-queries` that will update certain fields
`serviceFee`, `automaticActivation`, `checkCapOnRedelegate`, `delegationCap`, `locked`
- vm-queries: `getContractConfig` and `getTotalActiveStake`
- Adding `withLatestInfo` as an API query parameter allows consumers of the API to specify whether they want to include the latest information about providers or not.
- Adding an options object to hold `withIdentityInfo` and `withLatesttInfo` flags.

## How to test ( TESTNET )
- `providers?owner=erd1czgky3rcqggezg6zan5k2c9sfnwlh644jc26t6vud256ack9xaaqvhqddm&withLatestInfo=true` -> try to stake to contract `erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx8llllsxavffq` where owner is `erd1czgky3rcqggezg6zan5k2c9sfnwlh644jc26t6vud256ack9xaaqvhqddm` and after transaction is success, you can observe that the `locked` value is updated with the new value. To compare, make the same request to `testnet-api.multiversx.com/providers?owner=erd1czgky3rcqggezg6zan5k2c9sfnwlh644jc26t6vud256ack9xaaqvhqddm&withLatestInfo=true`

- To be able to test all the fields, you need to create your own delegation contract and change all the values to observe the change s in your local API
