### PR TITLE
fetch numNodes using vmquery

### DIFF
--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -188,6 +188,7 @@ export class ProviderService {
       for (const provider of providers) {
         const contractConfig = await this.getProviderConfig(provider.provider);
         const contractTotalActiveStake = await this.getTotalActiveStake(provider.provider);
+        const contractNodesCount = await this.getNumNodes(provider.provider);
 
         if (contractConfig) {
           if (provider.serviceFee !== undefined) {
@@ -204,6 +205,10 @@ export class ProviderService {
 
           if (provider.delegationCap !== undefined) {
             provider.delegationCap = contractConfig.delegationCap;
+          }
+
+          if (provider.numNodes !== undefined) {
+            provider.numNodes = contractNodesCount;
           }
 
           if (contractTotalActiveStake !== undefined) {
@@ -481,5 +486,14 @@ export class ProviderService {
     );
 
     return BinaryUtils.base64ToBigInt(activeStake).toString();
+  }
+
+  private async getNumNodes(address: string): Promise<number> {
+    const [numNodesBase64] = await this.vmQueryService.vmQuery(
+      address,
+      'getNumNodes'
+    );
+
+    return Number(BinaryUtils.base64ToBigInt(numNodesBase64));
   }
 }


### PR DESCRIPTION
## Reasoning
-  Same as PR https://github.com/multiversx/mx-api-service/pull/1110 we need to return numNodes value when withLatestInfo = true
  
## Proposed Changes
- Fetch `numNode` value using vm-query `getNumNodes`

## How to test ( TESTNET )
-  create new delegation contract -> numNode value will be 0
-  add node to your staking provider
- `providers?owner=erd1czgky3rcqggezg6zan5k2c9sfnwlh644jc26t6vud256ack9xaaqvhqddm&withLatestInfo=true` ->  numNodes should be 1
