### PR TITLE
add complexity to withLatestInfo filter

### DIFF
--- a/src/endpoints/providers/entities/provider.query.options.ts
+++ b/src/endpoints/providers/entities/provider.query.options.ts
@@ -9,7 +9,7 @@ export class ProviderQueryOptions {
   withIdentityInfo?: boolean = false;
 
   static applyDefaultOptions(owner: string | undefined, options: ProviderQueryOptions): ProviderQueryOptions {
-    if (options.withLatestInfo === true && owner === undefined && !owner) {
+    if (options.withLatestInfo === true && !owner) {
       throw new BadRequestException(`'withLatestInfo' can only be activated when an 'owner' filter is also applied.`);
     }
 

--- a/src/endpoints/providers/entities/provider.query.options.ts
+++ b/src/endpoints/providers/entities/provider.query.options.ts
@@ -1,0 +1,18 @@
+import { BadRequestException } from "@nestjs/common";
+
+export class ProviderQueryOptions {
+  constructor(init?: Partial<ProviderQueryOptions>) {
+    Object.assign(this, init);
+  }
+
+  withLatestInfo?: boolean = false;
+  withIdentityInfo?: boolean = false;
+
+  static applyDefaultOptions(owner: string | undefined, options: ProviderQueryOptions): ProviderQueryOptions {
+    if (options.withLatestInfo === true && owner === undefined) {
+      throw new BadRequestException(`'withLatestInfo' can only be activated when an 'owner' filter is also applied.`);
+    }
+
+    return options;
+  }
+}

--- a/src/endpoints/providers/entities/provider.query.options.ts
+++ b/src/endpoints/providers/entities/provider.query.options.ts
@@ -9,7 +9,7 @@ export class ProviderQueryOptions {
   withIdentityInfo?: boolean = false;
 
   static applyDefaultOptions(owner: string | undefined, options: ProviderQueryOptions): ProviderQueryOptions {
-    if (options.withLatestInfo === true && owner === undefined) {
+    if (options.withLatestInfo === true && owner === undefined && !owner) {
       throw new BadRequestException(`'withLatestInfo' can only be activated when an 'owner' filter is also applied.`);
     }
 

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -5,6 +5,7 @@ import { Provider } from "./entities/provider";
 import { ParseAddressArrayPipe, ParseAddressPipe, ParseBoolPipe } from "@multiversx/sdk-nestjs-common";
 import { ProviderFilter } from "./entities/provider.filter";
 import { Response } from "express";
+import { ProviderQueryOptions } from "./entities/provider.query.options";
 
 @Controller()
 @ApiTags('providers')
@@ -25,10 +26,8 @@ export class ProviderController {
     @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
     @Query('withLatestInfo', new ParseBoolPipe) withLatestInfo?: boolean,
   ): Promise<Provider[]> {
-    const options = {
-      withIdentityInfo: withIdentityInfo ?? false,
-      withLatestInfo: withLatestInfo ?? false,
-    };
+    const options = ProviderQueryOptions.applyDefaultOptions(owner, { withIdentityInfo, withLatestInfo });
+
     return await this.providerService.getProviders(
       new ProviderFilter({ identity, providers, owner }), options);
   }

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -13,6 +13,7 @@ import { ApiService } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { IdentitiesService } from "../identities/identities.service";
+import { ProviderQueryOptions } from "./entities/provider.query.options";
 
 @Injectable()
 export class ProviderService {
@@ -168,10 +169,10 @@ export class ProviderService {
     return /^[\w]*$/g.test(identity ?? '');
   }
 
-  async getProviders(filter: ProviderFilter, options?: { withIdentityInfo?: boolean, withLatestInfo?: boolean }): Promise<Provider[]> {
+  async getProviders(filter: ProviderFilter, queryOptions?: ProviderQueryOptions): Promise<Provider[]> {
     const providers = await this.getFilteredProviders(filter);
 
-    if (options && options.withIdentityInfo === true) {
+    if (queryOptions && queryOptions.withIdentityInfo === true) {
       for (const provider of providers) {
         if (provider.identity) {
           const identityInfo = await this.identitiesService.getIdentity(provider.identity);
@@ -184,7 +185,7 @@ export class ProviderService {
       }
     }
 
-    if (options && options.withLatestInfo) {
+    if (queryOptions && queryOptions.withLatestInfo) {
       for (const provider of providers) {
         const contractConfig = await this.getProviderConfig(provider.provider);
         const contractTotalActiveStake = await this.getTotalActiveStake(provider.provider);


### PR DESCRIPTION
 
## Proposed Changes
- 
- 
- 

## How to test
- `/providers?withLatestInfo=true` -> should throw `BadRequestException` because `owner` filter is not defined
- `providers?owner=erd1fx5t2nwq4fh9jws5xqfl85hr0l8tuqks9sr7ut9wrpkp7dugzxnqyksfyg&withLatestInfo=true` -> should return provider info based on `owner` filter and `withLatestInfo` filter applied
