### PR TITLE
add support for token accounts assets

### DIFF
--- a/src/endpoints/tokens/entities/token.account.ts
+++ b/src/endpoints/tokens/entities/token.account.ts
@@ -1,6 +1,7 @@
 import { SwaggerUtils } from "@multiversx/sdk-nestjs-common";
 import { Field, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 
 @ObjectType("TokenAccount", { description: "TokenAccount object type." })
 export class TokenAccount {
@@ -23,4 +24,8 @@ export class TokenAccount {
   @Field(() => String, { description: "Token attributes if MetaESDT.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   attributes: string | undefined = undefined;
+
+  @Field(() => AccountAssets, { description: 'Account assets for the given account.', nullable: true })
+  @ApiProperty({ type: AccountAssets, nullable: true, description: 'Account assets' })
+  assets: AccountAssets | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -394,13 +394,14 @@ export class TokenService {
     }
 
     const tokenAccounts = await this.indexerService.getTokenAccounts(pagination, identifier);
-
+    const assets = await this.assetsService.getAllAccountAssets();
     const result: TokenAccount[] = [];
 
     for (const tokenAccount of tokenAccounts) {
       result.push(new TokenAccount({
         address: tokenAccount.address,
         balance: tokenAccount.balance,
+        assets: assets[tokenAccount.address],
         attributes: tokenAccount.data?.attributes,
         identifier: tokenAccount.type === TokenType.MetaESDT ? tokenAccount.identifier : undefined,
       }));

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -22,12 +22,14 @@ import { TokenProperties } from "src/endpoints/tokens/entities/token.properties"
 import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import * as fs from 'fs';
 import * as path from 'path';
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 
 describe('Token Service', () => {
   let tokenService: TokenService;
   let esdtService: EsdtService;
   let collectionService: CollectionService;
   let indexerService: IndexerService;
+  let assetsService: AssetsService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -86,6 +88,7 @@ describe('Token Service', () => {
           provide: AssetsService,
           useValue: {
             getTokenAssets: jest.fn(),
+            getAllAccountAssets: jest.fn(),
           },
         },
         {
@@ -120,6 +123,7 @@ describe('Token Service', () => {
     esdtService = moduleRef.get<EsdtService>(EsdtService);
     collectionService = moduleRef.get<CollectionService>(CollectionService);
     indexerService = moduleRef.get<IndexerService>(IndexerService);
+    assetsService = moduleRef.get<AssetsService>(AssetsService);
   });
 
   afterEach(() => {
@@ -741,6 +745,18 @@ describe('Token Service', () => {
       NFTCreateStopped: false,
     };
 
+    const assets = {
+      erd16jruked88jgtsar78ej85hjp3qsd9jkjcw4swsn7k0teqh3wgcqqgyrupq: new AccountAssets({
+        name: 'Exchange: Tests',
+        description: '',
+        tags: ['exchange', 'tests'],
+        iconPng:
+          'https://raw.githubusercontent.com/multiversx/mx-assets/master/accounts/icons/test.png',
+        iconSvg:
+          'https://raw.githubusercontent.com/multiversx/mx-assets/master/accounts/icons/test.svg',
+      }),
+    };
+
     it('should returns undefined if getTokenProperties returns undefined', async () => {
       const tokensPropertiesMock = jest.spyOn(tokenService, 'getTokenProperties').mockResolvedValueOnce(Promise.resolve(undefined));
       const result = await tokenService.getTokenAccounts(new QueryPagination(), identifier);
@@ -753,6 +769,7 @@ describe('Token Service', () => {
       const mockTokens = JSON.parse(fs.readFileSync(path.join(__dirname, '../../mocks/token.accounts.mock.json'), 'utf-8'));
       const tokensPropertiesMock = jest.spyOn(tokenService, 'getTokenProperties').mockResolvedValueOnce(Promise.resolve(propertiesMock));
       const tokenAccountsMock = jest.spyOn(indexerService, 'getTokenAccounts').mockResolvedValueOnce(mockTokens);
+      const accountAssetsMock = jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValueOnce(assets);
 
       const results = await tokenService.getTokenAccounts(new QueryPagination(), identifier);
       if (results) {
@@ -761,16 +778,19 @@ describe('Token Service', () => {
         for (const result of results) {
           expect(result.hasOwnProperty('address')).toBe(true);
           expect(result.hasOwnProperty('balance')).toBe(true);
+          expect(result.hasOwnProperty('assets')).toBe(true);
         }
       }
       expect(tokensPropertiesMock).toHaveBeenCalledTimes(1);
       expect(tokenAccountsMock).toHaveBeenCalledTimes(1);
+      expect(accountAssetsMock).toHaveBeenCalledTimes(1);
     });
 
     it('should return single account for given identifier', async () => {
       const mockTokens = JSON.parse(fs.readFileSync(path.join(__dirname, '../../mocks/token.accounts.mock.json'), 'utf-8'));
       const tokensPropertiesMock = jest.spyOn(tokenService, 'getTokenProperties').mockResolvedValueOnce(Promise.resolve(propertiesMock));
       const tokenAccountsMock = jest.spyOn(indexerService, 'getTokenAccounts').mockResolvedValueOnce([mockTokens[2]]);
+      const accountAssetsMock = jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValueOnce(assets);
 
       const results = await tokenService.getTokenAccounts(new QueryPagination({ size: 1 }), identifier);
       if (results) {
@@ -778,10 +798,12 @@ describe('Token Service', () => {
           expect(result.address).toStrictEqual("erd1qqqqqqqqqqqqqpgq0lzzvt2faev4upyf586tg38s84d7zsaj2jpsglugga");
           expect(result.hasOwnProperty('address')).toBe(true);
           expect(result.hasOwnProperty('balance')).toBe(true);
+          expect(result.hasOwnProperty('assets')).toBe(true);
         }
       }
       expect(tokensPropertiesMock).toHaveBeenCalledTimes(1);
       expect(tokenAccountsMock).toHaveBeenCalledTimes(1);
+      expect(accountAssetsMock).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Reasoning
-  For `tokens/:token/accounts`, for each account, the assets field is missing
  
## Proposed Changes
- Adding the assets field for each account that owns a specific token

## How to test
- `/tokens/WEGLD-bd4d79/accounts` -> every account should contain assets field
- `tokens/BHAT-c1fde3/accounts` -> if an account does not have assets defined, the assets field will not be displayed
