### PR TITLE
handle situation when hex string is empty

### DIFF
--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -495,6 +495,11 @@ export class ProviderService {
       'getNumNodes'
     );
 
-    return Number(BinaryUtils.base64ToBigInt(numNodesBase64));
+    return Number(this.numberDecode(numNodesBase64));
+  }
+
+  numberDecode(encoded: string) {
+    const hex = Buffer.from(encoded, 'base64').toString('hex');
+    return BigInt(hex ? '0x' + hex : hex).toString();
   }
 }


### PR DESCRIPTION
## Reasoning
- Cannot convert 0x to a BigInt
  
## Proposed Changes
- Add `numberDecode` that includes a conditional (hex ? '0x' + hex : hex), ensuring that if the hex string is empty, it defaults to an empty string (which will be transformed into BigInt(0))

## How to test
- `providers?withIdentityInfo=true&owner=erd1vdhv6a4jec7sr2r4vcznthreu3wesul2t0j345ay3cwch7qv4p7qxk5f99&withLatestInfo=true` -> 
