### PR TITLE
take token name from assets if exist

### DIFF
--- a/src/common/assets/entities/token.assets.ts
+++ b/src/common/assets/entities/token.assets.ts
@@ -29,6 +29,10 @@ export class TokenAssets {
   @ApiProperty({ type: String })
   pngUrl: string = '';
 
+  @Field(() => String, { description: 'Name for the given token assets.' })
+  @ApiProperty({ type: String })
+  name: string = '';
+
   @Field(() => String, { description: 'SVG URL for the given token assets.' })
   @ApiProperty({ type: String })
   svgUrl: string = '';

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -689,6 +689,12 @@ export class TokenService {
     let tokens = tokensProperties.map(properties => ApiUtils.mergeObjects(new TokenDetailed(), properties));
 
     for (const token of tokens) {
+      const assets = await this.assetsService.getTokenAssets(token.identifier);
+
+      if (assets && assets.name) {
+        token.name = assets.name;
+      }
+
       token.type = TokenType.FungibleESDT;
     }
 


### PR DESCRIPTION
## Reasoning
- If token name from assets is changed, in API `tokens` route, the new value from assets is not displayed
  
## Proposed Changes
- Override the new value for token.name from token assets

## How to test
- `/tokens` -> search for `UTK-2f80e9` and token name should be `xMoney UTK`
- `/tokens/UTK-2f80e9` -> token name should be `xMoney UTK` instead of `Utrust`
