### PR TITLE
add support for guardian info in username controller

### DIFF
--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -23,7 +23,8 @@ export class UsernameController {
   @NoCache()
   async getUsernameDetails(
     @Param('username') username: string,
-    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean): Promise<AccountDetailed | null> {
+    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean
+  ): Promise<AccountDetailed | null> {
     const address = await this.usernameService.getAddressForUsername(username);
     if (!address) {
       throw new HttpException('Account not found', HttpStatus.NOT_FOUND);

--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -30,8 +30,6 @@ export class UsernameController {
       throw new HttpException('Account not found', HttpStatus.NOT_FOUND);
     }
 
-    const account = await this.accountService.getAccount(address, undefined, withGuardianInfo);
-
-    return account;
+    return await this.accountService.getAccount(address, undefined, withGuardianInfo);
   }
 }

--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -1,9 +1,8 @@
 import { AccountUsername } from './entities/account.username';
-import { Controller, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
+import { Controller, Get, HttpException, HttpStatus, Param, Query, Res } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { UsernameService } from "./username.service";
 import { NoCache } from '@multiversx/sdk-nestjs-cache';
-import { AccountService } from '../accounts/account.service';
 import { ParseBoolPipe } from '@multiversx/sdk-nestjs-common';
 import { AccountDetailed } from '../accounts/entities/account.detailed';
 
@@ -12,7 +11,6 @@ import { AccountDetailed } from '../accounts/entities/account.detailed';
 export class UsernameController {
   constructor(
     private readonly usernameService: UsernameService,
-    private readonly accountService: AccountService,
   ) { }
 
   @Get("/usernames/:username")
@@ -22,6 +20,7 @@ export class UsernameController {
 
   @NoCache()
   async getUsernameDetails(
+    @Res() res: any,
     @Param('username') username: string,
     @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean
   ): Promise<AccountDetailed | null> {
@@ -30,6 +29,8 @@ export class UsernameController {
       throw new HttpException('Account not found', HttpStatus.NOT_FOUND);
     }
 
-    return await this.accountService.getAccount(address, undefined, withGuardianInfo);
+    const route = this.usernameService.getUsernameRedirectRoute(address, withGuardianInfo);
+
+    return res.redirect(route);
   }
 }

--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -5,6 +5,7 @@ import { UsernameService } from "./username.service";
 import { NoCache } from '@multiversx/sdk-nestjs-cache';
 import { AccountService } from '../accounts/account.service';
 import { ParseBoolPipe } from '@multiversx/sdk-nestjs-common';
+import { AccountDetailed } from '../accounts/entities/account.detailed';
 
 @Controller()
 @ApiTags('usernames')
@@ -22,7 +23,7 @@ export class UsernameController {
   @NoCache()
   async getUsernameDetails(
     @Param('username') username: string,
-    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean): Promise<any> {
+    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean): Promise<AccountDetailed | null> {
     const address = await this.usernameService.getAddressForUsername(username);
     if (!address) {
       throw new HttpException('Account not found', HttpStatus.NOT_FOUND);

--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -1,13 +1,18 @@
 import { AccountUsername } from './entities/account.username';
-import { Controller, Get, HttpException, HttpStatus, Param, Res } from "@nestjs/common";
+import { Controller, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { UsernameService } from "./username.service";
 import { NoCache } from '@multiversx/sdk-nestjs-cache';
+import { AccountService } from '../accounts/account.service';
+import { ParseBoolPipe } from '@multiversx/sdk-nestjs-common';
 
 @Controller()
 @ApiTags('usernames')
 export class UsernameController {
-  constructor(private readonly usernameService: UsernameService) { }
+  constructor(
+    private readonly usernameService: UsernameService,
+    private readonly accountService: AccountService,
+  ) { }
 
   @Get("/usernames/:username")
   @ApiOperation({ summary: 'Account details by username', description: 'Returns account details for a given username. Performs a redirect on the proper account address' })
@@ -15,12 +20,16 @@ export class UsernameController {
   @ApiNotFoundResponse({ description: 'Username not found' })
 
   @NoCache()
-  async getUsernameDetails(@Param('username') username: string, @Res() res: any): Promise<any> {
+  async getUsernameDetails(
+    @Param('username') username: string,
+    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean): Promise<any> {
     const address = await this.usernameService.getAddressForUsername(username);
     if (!address) {
       throw new HttpException('Account not found', HttpStatus.NOT_FOUND);
     }
 
-    return res.redirect(`/accounts/${address}`);
+    const account = await this.accountService.getAccount(address, undefined, withGuardianInfo);
+
+    return account;
   }
 }

--- a/src/endpoints/usernames/username.service.ts
+++ b/src/endpoints/usernames/username.service.ts
@@ -77,4 +77,25 @@ export class UsernameService {
 
     return address;
   }
+
+  getUsernameRedirectRoute(address: string, withGuardianInfo: boolean | undefined) {
+    const params: {} = {
+      withGuardianInfo,
+    };
+
+    const paramArray = [];
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value) {
+        paramArray.push(`${key}=${value}`);
+      }
+    }
+
+    let route = `/accounts/${address}`;
+    if (paramArray.length > 0) {
+      route += '?' + paramArray.join('&');
+    }
+
+    return route;
+  }
 }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -2016,6 +2016,9 @@ enum MexPairState {
   """Inactive state."""
   inactive
 
+  """Partial state."""
+  partial
+
   """Pause state."""
   paused
 }
@@ -3426,6 +3429,9 @@ type TokenAccount {
   """Token account address."""
   address: String!
 
+  """Account assets for the given account."""
+  assets: AccountAssets
+
   """Token attributes if MetaESDT."""
   attributes: String
 
@@ -3449,6 +3455,9 @@ type TokenAssets {
 
   """Locked accounts for the given token assets."""
   lockedAccounts: JSON
+
+  """Name for the given token assets."""
+  name: String!
 
   """PNG URL for the given token assets."""
   pngUrl: String!

--- a/src/test/integration/controllers/username.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/username.controller.e2e-spec.ts
@@ -17,12 +17,12 @@ describe("Username Controller", () => {
   });
 
   describe('/usernames/{username}', () => {
-    it('should return return account details for a given username', async () => {
+    it('should return account details for a given username', async () => {
       const username: string = 'alice';
 
       await request(app.getHttpServer())
         .get(`${path}/${username}`)
-        .expect(302);
+        .expect(200);
     });
   });
 

--- a/src/test/integration/controllers/username.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/username.controller.e2e-spec.ts
@@ -22,7 +22,7 @@ describe("Username Controller", () => {
 
       await request(app.getHttpServer())
         .get(`${path}/${username}`)
-        .expect(200);
+        .expect(302);
     });
   });
 

--- a/src/test/integration/services/username.e2e-spec.ts
+++ b/src/test/integration/services/username.e2e-spec.ts
@@ -168,4 +168,24 @@ describe('UsernameService', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('getUsernameRedirectRoute', () => {
+    it('should return route with address only when withGuardianInfo is undefined', () => {
+      const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
+      const result = service.getUsernameRedirectRoute(address, undefined);
+      expect(result).toEqual(`/accounts/${address}`);
+    });
+
+    it('should return route with address only when withGuardianInfo is false', () => {
+      const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
+      const result = service.getUsernameRedirectRoute(address, false);
+      expect(result).toEqual(`/accounts/${address}`);
+    });
+
+    it('should return route with address and withGuardianInfo when withGuardianInfo is true', () => {
+      const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
+      const result = service.getUsernameRedirectRoute(address, true);
+      expect(result).toEqual(`/accounts/${address}?withGuardianInfo=true`);
+    });
+  });
 });

--- a/src/test/integration/services/username.e2e-spec.ts
+++ b/src/test/integration/services/username.e2e-spec.ts
@@ -173,19 +173,19 @@ describe('UsernameService', () => {
     it('should return route with address only when withGuardianInfo is undefined', () => {
       const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
       const result = service.getUsernameRedirectRoute(address, undefined);
-      expect(result).toEqual(`/accounts/${address}`);
+      expect(result).toStrictEqual(`/accounts/${address}`);
     });
 
     it('should return route with address only when withGuardianInfo is false', () => {
       const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
       const result = service.getUsernameRedirectRoute(address, false);
-      expect(result).toEqual(`/accounts/${address}`);
+      expect(result).toStrictEqual(`/accounts/${address}`);
     });
 
     it('should return route with address and withGuardianInfo when withGuardianInfo is true', () => {
       const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
       const result = service.getUsernameRedirectRoute(address, true);
-      expect(result).toEqual(`/accounts/${address}?withGuardianInfo=true`);
+      expect(result).toStrictEqual(`/accounts/${address}?withGuardianInfo=true`);
     });
   });
 });


### PR DESCRIPTION
## Proposed Changes
- Instead of fetch (redirect) to `accounts/address`, use  `getAccount` from `AccountService` to return `AccountDetailed` with Guardian Info when `withGuardianInfo` filter is set.

## How to test
- use an account guarded -> `/usernames/:username?withGuardianInfo=true` -> it should return guardian info keys

