### PR TITLE
Add function attribute to smart contract results

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -347,13 +347,13 @@ export class ElasticIndexerService implements IndexerInterface {
       query = query.withShouldCondition(filter.originalTxHashes.map(originalTxHash => QueryType.Match('originalTxHash', originalTxHash)));
     }
 
-    const items = await this.elasticService.getList('scresults', 'hash', query);
+    const results = await this.elasticService.getList('scresults', 'hash', query);
 
-    for (const item of items) {
-      this.processTransaction(item);
+    for (const result of results) {
+      this.processTransaction(result);
     }
 
-    return items;
+    return results;
   }
 
   async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<any[]> {
@@ -524,8 +524,8 @@ export class ElasticIndexerService implements IndexerInterface {
 
     const results = await this.elasticService.getList('scresults', 'hash', elasticQuerySc);
 
-    for (const item of results) {
-      this.processTransaction(item);
+    for (const result of results) {
+      this.processTransaction(result);
     }
 
     return results;

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -208,7 +208,11 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResult(scHash: string): Promise<any> {
-    return await this.elasticService.getItem('scresults', 'hash', scHash);
+    const result = await this.elasticService.getItem('scresults', 'hash', scHash);
+
+    this.processTransaction(result);
+
+    return result;
   }
 
   async getBlock(hash: string): Promise<Block> {
@@ -343,7 +347,15 @@ export class ElasticIndexerService implements IndexerInterface {
       query = query.withShouldCondition(filter.originalTxHashes.map(originalTxHash => QueryType.Match('originalTxHash', originalTxHash)));
     }
 
-    return await this.elasticService.getList('scresults', 'hash', query);
+    const items = await this.elasticService.getList('scresults', 'hash', query);
+
+    console.log({ items });
+
+    for (const item of items) {
+      this.processTransaction(item);
+    }
+
+    return items;
   }
 
   async getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<any[]> {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -512,7 +512,13 @@ export class ElasticIndexerService implements IndexerInterface {
       .withSort([timestamp])
       .withCondition(QueryConditionOptions.must, [originalTxHashQuery]);
 
-    return await this.elasticService.getList('scresults', 'hash', elasticQuerySc);
+    const results = await this.elasticService.getList('scresults', 'hash', elasticQuerySc);
+
+    for (const item of results) {
+      this.processTransaction(item);
+    }
+
+    return results;
   }
 
   async getScResultsForTransactions(elasticTransactions: any[]): Promise<any[]> {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -349,8 +349,6 @@ export class ElasticIndexerService implements IndexerInterface {
 
     const items = await this.elasticService.getList('scresults', 'hash', query);
 
-    console.log({ items });
-
     for (const item of items) {
       this.processTransaction(item);
     }

--- a/src/endpoints/sc-results/entities/smart.contract.result.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.ts
@@ -86,4 +86,8 @@ export class SmartContractResult {
   @Field(() => TransactionAction, { description: 'Transaction action for the given smart contract result.', nullable: true })
   @ApiProperty({ type: TransactionAction, nullable: true })
   action: TransactionAction | undefined = undefined;
+
+  @Field(() => String, { description: 'Function call', nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  function: string | undefined = undefined;
 }


### PR DESCRIPTION
## Proposed Changes
- Add `function` attribute to smart contract results

## How to test
- `/results?miniBlockHash=de06738bc512eb3995671e07c79149a4888ad5d9d6355457fd210dd081fb975b`
- `/results/898686a2bd64e8da4864c248e56a1a1771ebab052672a2d1e9c9c848d83539e7`
- `/transactions/2d6aa31a10788118148eabf316f40b0339df0002d47cc08c1bfa986071fec1b9`
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx0llllsdx93z0/results/d6657f6eca39a78e6eeb1afdd634e6416bb9e7f5748e4a961693681a199dcb64`
- all of the above, should provide the `function` attribute for smart contract results

