### PR TITLE
add token timestamp

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -804,7 +804,7 @@ export class ElasticIndexerService implements IndexerInterface {
   async getAllFungibleTokens(): Promise<any[]> {
     const query = ElasticQuery.create()
       .withMustMatchCondition('type', TokenType.FungibleESDT)
-      .withFields(["name", "type", "currentOwner", "numDecimals", "properties"])
+      .withFields(["name", "type", "currentOwner", "numDecimals", "properties", "timestamp"])
       .withMustNotExistCondition('identifier');
 
     const allTokens: any[] = [];

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -219,6 +219,7 @@ export class EsdtService {
       canTransferNFTCreateRole: elasticProperties.properties?.canTransferNFTCreateRole ?? false,
       NFTCreateStopped: elasticProperties.properties?.NFTCreateStopped ?? false,
       isPaused: elasticProperties.properties?.isPaused ?? false,
+      timestamp: elasticProperties.timestamp,
     });
 
     if (elasticProperties.type === 'FungibleESDT') {

--- a/src/endpoints/tokens/entities/token.properties.ts
+++ b/src/endpoints/tokens/entities/token.properties.ts
@@ -68,4 +68,7 @@ export class TokenProperties {
 
   @ApiProperty()
   NFTCreateStopped: boolean = false;
+
+  @ApiProperty()
+  timestamp: number = 0;
 }

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -697,6 +697,7 @@ describe('Token Service', () => {
       canAddSpecialRoles: false,
       canTransferNFTCreateRole: false,
       NFTCreateStopped: false,
+      timestamp: 1643824710,
     };
 
     it('should returns undefined if getTokenProperties returns undefined', async () => {
@@ -744,6 +745,7 @@ describe('Token Service', () => {
       canAddSpecialRoles: false,
       canTransferNFTCreateRole: false,
       NFTCreateStopped: false,
+      timestamp: 1643824710,
     };
 
     const assets = {


### PR DESCRIPTION
## Reasoning
- For all fungible tokens, creation date field was not defined
  
## Proposed Changes
- Fetch `timestamp` value from ES for every fungible token

## How to test
- `/tokens` -> all tokens should have `timestamp` field defined
- `/accounts/erd1awuuva7dhnlun9huwx7uefwpkhzjx9d3phenujgkv3zvx9tvsatsw420qt/tokens/UTK-2f80e9` -> returned token should have `timestamp` field defined
-  `/accounts/erd1kc3y0d3jhmv4j42lvyq84t395s7s47tucpw97grwgaj8dqlkzumsw97k34/roles/tokens`  -> returned token should have `timestamp` field defined
-  `/accounts/erd1kc3y0d3jhmv4j42lvyq84t395s7s47tucpw97grwgaj8dqlkzumsw97k34/roles/tokens/UTK-2f80e9` -> returned token should have `timestamp` field defined