### PR TITLE
add token value key for ESDTNFTBurn transaction

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
@@ -77,6 +77,7 @@ export class TransactionActionEsdtNftRecognizerService implements TransactionAct
       token: {
         ...tokenProperties,
       },
+      value: BinaryUtils.hexToNumber(metadata.functionArgs[2]),
     };
     return result;
   }

--- a/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
@@ -63,6 +63,7 @@ export class TransactionActionEsdtNftRecognizerService implements TransactionAct
     }
 
     const tokenIdentifier = BinaryUtils.hexToString(metadata.functionArgs[0]);
+    const value = BinaryUtils.hexToNumber(metadata.functionArgs[2]);
     const tokenProperties = await this.tokenTransferService.getTokenTransferProperties(tokenIdentifier);
 
     if (!tokenProperties) {
@@ -77,7 +78,7 @@ export class TransactionActionEsdtNftRecognizerService implements TransactionAct
       token: {
         ...tokenProperties,
       },
-      value: BinaryUtils.hexToNumber(metadata.functionArgs[2]),
+      value: value,
     };
     return result;
   }

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -173,7 +173,11 @@ describe('Transaction Service', () => {
       const txHash: string = "1a9176f5e3be9b2bff237e9fc6da34589d1cd9a8f3499354df26c5efd7a8a5a8";
       const result = await transactionService.getTransaction(txHash);
 
-      expect(result?.action?.name).toStrictEqual('burn');
+
+      if (result?.action?.arguments) {
+        expect(result.action.name).toStrictEqual('burn');
+        expect(result.action.arguments.value).toStrictEqual(1);
+      }
     });
 
     it(`should return "action" key for ESDTNFTTransfer transaction`, async () => {


### PR DESCRIPTION
 
## Proposed Changes
- Add token burn value for ESDTNFTBurn transaction

## How to test
-`/transactions/e3526867c86fa9f31ef174d67578def2716ceb7d144f42fb2756ae9e4d0121d4` -> value should be 1
