### PR TITLE
Removed getTotalActiveStake vm query

### DIFF
--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -247,11 +247,6 @@ export class NetworkService {
     const {
       account: { balance: stakedBalance },
     } = await this.gatewayService.getAddressDetails(`${this.apiConfigService.getAuctionContractAddress()}`);
-    let [activeStake] = await this.vmQueryService.vmQuery(
-      this.apiConfigService.getDelegationContractAddress(),
-      'getTotalActiveStake',
-    );
-    activeStake = this.numberDecode(activeStake);
 
     const elrondConfig = {
       feesInEpoch: 0,


### PR DESCRIPTION
## Proposed Changes
- Removed getTotalActiveStake vm query since the resulting variable is not used anywhere

## How to test
- nothing should be affected by this change