### PR TITLE
Raw token image if not standard network

### DIFF
--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -93,7 +93,11 @@ export class AssetsService {
   }
 
   private getImageUrl(tokenIdentifier: string, name: string) {
-    return `${this.apiConfigService.getExternalMediaUrl()}/tokens/asset/${tokenIdentifier}/${name}`;
+    if (['mainnet', 'devnet', 'testnet'].includes(this.apiConfigService.getNetwork())) {
+      return `${this.apiConfigService.getExternalMediaUrl()}/tokens/asset/${tokenIdentifier}/${name}`;
+    }
+
+    return `https://raw.githubusercontent.com/multiversx/mx-assets/master/${this.apiConfigService.getNetwork()}/tokens/${tokenIdentifier}/${name}`;
   }
 
   private getTokenAssetsPath() {


### PR DESCRIPTION
## Reasoning
- *-media.elrond.com works only with standard networks, and will not work with newer networks, such as `devnet2`
  
## Proposed Changes
- if not standard network, return the raw image from `githubusercontent.com`

## How to test
- if network `devnet2`, token image from github
