### PR TITLE
 add token identifier into esdnft burn transaction action

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
@@ -62,9 +62,10 @@ export class TransactionActionEsdtNftRecognizerService implements TransactionAct
       return undefined;
     }
 
-    const tokenIdentifier = BinaryUtils.hexToString(metadata.functionArgs[0]);
+    const identifier = BinaryUtils.hexToString(metadata.functionArgs[0]);
     const value = BinaryUtils.hexToNumber(metadata.functionArgs[2]);
-    const tokenProperties = await this.tokenTransferService.getTokenTransferProperties(tokenIdentifier);
+    const nonce = metadata.functionArgs[1];
+    const tokenProperties = await this.tokenTransferService.getTokenTransferProperties(identifier);
 
     if (!tokenProperties) {
       return undefined;
@@ -73,12 +74,13 @@ export class TransactionActionEsdtNftRecognizerService implements TransactionAct
     const result = new TransactionAction();
     result.category = TransactionActionCategory.esdtNft;
     result.name = 'burn';
-    result.description = `Burned token ${tokenIdentifier}`;
+    result.description = `Burned token ${identifier}`;
     result.arguments = {
       token: {
         ...tokenProperties,
+        identifier: `${identifier}-${nonce}`,
+        value: value,
       },
-      value: value,
     };
     return result;
   }

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -176,7 +176,7 @@ describe('Transaction Service', () => {
 
       if (result?.action?.arguments) {
         expect(result.action.name).toStrictEqual('burn');
-        expect(result.action.arguments.value).toStrictEqual(1);
+        expect(result.action.arguments.token.value).toStrictEqual(1);
       }
     });
 


### PR DESCRIPTION

## Proposed Changes
- Add `token identifier` into transaction `action`
- Add `value` key into token object

## How to test (DEVNET)
- `/transactions/d1256602d14dc902a7768435c0ca32769697859d228555e39d59ae8bae1477db` - 
action.token should contain `identifier` and `value` key
```
"token": {
                "type": "MetaESDT",
                "name": "TMST",
                "ticker": "TMST-cab4bb",
                "collection": "TMST-cab4bb",
                "decimals": 18,
                "identifier": "TMST-cab4bb-01",
                "value": 1000000000000000000
            }
```
