### PR TITLE
remove api urls servers config

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -65,13 +65,8 @@ aws:
   s3Region: ''
 urls:
   self: 'https://devnet-api.multiversx.com'
-  api:
-    - 'https://devnet-api.multiversx.com'
-    - 'https://testnet-api.multiversx.com'
-    - 'https://api.multiversx.com'
-    - 'http://localhost:3001'
   elastic:
-    - 'https://devnet-index.elrond.com'
+    - 'https://devnet-index.multiversx.com'
   gateway:
     - 'https://devnet-gateway.multiversx.com'
   verifier: 'https://play-api.multiversx.com'

--- a/config/config.devnet2.yaml
+++ b/config/config.devnet2.yaml
@@ -65,11 +65,6 @@ aws:
   s3Region: ''
 urls:
   self: 'https://devnet2-api.multiversx.com'
-  api:
-    - 'https://devnet2-api.multiversx.com'
-    - 'https://testnet-api.multiversx.com'
-    - 'https://api.multiversx.com'
-    - 'http://localhost:3001'
   elastic:
     - 'https://devnet2-index.multiversx.com'
   gateway:

--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -25,10 +25,6 @@ flags:
   collectionPropertiesFromGateway: false
 urls:
   self: 'https://api.multiversx.com'
-  api:
-    - 'https://api.multiversx.com'
-    - 'https://devnet-api.multiversx.com'
-    - 'https://testnet-api.multiversx.com'
   elastic:
     - 'https://index.multiversx.com'
   gateway:

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -25,10 +25,6 @@ flags:
   collectionPropertiesFromGateway: false
 urls:
   self: 'https://api.multiversx.com'
-  api:
-    - 'https://api.multiversx.com'
-    - 'https://devnet-api.multiversx.com'
-    - 'https://testnet-api.multiversx.com'
   elastic:
     - 'https://index.multiversx.com'
   gateway:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -65,10 +65,6 @@ aws:
   s3Region: ''
 urls:
   self: 'https://api.multiversx.com'
-  api:
-    - 'https://api.multiversx.com'
-    - 'https://devnet-api.multiversx.com'
-    - 'https://testnet-api.multiversx.com'
   elastic:
     - 'https://index.multiversx.com'
   gateway:

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -65,10 +65,6 @@ aws:
   s3Region: ''
 urls:
   self: 'https://testnet-api.multiversx.com'
-  api:
-    - 'https://testnet-api.multiversx.com'
-    - 'https://devnet-api.multiversx.com'
-    - 'https://api.multiversx.com'
   elastic:
     - 'https://testnet-index.multiversx.com'
   gateway:

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -11,15 +11,6 @@ export class ApiConfigService {
     return this.configService.get<T>(configKey);
   }
 
-  getApiUrls(): string[] {
-    const apiUrls = this.configService.get<string[]>('urls.api');
-    if (!apiUrls) {
-      throw new Error('No API urls present');
-    }
-
-    return apiUrls;
-  }
-
   getSelfUrl(): string {
     const selfUrl = this.configService.get<string>('urls.self');
     if (!selfUrl) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,16 +261,11 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
     'utf8',
   );
 
-  let documentBuilder = new DocumentBuilder()
+  const documentBuilder = new DocumentBuilder()
     .setTitle('Multiversx API')
     .setDescription(description)
     .setVersion('1.0.0')
     .setExternalDoc('Find out more about Multiversx API', 'https://docs.multiversx.com/sdk-and-tools/rest-api/rest-api/');
-
-  const apiUrls = apiConfigService.getApiUrls();
-  for (const apiUrl of apiUrls) {
-    documentBuilder = documentBuilder.addServer(apiUrl);
-  }
 
   const config = documentBuilder.build();
   const options = {

--- a/src/test/integration/services/api.config.e2e-spec.ts
+++ b/src/test/integration/services/api.config.e2e-spec.ts
@@ -18,33 +18,6 @@ describe('API Config', () => {
 
   beforeEach(() => { jest.restoreAllMocks(); });
 
-  describe("getApiUrls", () => {
-    it("should return api urls", () => {
-      jest
-        .spyOn(ConfigService.prototype, "get")
-        .mockImplementation(jest.fn(() => [
-          'https://api.multiversx.com',
-          'https://devnet-api.multiversx.com',
-          'https://testnet-api.multiversx.com',
-        ]));
-
-      const results = apiConfigService.getApiUrls();
-      expect(results).toEqual(expect.arrayContaining([
-        'https://api.multiversx.com',
-        'https://devnet-api.multiversx.com',
-        'https://testnet-api.multiversx.com',
-      ]));
-    });
-
-    it("should throw error because test simulates that api urls are not defined", () => {
-      jest
-        .spyOn(ConfigService.prototype, 'get')
-        .mockImplementation(jest.fn(() => undefined));
-
-      expect(() => apiConfigService.getApiUrls()).toThrowError('No API urls present');
-    });
-  });
-
   describe("getGatewayUrl", () => {
     it("should return gateway url", () => {
       jest


### PR DESCRIPTION
 
## Proposed Changes
-  Remove support for swagger API servers ( testnet / devnet / mainnet )
-  Remove urls.api from configs
-  Remove getApiUrls from apiConfigService.ts
-  Remove e2e-spec.ts for getApiUrls

## How to test
- `run: npm run start:mainnet` -> access `localhost:3001`  and verify is servers dropdown list are removed
