### PR TITLE
add support for events topics

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -98,7 +98,7 @@ export class TokenTransferService {
 
     const operations: TransactionOperation[] = [];
     for (const scResult of scResults) {
-      if (scResult.value === undefined || scResult.value === '0') {
+      if (scResult.nonce !== 0 || scResult.value === undefined || scResult.value === '0') {
         continue;
       }
 

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -248,9 +248,21 @@ export class TokenTransferService {
 
   private getTransactionTransferValueOperation(txHash: string, log: TransactionLog, event: TransactionLogEvent, action: TransactionOperationAction): TransactionOperation | undefined {
     try {
-      const sender = BinaryUtils.base64ToAddress(event.topics[0]);
-      const receiver = BinaryUtils.base64ToAddress(event.topics[1]);
-      const value = BinaryUtils.base64ToBigInt(event.topics[2]).toString();
+      let sender: string;
+      let receiver: string;
+      let value: string;
+
+      if (event.topics.length === 2) {
+        sender = event.address;
+        receiver = BinaryUtils.base64ToAddress(event.topics[1]);
+        value = BinaryUtils.base64ToBigInt(event.topics[0]).toString();
+      } else if (event.topics.length === 3) {
+        sender = BinaryUtils.base64ToAddress(event.topics[0]);
+        receiver = BinaryUtils.base64ToAddress(event.topics[1]);
+        value = BinaryUtils.base64ToBigInt(event.topics[2]).toString();
+      } else {
+        throw new Error(`Unrecognized topic count when interpreting transferValue event`);
+      }
 
       const operation = new TransactionOperation();
       operation.id = log.id ?? '';

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -98,7 +98,7 @@ export class TokenTransferService {
 
     const operations: TransactionOperation[] = [];
     for (const scResult of scResults) {
-      if (scResult.nonce !== 0 || scResult.value === undefined || scResult.value === '0') {
+      if (scResult.value === undefined || scResult.value === '0') {
         continue;
       }
 


### PR DESCRIPTION
## Reasoning
-  At the topic event level, changes were made to the number of events

## Proposed Changes
-  Handle events topics with length 2 
-  Keep support for event topics with length 3

## How to test ( TESTNET )
- `/transactions/68c028cfcecbf4acc625ef5d0591e3bcc8b8d352e761a324f1bec9f1d42e9b40` -> operations attribute should contain 2 transfers events 