### PR TITLE
add support for dynamic pairLimit

### DIFF
--- a/src/common/graphql/graphql.service.ts
+++ b/src/common/graphql/graphql.service.ts
@@ -11,13 +11,14 @@ export class GraphQlService {
     private readonly apiConfigService: ApiConfigService
   ) { }
 
-  async getData(query: string, variables: any): Promise<any> {
+  async getData(query: string, variables?: any): Promise<any> {
     const MAIAR_EXCHANGE_URL = this.apiConfigService.getExchangeServiceUrlMandatory();
-
     const graphqlClient = new GraphQLClient(MAIAR_EXCHANGE_URL);
 
     try {
-      const data = await graphqlClient.request(query, variables);
+      const data = variables
+        ? await graphqlClient.request(query, variables)
+        : await graphqlClient.request(query);
 
       if (!data) {
         return null;

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -70,9 +70,19 @@ export class MexPairService {
         throw new BadRequestException('Could not fetch MEX settings');
       }
 
+      const pairsLimit = gql`
+      query PairCount {
+        factory {
+          pairCount
+        }
+      }`;
+
+      const pairsLimitResult: any = await this.graphQlService.getData(pairsLimit);
+      const totalPairs = pairsLimitResult?.factory?.pairCount;
+
       const variables = {
         "offset": 0,
-        "pairsLimit": 100,
+        "pairsLimit": totalPairs,
       };
 
       const query = gql`


### PR DESCRIPTION
## Reasoning
- pairLimit it was hardcoded when making a request to pairs dex graphql 
- since the limit was set to 100, all the pairs created later did not contain the date such as `marketCap`, `price`, for example `XBID-c7e360`
  
## Proposed Changes
- Add new query to return total number of available pairs from DEX
- refactoring of the `getData` method to allow the execution of the query without the declared variables

## How to test
- `mex/pairs?size=200` -> should return 104 pairs
- `tokens/XBID-c7e360` -> `marketCap, price` attributes should be defined
