### PR TITLE
update delegation contract

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -104,7 +104,7 @@ contracts:
   auction: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l'
   staking: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqllls0lczs7'
   delegationManager: 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqylllslmq6y6'
-  delegation: 'erd1qqqqqqqqqqqqqpgqp699jngundfqw07d8jzkepucvpzush6k3wvqyc44rx'
+  delegation: 'erd1qqqqqqqqqqqqqpgq97wezxw6l7lgg7k9rxvycrz66vn92ksh2tssxwf7ep'
   metabonding: 'erd1qqqqqqqqqqqqqpgqkg7we73j769ew5we4yyx7uyvnn0nefqgd8ssm6vjc2'
 inflation:
   - 1952123


### PR DESCRIPTION
## Reasoning
- Due to the transition to the new `devnet`, the `delegation contract` was changed
  
## Proposed Changes
- Update delegation contract to the new contract

## How to test
-` /economics` -> should return economics info 
