### PR TITLE
support for transfer function hex value

### DIFF
--- a/src/common/indexer/entities/transaction.ts
+++ b/src/common/indexer/entities/transaction.ts
@@ -24,5 +24,6 @@ export interface Transaction {
   receivers: string[];
   receiversShardIDs: number[];
   operation: string;
+  function: string;
   scResults: any[];
 }

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -419,6 +419,7 @@ describe('Account Service', () => {
         receiversShardIDs: [],
         operation: '',
         scResults: [],
+        function: 'unDelegate',
       });
 
       const result = await service.getAccountDeployedAtRaw(address);

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -179,6 +179,7 @@ describe('TransactionService', () => {
         receiversShardIDs: [1],
         operation: 'transfer',
         scResults: [''],
+        function: 'lockTokens',
       },
       {
         hash: '2b1ce5558f5faa533afd437a42a5aeadea8302dc3cca778c0ed50d19c0a047a4',
@@ -210,6 +211,7 @@ describe('TransactionService', () => {
         receiversShardIDs: [1],
         operation: 'transfer',
         scResults: [''],
+        function: 'unDelegate',
       },
     ];
 


### PR DESCRIPTION
## Reasoning
- To enhance the functionality of the `getTransfers` method by adding support for decoding hex values when specific conditions are met.
- Handling edge cases where `senderShard` and `receiverShard` equal the `metaChainShardId`, which requires decoding the `function` field from `hex` -> `string`.
  
## Proposed Changes
- Updated the `getTransfers` method to decode the function field from hex to a string when both `senderShard`, `receiverShard` are equal to `metaChainShardId` and function value is a valid `hex` .
- Refactored the `getTransactionAction` to correctly process the `action.name` by checking for the meta chain shard ID condition and applying hex decoding as needed.
- Introduced  new unit tests to verify the correct behavior of the `getTransfers` method, ensuring that the function is decoded only under the right conditions, and remains unchanged otherwise.

## How to test ( DEVNET)
- `accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz0llllsup4dew/transfers` -> `function` field should be decoded ( hex -> string ) correctly
- run transfers.spec.ts unit tests and verify if all test are :green_circle: 
- run transactions.spec.ts unit tests and verify if all test are :green_circle: 
- run accounts.spec.ts unit tests and verify if all test are :green_circle: 
