### PR TITLE
update eGLD to EGLD token label

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ An API instance can be started with the following behavior:
 
 It depends on the following optional external systems:
 - events notifier rabbitmq: queue that pushes logs & events which are handled internally e.g. to trigger NFT media fetch
-- data: provides eGLD price information for transactions
+- data: provides EGLD price information for transactions
 - xexchange: provides price information regarding various tokens listed on the xExchange
 - ipfs: ipfs gateway for fetching mainly NFT metadata & media files
 - media: ipfs gateway which will be used as prefix for NFT media & metadata returned in the NFT details

--- a/config/dapp.config.mainnet.json
+++ b/config/dapp.config.mainnet.json
@@ -1,7 +1,7 @@
 {
   "id": "mainnet",
   "name": "Mainnet",
-  "egldLabel": "eGLD",
+  "egldLabel": "EGLD",
   "decimals": "4",
   "egldDenomination": "18",
   "gasPerDataByte": "1500",

--- a/src/endpoints/dapp-config/entities/dapp-config.ts
+++ b/src/endpoints/dapp-config/entities/dapp-config.ts
@@ -16,7 +16,7 @@ export class DappConfig {
   name: string = '';
 
   @Field(() => String, { description: 'Token label details' })
-  @ApiProperty({ type: String, example: 'eGLD' })
+  @ApiProperty({ type: String, example: 'EGLD' })
   egldLabel: string = '';
 
   @Field(() => String, { description: 'Token details' })

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
@@ -43,7 +43,7 @@ export class MexWrapActionRecognizerService {
     const result = new TransactionAction();
     result.category = TransactionActionCategory.mex;
     result.name = MexFunction.wrapEgld;
-    result.description = `Wrap ${valueDenominated} eGLD`;
+    result.description = `Wrap ${valueDenominated} EGLD`;
     result.arguments = {
       token: {
         type: EsdtType.FungibleESDT,

--- a/src/endpoints/transactions/transaction-action/recognizers/staking/transaction.action.stake.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/staking/transaction.action.stake.recognizer.service.ts
@@ -84,7 +84,7 @@ export class StakeActionRecognizerService implements TransactionActionRecognizer
     const result = new TransactionAction();
     result.category = TransactionActionCategory.stake;
     result.name = StakeFunction.delegate;
-    result.description = `Delegate ${valueDenominated} eGLD to staking provider ${providerDetails.providerName}`;
+    result.description = `Delegate ${valueDenominated} EGLD to staking provider ${providerDetails.providerName}`;
     result.arguments = {
       value: value.toString(),
       ...providerDetails,
@@ -100,7 +100,7 @@ export class StakeActionRecognizerService implements TransactionActionRecognizer
     const result = new TransactionAction();
     result.category = TransactionActionCategory.stake;
     result.name = StakeFunction.unDelegate;
-    result.description = `Undelegate ${valueDenominated} eGLD from staking provider ${providerDetails.providerName}`;
+    result.description = `Undelegate ${valueDenominated} EGLD from staking provider ${providerDetails.providerName}`;
     result.arguments = {
       value: value.toString(),
       ...providerDetails,


### PR DESCRIPTION
## Reasoning
- xPortal need to display on app EGLD token label, instead of eGLD
  
## Proposed Changes
- Update token label from eGLD -> EGLD to `dapp.config`, `action recognizer`, `stake recognizer` 

## How to test ( MAINNET )
- `/dapp/config` ->` "egldLabel": "EGLD"` -> EGLD label should contain `EGLD` instead of `eGLD`

