### PR TITLE
avoid magic numbers for metaChainShardId

### DIFF
--- a/src/common/protocol/protocol.service.ts
+++ b/src/common/protocol/protocol.service.ts
@@ -4,6 +4,7 @@ import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { CacheInfo } from "../../utils/cache.info";
 import { GatewayService } from "../gateway/gateway.service";
 import { IndexerService } from "../indexer/indexer.service";
+import { ApiConfigService } from "../api-config/api.config.service";
 
 @Injectable()
 export class ProtocolService {
@@ -15,7 +16,8 @@ export class ProtocolService {
     @Inject(forwardRef(() => CacheService))
     private readonly cachingService: CacheService,
     @Inject(forwardRef(() => IndexerService))
-    private readonly indexerService: IndexerService
+    private readonly indexerService: IndexerService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   async getShardIds(): Promise<number[]> {
@@ -42,13 +44,14 @@ export class ProtocolService {
 
   private async getShardIdsRaw(): Promise<number[]> {
     const shardCount = await this.getShardCountRaw();
+    const metaChainShardId = this.apiConfigService.getMetaChainShardId();
 
     const result = [];
     for (let i = 0; i < shardCount; i++) {
       result.push(i);
     }
 
-    result.push(4294967295);
+    result.push(metaChainShardId);
     return result;
   }
 

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -270,13 +270,13 @@ export class NetworkService {
     const stake = await this.stakeService.getGlobalStake();
     const stakedBalance = await this.getAuctionContractBalance();
 
-    const elrondConfig = {
+    const multiversxConfig = {
       feesInEpoch: 0,
       stakePerNode: 2500,
     };
 
-    const feesInEpoch = elrondConfig.feesInEpoch;
-    const stakePerNode = elrondConfig.stakePerNode;
+    const feesInEpoch = multiversxConfig.feesInEpoch;
+    const stakePerNode = multiversxConfig.stakePerNode;
     const epochDuration = config.roundDuration * config.roundsPerEpoch;
     const secondsInYear = 365 * 24 * 3600;
     const epochsInYear = secondsInYear / epochDuration;

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -220,7 +220,14 @@ export class NetworkService {
   async getStats(): Promise<Stats> {
     const metaChainShard = this.apiConfigService.getMetaChainShardId();
 
-    const promiseResults = await Promise.all([
+    const [
+      networkConfig,
+      networkStatus,
+      blocksCount,
+      accountsCount,
+      transactionsCount,
+      scResultsCount,
+    ] = await Promise.all([
       this.gatewayService.getNetworkConfig(),
       this.gatewayService.getNetworkStatus(metaChainShard),
       this.blockService.getBlocksCount(new BlockFilter()),
@@ -228,13 +235,6 @@ export class NetworkService {
       this.transactionService.getTransactionCount(new TransactionFilter()),
       this.smartContractResultService.getScResultsCount(),
     ]);
-
-    const networkConfig = promiseResults[0];
-    const networkStatus = promiseResults[1];
-    const blocksCount = promiseResults[2];
-    const accountsCount = promiseResults[3];
-    const transactionsCount = promiseResults[4];
-    const scResultsCount = promiseResults[5];
 
     const { erd_num_shards_without_meta: shards, erd_round_duration: refreshRate } = networkConfig;
     const { erd_epoch_number: epoch, erd_rounds_passed_in_current_epoch: roundsPassed, erd_rounds_per_epoch: roundsPerEpoch } = networkStatus;

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -14,7 +14,6 @@ import { StakeService } from '../stake/stake.service';
 import { GatewayService } from 'src/common/gateway/gateway.service';
 import { CacheInfo } from 'src/utils/cache.info';
 import { BinaryUtils, NumberUtils } from '@multiversx/sdk-nestjs-common';
-import { ApiService } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { About } from './entities/about';
 import { PluginService } from 'src/common/plugins/plugin.service';
@@ -39,7 +38,6 @@ export class NetworkService {
     @Inject(forwardRef(() => TransactionService))
     private readonly transactionService: TransactionService,
     private readonly dataApiService: DataApiService,
-    private readonly apiService: ApiService,
     @Inject(forwardRef(() => StakeService))
     private readonly stakeService: StakeService,
     private readonly pluginService: PluginService,
@@ -55,23 +53,13 @@ export class NetworkService {
   }
 
   private async getConstantsRaw(): Promise<NetworkConstants> {
-    const gatewayUrl = this.apiConfigService.getGatewayUrl();
+    const networkConfig = await this.gatewayService.getNetworkConfig();
 
-    const {
-      data: {
-        data: {
-          config: {
-            erd_chain_id: chainId,
-            // erd_denomination: denomination,
-            erd_gas_per_data_byte: gasPerDataByte,
-            erd_min_gas_limit: minGasLimit,
-            erd_min_gas_price: minGasPrice,
-            erd_min_transaction_version: minTransactionVersion,
-            // erd_round_duration: roundDuration,
-          },
-        },
-      },
-    } = await this.apiService.get(`${gatewayUrl}/network/config`);
+    const chainId = networkConfig.erd_chain_id;
+    const gasPerDataByte = networkConfig.erd_gas_per_data_byte;
+    const minGasLimit = networkConfig.erd_min_gas_limit;
+    const minGasPrice = networkConfig.erd_min_gas_price;
+    const minTransactionVersion = networkConfig.erd_min_transaction_version;
 
     return {
       chainId,

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -232,21 +232,7 @@ export class NetworkService {
   async getStats(): Promise<Stats> {
     const metaChainShard = this.apiConfigService.getMetaChainShardId();
 
-    const [
-      {
-        erd_num_shards_without_meta: shards,
-        erd_round_duration: refreshRate,
-      },
-      {
-        erd_epoch_number: epoch,
-        erd_rounds_passed_in_current_epoch: roundsPassed,
-        erd_rounds_per_epoch: roundsPerEpoch,
-      },
-      blocks,
-      accounts,
-      transactions,
-      scResults,
-    ] = await Promise.all([
+    const promiseResults = await Promise.all([
       this.gatewayService.getNetworkConfig(),
       this.gatewayService.getNetworkStatus(metaChainShard),
       this.blockService.getBlocksCount(new BlockFilter()),
@@ -255,12 +241,22 @@ export class NetworkService {
       this.smartContractResultService.getScResultsCount(),
     ]);
 
+    const networkConfig = promiseResults[0];
+    const networkStatus = promiseResults[1];
+    const blocksCount = promiseResults[2];
+    const accountsCount = promiseResults[3];
+    const transactionsCount = promiseResults[4];
+    const scResultsCount = promiseResults[5];
+
+    const { erd_num_shards_without_meta: shards, erd_round_duration: refreshRate } = networkConfig;
+    const { erd_epoch_number: epoch, erd_rounds_passed_in_current_epoch: roundsPassed, erd_rounds_per_epoch: roundsPerEpoch } = networkStatus;
+
     return {
       shards,
-      blocks,
-      accounts,
-      transactions: transactions + scResults,
-      scResults,
+      blocks: blocksCount,
+      accounts: accountsCount,
+      transactions: transactionsCount + scResultsCount,
+      scResults: scResultsCount,
       refreshRate,
       epoch,
       roundsPassed: roundsPassed % roundsPerEpoch,

--- a/src/test/unit/services/network.spec.ts
+++ b/src/test/unit/services/network.spec.ts
@@ -1,4 +1,3 @@
-import { ApiService } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { Test } from "@nestjs/testing";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
@@ -96,12 +95,6 @@ describe('NetworkService', () => {
           provide: TransactionService,
           useValue: {
             getTransactionCount: jest.fn(),
-          },
-        },
-        {
-          provide: ApiService,
-          useValue: {
-            get: jest.fn(),
           },
         },
         {

--- a/src/test/unit/services/network.spec.ts
+++ b/src/test/unit/services/network.spec.ts
@@ -23,6 +23,12 @@ import { CacheInfo } from "src/utils/cache.info";
 
 describe('NetworkService', () => {
   let networkService: NetworkService;
+  let apiConfigService: ApiConfigService;
+  let gatewayService: GatewayService;
+  let blockService: BlockService;
+  let accountService: AccountService;
+  let transactionService: TransactionService;
+  let smartContractResultService: SmartContractResultService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -108,6 +114,7 @@ describe('NetworkService', () => {
           provide: SmartContractResultService,
           useValue: {
             getScResultsCount: jest.fn(),
+            getAccountScResultsCount: jest.fn(),
           },
         },
         {
@@ -126,6 +133,12 @@ describe('NetworkService', () => {
     }).compile();
 
     networkService = moduleRef.get<NetworkService>(NetworkService);
+    apiConfigService = moduleRef.get<ApiConfigService>(ApiConfigService);
+    gatewayService = moduleRef.get<GatewayService>(GatewayService);
+    blockService = moduleRef.get<BlockService>(BlockService);
+    accountService = moduleRef.get<AccountService>(AccountService);
+    transactionService = moduleRef.get<TransactionService>(TransactionService);
+    smartContractResultService = moduleRef.get<SmartContractResultService>(SmartContractResultService);
   });
 
   it('service should be defined', () => {
@@ -393,6 +406,77 @@ describe('NetworkService', () => {
       const decodedNumber = networkService.numberDecode(encodedNumber);
 
       expect(decodedNumber).toBe('0');
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return stats details', async () => {
+      const mockNetworkConfig: NetworkConfig = {
+        erd_adaptivity: false,
+        erd_chain_id: '1',
+        erd_denomination: 18,
+        erd_gas_per_data_byte: 1500,
+        erd_gas_price_modifier: '0.01',
+        erd_hysteresis: '0.200000',
+        erd_latest_tag_software_version: 'v1.5.14.0',
+        erd_max_gas_per_transaction: 600000000,
+        erd_meta_consensus_group_size: 400,
+        erd_min_gas_limit: 50000,
+        erd_min_gas_price: 1000000000,
+        erd_min_transaction_version: 1,
+        erd_num_metachain_nodes: 400,
+        erd_num_nodes_in_shard: 400,
+        erd_num_shards_without_meta: 3,
+        erd_rewards_top_up_gradient_point: '2000000000000000000000000',
+        erd_round_duration: 6000,
+        erd_rounds_per_epoch: 14400,
+        erd_shard_consensus_group_size: 63,
+        erd_start_time: 1596117600,
+        erd_top_up_factor: '0.500000',
+      };
+
+      const mockNetworkStatus: NetworkStatus = {
+        erd_cross_check_block_height: '0: 17287291, 1: 17280583, 2: 17287747, ',
+        erd_current_round: 17293220,
+        erd_epoch_number: 1200,
+        erd_highest_final_nonce: 17272382,
+        erd_nonce: 17272383,
+        erd_nonce_at_epoch_start: 17260366,
+        erd_nonces_passed_in_current_epoch: 12017,
+        erd_round_at_epoch_start: 17281202,
+        erd_rounds_passed_in_current_epoch: 12018,
+        erd_rounds_per_epoch: 14400,
+      };
+
+      jest.spyOn(apiConfigService, 'getMetaChainShardId').mockReturnValue(4294967295);
+      jest.spyOn(gatewayService, 'getNetworkConfig').mockResolvedValue(mockNetworkConfig);
+      jest.spyOn(gatewayService, 'getNetworkStatus').mockResolvedValue(mockNetworkStatus);
+      jest.spyOn(blockService, 'getBlocksCount').mockResolvedValue(97128014);
+      jest.spyOn(accountService, 'getAccountsCount').mockResolvedValue(2429648);
+      jest.spyOn(transactionService, 'getTransactionCount').mockResolvedValue(87054604);
+      jest.spyOn(smartContractResultService, 'getScResultsCount').mockResolvedValue(271213143);
+
+      const result = await networkService.getStats();
+
+      expect(apiConfigService.getMetaChainShardId).toHaveBeenCalled();
+      expect(gatewayService.getNetworkConfig).toHaveBeenCalled();
+      expect(gatewayService.getNetworkStatus).toHaveBeenCalled();
+      expect(blockService.getBlocksCount).toHaveBeenCalled();
+      expect(accountService.getAccountsCount).toHaveBeenCalled();
+      expect(transactionService.getTransactionCount).toHaveBeenCalled();
+      expect(smartContractResultService.getScResultsCount).toHaveBeenCalled();
+
+      expect(result).toEqual(expect.objectContaining({
+        shards: 3,
+        blocks: 97128014,
+        accounts: 2429648,
+        transactions: 358267747,
+        scResults: 271213143,
+        refreshRate: 6000,
+        epoch: 1200,
+        roundsPassed: 12018,
+        roundsPerEpoch: 14400,
+      }));
     });
   });
 });


### PR DESCRIPTION
  
## Proposed Changes
- instead of using magic numbers `4294967295` take metaChainShardId from config 
- refactor `getStatus` method from `network.service.ts`
- add new unit tests for `network.spec.ts`
- refactor `getConstantsRaw` method from `network.service.ts`
- remove `apiService.get` and fetch constats data directly from gatewayService using method `getNetworkConfig`
- update `network.spec.ts`


## How to test
- `/shards` -> should return all shards id
- `/nodes` -> all returned nodes should contains shard details
- run `npm run test newtork.spec.ts`
