### PR TITLE
Node sync progress fixes

### DIFF
--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -742,7 +742,7 @@ export class ApiConfigService {
   }
 
   isNodeSyncProgressEnabled(): boolean {
-    return this.configService.get<boolean>('features.nodeSyncProgress.enabled') ?? false;
+    return this.configService.get<boolean>('features.nodeSyncProgress.enabled') ?? true;
   }
 
   isUpdateCollectionExtraDetailsEnabled(): boolean {

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -625,6 +625,8 @@ export class NodeService {
       if (this.apiConfigService.isNodeSyncProgressEnabled() && numTrieNodesReceived > 0) {
         node.syncProgress = numTrieNodesReceived / nodesPerShardDict[shard];
 
+        console.log(`Sync progress for node with bls ${bls} is ${node.syncProgress}`);
+
         if (node.syncProgress > 1) {
           node.syncProgress = 1;
         }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -622,8 +622,9 @@ export class NodeService {
         node.online = false;
       }
 
-      if (this.apiConfigService.isNodeSyncProgressEnabled() && numTrieNodesReceived > 0) {
-        node.syncProgress = numTrieNodesReceived / nodesPerShardDict[shard];
+      const nodesPerShard = nodesPerShardDict[shard];
+      if (this.apiConfigService.isNodeSyncProgressEnabled() && numTrieNodesReceived > 0 && nodesPerShard > 0) {
+        node.syncProgress = numTrieNodesReceived / nodesPerShard;
 
         console.log(`Sync progress for node with bls ${bls} is ${node.syncProgress}`);
 

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -514,7 +514,10 @@ export class NodeService {
       for (const shardId of shardIds) {
         const shardTrieStatistics = await this.gatewayService.getTrieStatistics(shardId);
 
-        nodesPerShardDict[shardId] = shardTrieStatistics.accounts_snapshot_num_nodes;
+        console.log({ shardTrieStatistics });
+
+        // @ts-ignore
+        nodesPerShardDict[shardId] = shardTrieStatistics['accounts-snapshot-num-nodes'];
       }
     }
 

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -514,8 +514,6 @@ export class NodeService {
       for (const shardId of shardIds) {
         const shardTrieStatistics = await this.gatewayService.getTrieStatistics(shardId);
 
-        console.log({ shardTrieStatistics });
-
         // @ts-ignore
         nodesPerShardDict[shardId] = shardTrieStatistics['accounts-snapshot-num-nodes'];
       }
@@ -628,8 +626,6 @@ export class NodeService {
       const nodesPerShard = nodesPerShardDict[shard];
       if (this.apiConfigService.isNodeSyncProgressEnabled() && numTrieNodesReceived > 0 && nodesPerShard > 0) {
         node.syncProgress = numTrieNodesReceived / nodesPerShard;
-
-        console.log(`Sync progress for node with bls ${bls} is ${node.syncProgress}`);
 
         if (node.syncProgress > 1) {
           node.syncProgress = 1;


### PR DESCRIPTION
## Proposed Changes
- Use the correct key when fetching number of trie nodes per shard

## How to test
- restart observer node, soon that bls will have a `syncProgress` attached to it
