### PR TITLE
fix senders filter

### DIFF
--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -367,7 +367,7 @@ export class TokenController {
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -393,9 +393,9 @@ export class TokenController {
     }
 
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScamInfo, withUsername, withBlockInfo });
-
+    console.log(sender);
     return await this.transferService.getTransfers(new TransactionFilter({
-      sender,
+      senders: sender,
       receivers: receiver,
       token: identifier,
       functions,
@@ -429,7 +429,7 @@ export class TokenController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getTokenTransfersCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -450,7 +450,7 @@ export class TokenController {
     }
 
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      sender,
+      senders: sender,
       receivers: receiver,
       token: identifier,
       functions,
@@ -468,7 +468,7 @@ export class TokenController {
   @ApiExcludeEndpoint()
   async getAccountTransfersCountAlternative(
     @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -489,7 +489,7 @@ export class TokenController {
     }
 
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      sender,
+      senders: sender,
       receivers: receiver,
       token: identifier,
       functions,


### PR DESCRIPTION
## Reasoning
- Filtering for senders on route `tokens/:identifier/transfers?sender=erd1` does not return a list of only transfers with sender = `erd1`
  
## Proposed Changes
- Add  support for `ParseAddressArrayPipe` on tokens/:identifier/transfer route `@Query('sender', ParseAddressArrayPipe) sender?: string[],`

## How to test
- `tokens/HTM-f51d55/transfers?withUsername=true&from=0&size=25&sender=erd109v7c0x9wddclwt4jv3g2y5tqfxgnvy4npd5aqhj7wjfhfkwtwzqr7g7m2&receiver=erd1qqqqqqqqqqqqqpgqxhgs55hpdqll93nnvf0nwnt3wmh62u692jps5wm8uj` -> should return only the transfers with sender = `erd109v7c0x9wddclwt4jv3g2y5tqfxgnvy4npd5aqhj7wjfhfkwtwzqr7g7m2`
- `tokens/HTM-f51d55/transfers/count?withUsername=true&from=0&size=25&sender=erd109v7c0x9wddclwt4jv3g2y5tqfxgnvy4npd5aqhj7wjfhfkwtwzqr7g7m2&receiver=erd1qqqqqqqqqqqqqpgqxhgs55hpdqll93nnvf0nwnt3wmh62u692jps5wm8uj` -> should return `~6` transfers
- 
