### PR TITLE
added /accounts/bulk endpoint

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -38,5 +38,6 @@ export enum GatewayComponentRequest {
   trieStatistics = 'trieStatistics',
   transactionPool = 'transactionPool',
   gasConfigs = 'gasConfigs',
-  transactionProcessStatus = 'transactionProcessStatus'
+  transactionProcessStatus = 'transactionProcessStatus',
+  addressesBulk = 'addressesBulk'
 }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, Query } from '@nestjs/common';
+import { Body, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, Post, Query } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { AccountService } from './account.service';
 import { AccountDetailed } from './entities/account.detailed';
@@ -1122,5 +1122,20 @@ export class AccountController {
       address, tokenIdentifier,
       new QueryPagination({ from, size }),
       new AccountHistoryFilter({ before, after }));
+  }
+
+  @Post('/accounts/bulk')
+  @ApiOperation({ summary: 'Perform bulk accounts request', description: 'Receives an array of addresses and returns the accounts details, as a map/dictionary' })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  async handleAccountsBulkRequest(
+    @Body(new ParseAddressArrayPipe) accounts: string[],
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+  ): Promise<Record<string, AccountDetailed>> {
+    return await this.accountService.getAccountsBulk(
+      accounts,
+      new QueryPagination({ from, size }),
+    );
   }
 }


### PR DESCRIPTION
## Reasoning
- `rc/v1.6.0` proxy will support bulk accounts requests    
  
## Proposed Changes
- added the `/accounts/bulk` endpoint that receives an array of addresses and returns a map (record) with the address key and the accounts details as value

## How to test
- POST api/accounts/bulk with an array of bech32 addresses as body
