### PR TITLE
fix array of functions

### DIFF
--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -12,7 +12,7 @@ cron:
   transactionBatchMaxLookBehind: 100
   cacheWarmer: true
   fastWarm: false
-  queueWorker: false
+  queueWorker: true
   elasticUpdater: false
   statusChecker: false
 flags:
@@ -21,8 +21,8 @@ flags:
   useTracing: false
   useRequestLogging: false
   useVmQueryTracing: false
-  processNfts: false
-  indexer-v3: true
+  processNfts: true
+  indexer-v3: false
   collectionPropertiesFromGateway: false
 features:
   eventsNotifier:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -12,7 +12,7 @@ cron:
   transactionBatchMaxLookBehind: 100
   cacheWarmer: true
   fastWarm: false
-  queueWorker: true
+  queueWorker: false
   elasticUpdater: false
   statusChecker: false
 flags:
@@ -21,8 +21,8 @@ flags:
   useTracing: false
   useRequestLogging: false
   useVmQueryTracing: false
-  processNfts: true
-  indexer-v3: false
+  processNfts: false
+  indexer-v3: true
   collectionPropertiesFromGateway: false
 features:
   eventsNotifier:

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -279,11 +279,17 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
+        const functionConditions = [];
         for (const field of filter.functions) {
-          elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
-            QueryType.Match('function', field),
+          const shouldConditions = QueryType.Should([
+            QueryType.Match('function', field, QueryOperator.AND),
             QueryType.Match('operation', field),
-          ]));
+          ]);
+          functionConditions.push(shouldConditions);
+        }
+
+        if (functionConditions.length > 0) {
+          elasticQuery = elasticQuery.withMustCondition(QueryType.Should(functionConditions));
         }
       }
     }
@@ -437,11 +443,17 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
+        const functionConditions = [];
         for (const field of filter.functions) {
-          elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
-            QueryType.Match('function', field),
+          const shouldConditions = QueryType.Should([
+            QueryType.Match('function', field, QueryOperator.AND),
             QueryType.Match('operation', field),
-          ]));
+          ]);
+          functionConditions.push(shouldConditions);
+        }
+
+        if (functionConditions.length > 0) {
+          elasticQuery = elasticQuery.withMustCondition(QueryType.Should(functionConditions));
         }
       }
     }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -279,18 +279,7 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
-        const functionConditions = [];
-        for (const field of filter.functions) {
-          const shouldConditions = QueryType.Should([
-            QueryType.Match('function', field, QueryOperator.AND),
-            QueryType.Match('operation', field),
-          ]);
-          functionConditions.push(shouldConditions);
-        }
-
-        if (functionConditions.length > 0) {
-          elasticQuery = elasticQuery.withMustCondition(QueryType.Should(functionConditions));
-        }
+        elasticQuery = this.applyFunctionFilter(elasticQuery, filter.functions);
       }
     }
 
@@ -443,18 +432,7 @@ export class ElasticIndexerHelper {
       if (filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
-        const functionConditions = [];
-        for (const field of filter.functions) {
-          const shouldConditions = QueryType.Should([
-            QueryType.Match('function', field, QueryOperator.AND),
-            QueryType.Match('operation', field),
-          ]);
-          functionConditions.push(shouldConditions);
-        }
-
-        if (functionConditions.length > 0) {
-          elasticQuery = elasticQuery.withMustCondition(QueryType.Should(functionConditions));
-        }
+        elasticQuery = this.applyFunctionFilter(elasticQuery, filter.functions);
       }
     }
 
@@ -564,6 +542,22 @@ export class ElasticIndexerHelper {
       }
     }
 
+    return elasticQuery;
+  }
+
+  public applyFunctionFilter(elasticQuery: ElasticQuery, functions: string[]) {
+    const functionConditions = [];
+    for (const field of functions) {
+      const shouldConditions = QueryType.Should([
+        QueryType.Match('function', field, QueryOperator.AND),
+        QueryType.Match('operation', field),
+      ]);
+      functionConditions.push(shouldConditions);
+    }
+
+    if (functionConditions.length > 0) {
+      return elasticQuery.withMustCondition(QueryType.Should(functionConditions));
+    }
     return elasticQuery;
   }
 }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -276,7 +276,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.functions && filter.functions.length > 0 && this.apiConfigService.getIsIndexerV3FlagActive()) {
-      if (filter.functions[0] === '') {
+      if (filter.functions.length === 1 && filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
         elasticQuery = this.applyFunctionFilter(elasticQuery, filter.functions);
@@ -429,7 +429,7 @@ export class ElasticIndexerHelper {
       .withDateRangeFilter('timestamp', filter.before, filter.after);
 
     if (filter.functions && filter.functions.length > 0 && this.apiConfigService.getIsIndexerV3FlagActive()) {
-      if (filter.functions[0] === '') {
+      if (filter.functions.length === 1 && filter.functions[0] === '') {
         elasticQuery = elasticQuery.withMustNotExistCondition('function');
       } else {
         elasticQuery = this.applyFunctionFilter(elasticQuery, filter.functions);
@@ -547,17 +547,12 @@ export class ElasticIndexerHelper {
 
   public applyFunctionFilter(elasticQuery: ElasticQuery, functions: string[]) {
     const functionConditions = [];
+
     for (const field of functions) {
-      const shouldConditions = QueryType.Should([
-        QueryType.Match('function', field, QueryOperator.AND),
-        QueryType.Match('operation', field),
-      ]);
-      functionConditions.push(shouldConditions);
+      functionConditions.push(QueryType.Match('function', field));
+      functionConditions.push(QueryType.Match('operation', field));
     }
 
-    if (functionConditions.length > 0) {
-      return elasticQuery.withMustCondition(QueryType.Should(functionConditions));
-    }
-    return elasticQuery;
+    return elasticQuery.withMustCondition(QueryType.Should(functionConditions));
   }
 }


### PR DESCRIPTION
## Reasoning
- When multiple functions were added to the `/transfers`, `/transactions` filter param, it returns empty array
  
## Proposed Changes
- Modify actual implementation for `buildTransferFilterQuery` , `buildTransactionFilterQuery` methods to be able to search for multiple functions

## How to test

### `/transfers` endpoint
- `transfers?function=buy,deposit` -> should return only `buy`, `deposit` transfers
- `transfers?function=buy` -> should return only `buy` transfers
- `transfers?function=` -> should return all transfers

### `transfers/count` && `transfers/c` endpoint
- `transfers/count?function=buy,deposit` -> should return total transfers count for transfers with `buy`, `deposit`
- `transfers/c?function=buy,deposit` -> should return total transfers count for transfers with `buy`, `deposit`
- `transfers/count?function=buy` -> should return total transfers count for transfers with `buy`
- `transfers/c?function=buy,deposit` -> should return total transfers count for transfers with `buy`, `deposit`

### `/transactions` endpoint
- `transactions?function=buy,deposit` -> should return only `buy`, `deposit` transactions
- `transactions?function=buy` -> should return only `buy` transactions
- `transactions?function=` -> should return all transactions

### `transactions/count` && `transactions/c`  endpoint
- `transactions/count?function=buy,deposit` -> should return total transactions count for transfers with `buy`, `deposit`
- `transactions/c?function=buy,deposit` -> should return total transactions count for transfers with `buy`, `deposit`
- `transactions/count?function=buy` -> should return total transactions count for transfers with `buy`
- `transactions/c?function=buy,deposit` -> should return total transactions count for transfers with `buy`, `deposit`

### `accounts/:address/transactions` endpoint
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transactions?function=buy,deposit` -> should return only the `buy`, `deposit` transactions for a given address
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transactions?function=buy` -> should return only the `buy` transactions for a given address

### `accounts/:address/transfers` endpoint
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transfers?function=buy,deposit` -> should return only the `buy`, `deposit` transfers for a given address
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transfers?function=buy` -> should return only the `buy`  transfers for a given address

### `accounts/:address/transactions/count` endpoint
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transactions?function=buy,deposit` -> should return only the `buy`, `deposit` transactions count for a given address
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transactions?function=buy` -> should return only the `buy` transactions count for a given address

### `accounts/:address/transfers/count` endpoint
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transfers?function=buy,deposit` -> should return only the `buy`, `deposit` transfers count for a given address
- `accounts/erd1f7d6q5h74g0h6hktvydkmmc7qcsyljy57ntxfpm7y8qdxz64xdrq482gru/transfers?function=buy` -> should return only the `buy`  transfers count for a given address

###TBT
### `tokens/:identifier/transactions` endpoint
### `tokens/:identifier/transactions/count` endpoint
### `tokens/:identifier/transfers` endpoint
### `tokens/:identifier/transfers/count` endpoint
### `collections/:collection/transfers` endpoint
### `collections/:collection/transfers/count` endpoint
### `collections/:collection/transactions` endpoint
### `collections/:collection/transactions/count` endpoint
### `nfts/:identifier/transactions/count` endpoint
### `nfts/:identifier/transactions/` endpoint
Alternative count
