### PR TITLE
add isSmartContract count support

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -100,18 +100,21 @@ export class AccountController {
   @ApiOperation({ summary: 'Total number of accounts', description: 'Returns total number of accounts available on blockchain' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'ownerAddress', description: 'Search by owner address', required: false })
+  @ApiQuery({ name: 'isSmartContract', description: 'Return total smart contracts count', required: false })
   async getAccountsCount(
     @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
+    @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
   ): Promise<number> {
-    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
+    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress, isSmartContract }));
   }
 
   @Get("/accounts/c")
   @ApiExcludeEndpoint()
   async getAccountsCountAlternative(
     @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
+    @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
   ): Promise<number> {
-    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress }));
+    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress, isSmartContract }));
   }
 
   @Get("/accounts/:address")

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -67,7 +67,7 @@ export class AccountService {
   ) { }
 
   async getAccountsCount(filter: AccountFilter): Promise<number> {
-    if (!filter.ownerAddress) {
+    if (!filter.ownerAddress && filter.isSmartContract === undefined) {
       return await this.cachingService.getOrSet(
         CacheInfo.AccountsCount.key,
         async () => await this.indexerService.getAccountsCount(filter),

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -206,6 +206,34 @@ describe('Account Service', () => {
       expect(indexerService.getAccountsCount).toHaveBeenCalled();
       expect(result).toEqual(expectedResult);
     });
+
+    it('should call cachingService.getOrSet if filter.isSmartContract is not provided', async () => {
+      const filter: AccountFilter = { isSmartContract: undefined };
+      const expectedResult = 3000;
+
+      jest.spyOn(cacheService, 'getOrSet').mockResolvedValue(expectedResult);
+      jest.spyOn(indexerService, 'getAccountsCount').mockResolvedValue(expectedResult);
+
+      const result = await service.getAccountsCount(filter);
+
+      expect(cacheService.getOrSet).toHaveBeenCalled();
+      expect(indexerService.getAccountsCount).not.toHaveBeenCalled();
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should call indexerService.getAccountsCount directly if filter.isSmartContract is provided', async () => {
+      const filter = { isSmartContract: true };
+      const expectedResult = 3000;
+
+      jest.spyOn(cacheService, 'getOrSet').mockResolvedValue(expectedResult);
+      jest.spyOn(indexerService, 'getAccountsCount').mockResolvedValue(expectedResult);
+
+      const result = await service.getAccountsCount(filter);
+
+      expect(cacheService.getOrSet).not.toHaveBeenCalled();
+      expect(indexerService.getAccountsCount).toHaveBeenCalled();
+      expect(result).toEqual(expectedResult);
+    });
   });
 
   describe('getAccountVerification', () => {


### PR DESCRIPTION
## Reasoning
- To be able to return total smart contract count, we need to add `isSmartContract` filter to be able to filter
  
## Proposed Changes
- Added `isSmartContract` for `account/count` & alternative count route `accounts/c`

## How to test
- `accounts/count?isSmartContract=true` -> should return total smart contracts count
- `accounts/c?isSmartContract=true` -> should return total smart contracts count
- `accounts/count?isSmartContract=false` -> should return total accounts, that's include also the smart contracts
- `accounts/c?isSmartContract=false` -> should return total accounts, that's include also the smart contracts
