### PR TITLE
add excludeFields parameter

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -660,6 +660,7 @@ export class AccountController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
+  @ApiQuery({ name: 'excludeFields', description: 'List of excludedFields to filter by', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'withScResults', description: 'Return scResults for transactions. When "withScresults" parameter is applied, complexity estimation is 200', required: false })
@@ -688,6 +689,7 @@ export class AccountController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
+    @Query('excludeFields', ParseArrayPipe) excludeFields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
@@ -714,7 +716,7 @@ export class AccountController {
       order,
       senderOrReceiver,
       isRelayed,
-    }), new QueryPagination({ from, size }), options, address, fields);
+    }), new QueryPagination({ from, size }), options, address, fields, excludeFields);
   }
 
   @Get("/accounts/:address/transactions/count")

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -197,6 +197,8 @@ export class TokenController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
+  @ApiQuery({ name: 'excludeFields', description: 'List of excludedFields to filter by', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -222,6 +224,7 @@ export class TokenController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
+    @Query('excludeFields', ParseArrayPipe) excludeFields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
@@ -254,6 +257,7 @@ export class TokenController {
       options,
       undefined,
       fields,
+      excludeFields
     );
   }
 

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -71,6 +71,7 @@ export class TransactionController {
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('excludeFields', ParseArrayPipe) excludeFields?: string[],
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 
@@ -94,6 +95,7 @@ export class TransactionController {
       options,
       undefined,
       fields,
+      excludeFields
     );
   }
 

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -37,6 +37,7 @@ export class TransactionController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
+  @ApiQuery({ name: 'excludeFields', description: 'List of excludedFields to filter by', required: false })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'condition', description: 'Condition for elastic search queries', required: false, deprecated: true })
@@ -64,6 +65,7 @@ export class TransactionController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
+    @Query('excludeFields', ParseArrayPipe) excludeFields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
@@ -71,7 +73,6 @@ export class TransactionController {
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
-    @Query('excludeFields', ParseArrayPipe) excludeFields?: string[],
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo });
 

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -148,7 +148,7 @@ export class TransactionService {
     return result;
   }
 
-  async getTransactions(filter: TransactionFilter, pagination: QueryPagination, queryOptions?: TransactionQueryOptions, address?: string, fields?: string[]): Promise<Transaction[]> {
+  async getTransactions(filter: TransactionFilter, pagination: QueryPagination, queryOptions?: TransactionQueryOptions, address?: string, fields?: string[], excludeFields?: string[]): Promise<Transaction[]> {
     const elasticTransactions = await this.indexerService.getTransactions(filter, pagination, address);
 
     let transactions: TransactionDetailed[] = [];
@@ -180,6 +180,16 @@ export class TransactionService {
       transaction.relayedVersion = this.extractRelayedVersion(transaction);
     }
 
+    if (excludeFields && excludeFields.length > 0) {
+      transactions = transactions.map(transaction => {
+        for (const field of excludeFields) {
+          if (field in transaction) {
+            delete transaction[field as keyof TransactionDetailed];
+          }
+        }
+        return transaction;
+      });
+    }
 
     await this.processTransactions(transactions, {
       withScamInfo: queryOptions?.withScamInfo ?? false,

--- a/src/test/integration/controllers/transactions.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/transactions.controller.e2e-spec.ts
@@ -91,6 +91,21 @@ describe("Transactions Controller", () => {
     });
   });
 
+  describe('getTransactions', () => {
+    it('should return a list of transactions without gasLimit, gasPrice attribute', async () => {
+      const excludeFields = ['gasLimit,gasPrice'];
+      await request(app.getHttpServer())
+        .get(`${path}?excludeFields=${excludeFields}`)
+        .expect(200)
+        .then(res => {
+          for (const item of res.body) {
+            expect(item.gasLimit).not.toBeDefined();
+            expect(item.gasPrice).not.toBeDefined();
+          }
+        });
+    });
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -250,5 +250,20 @@ describe('TransactionService', () => {
 
       expect(service.applyBlockInfo).toHaveBeenCalledWith(expect.any(Array));
     });
+
+    it('should return transactions details without gasLimit and gasPrice keys', async () => {
+      const filter = new TransactionFilter();
+      const pagination = new QueryPagination();
+
+      jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValue(assetsAccountMock);
+      jest.spyOn(indexerService, 'getTransactions').mockResolvedValue(elasticTransactionsMock);
+
+      const results = await service.getTransactions(filter, pagination, undefined, undefined, undefined, ['gasLimit', 'gasPrice']);
+
+      for (const result of results) {
+        expect(result.gasLimit).not.toBeDefined();
+        expect(result.gasPrice).not.toBeDefined();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Reasoning
- Implementing the `excludeFields` parameter in the transactions API provides users with more control over the response payload, allowing them to exclude specific fields they are not interested in, rather than specifying a long list of fields they want to include.
  
## Proposed Changes
- Added the `excludeFields` query parameter to the `getTransactions` method in the transactions controller. This allows to specify fields they wish to exclude from the response.
- Updated the `getTransactions` method in the transaction service to process the `excludeFields` parameter. The method now iterates over each transaction and removes any fields listed in `excludeFields`.

## How to test
- `transactions?excludeFields=txHash` -> should return all transactions details buy without `txHash` field
