### PR TITLE
update mexFarms / mexPairs with specific return types

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -57,7 +57,7 @@ export class MexController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('exchange', new ParseEnumPipe(MexPairExchange)) exchange?: MexPairExchange,
-  ): Promise<any> {
+  ): Promise<MexPair[]> {
     const filter = new MexPairsFilter({ exchange });
     return await this.mexPairsService.getMexPairs(from, size, filter);
   }
@@ -114,7 +114,7 @@ export class MexController {
   async getMexFarms(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number
-  ): Promise<any> {
+  ): Promise<MexFarm[]> {
     return await this.mexFarmsService.getMexFarms(new QueryPagination({ from, size }));
   }
 


### PR DESCRIPTION
## Reasoning
- We should avoid using 'any' type.
  
## Proposed Changes
- Replace 'any' type usages with specific types.

## How to test
- `mex/farms` -> should return all mex farms
- `mex/pairs` -> should return all mex pairs
