### PR TITLE
add account social assets

### DIFF
--- a/src/common/assets/entities/account.assets.social.ts
+++ b/src/common/assets/entities/account.assets.social.ts
@@ -1,0 +1,45 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("AccountAssetsSocial", { description: "Account assets social object type." })
+export class AccountAssetsSocial {
+  constructor(init?: Partial<AccountAssetsSocial>) {
+    Object.assign(this, init);
+  }
+
+  @Field(() => String, { description: "Website asset for the given account asset." })
+  website: string = '';
+
+  @Field(() => String, { description: "Blog assetfor the given account asset." })
+  blog: string = '';
+
+  @Field(() => String, { description: "Twitter asset for the given account asset." })
+  twitter: string = '';
+
+  @Field(() => String, { description: "Discord asset for the given account asset." })
+  discord: string = '';
+
+  @Field(() => String, { description: "Telegram asset for the given account asset." })
+  telegram: string = '';
+
+  @Field(() => String, { description: "Facebook asset for the given account asset." })
+  facebook: string = '';
+
+  @Field(() => String, { description: "Instagram asset for the given account asset." })
+  instagram: string = '';
+
+  @Field(() => String, { description: "YouTube asset for the given account asset." })
+  youtube: string = '';
+
+  @Field(() => String, { description: "Whitepapper asset for the given account asset." })
+  whitepaper: string = '';
+
+  @Field(() => String, { description: "Coinmarketcap asset for the given account asset." })
+  coinmarketcap: string = '';
+
+  @Field(() => String, { description: "Coingecko asset for the given account asset." })
+  coingecko: string = '';
+
+  @Field(() => String, { description: "Linkedin asset for the given account asset." })
+  linkedin: string = '';
+
+}

--- a/src/common/assets/entities/account.assets.ts
+++ b/src/common/assets/entities/account.assets.ts
@@ -1,4 +1,5 @@
 import { Field, ObjectType } from "@nestjs/graphql";
+import { AccountAssetsSocial } from "./account.assets.social";
 
 @ObjectType("AccountAssets", { description: "Account assets object type." })
 export class AccountAssets {
@@ -11,6 +12,9 @@ export class AccountAssets {
 
   @Field(() => String, { description: "Description for the given account asset." })
   description: string = '';
+
+  @Field(() => String, { description: "Social for the given account asset." })
+  social: AccountAssetsSocial | undefined = undefined;
 
   @Field(() => [String], { description: "Tags list for the given account asset." })
   tags: string[] = [];

--- a/src/test/data/transactions/transactions.with.logs.ts
+++ b/src/test/data/transactions/transactions.with.logs.ts
@@ -1,3 +1,4 @@
+import { AccountAssetsSocial } from "src/common/assets/entities/account.assets.social";
 import { TransactionLog } from "src/endpoints/transactions/entities/transaction.log";
 import { TransactionLogEvent } from "src/endpoints/transactions/entities/transaction.log.event";
 
@@ -16,6 +17,7 @@ const transactionsWithLogs: TransactionLog[] =
         "mex",
         "liquiditypool",
       ],
+      social: new AccountAssetsSocial(),
     },
     events: [] as TransactionLogEvent[],
   },

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -5,6 +5,7 @@ import { Test } from "@nestjs/testing";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { AssetsService } from "src/common/assets/assets.service";
 import { AccountAssets } from "src/common/assets/entities/account.assets";
+import { AccountAssetsSocial } from "src/common/assets/entities/account.assets.social";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { IndexerService } from "src/common/indexer/indexer.service";
@@ -799,6 +800,12 @@ describe('Account Service', () => {
       erd1qqqqqqqqqqqqqpgqc0htpys8vhtf5m3tg7t6ts2wvkgx3favqrhsdsz9w0: {
         name: 'Multiversx DNS: Contract 239',
         description: '',
+        social: new AccountAssetsSocial({
+          website: "https://xexchange.com",
+          twitter: "https://twitter.com/xExchangeApp",
+          telegram: "https://t.me/xExchangeApp",
+          blog: "https://multiversx.com/blog/maiar-exchange-mex-tokenomics",
+        }),
         tags: ['dns'],
         icon: 'multiversx',
         iconPng: '',


### PR DESCRIPTION
## Reasoning
-  in mx-assets account branding has been adding new attribute `social`
  
## Proposed Changes
- add in `accountAssets` entity `social` attribute to be able to return all `social` informations
- add unit tests

## How to test
- `accounts/erd1qqqqqqqqqqqqqpgq0tajepcazernwt74820t8ef7t28vjfgukp2sw239f3` - should return in `assets` field `social` key
