### PR TITLE
add support for mex tokens previous price

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -30,6 +30,14 @@ export class MexPair {
   @ApiProperty()
   price: number = 0;
 
+  @Field(() => Number, { description: "Mex token basePrevious24hPrice equivalent" })
+  @ApiProperty()
+  basePrevious24hPrice: number = 0;
+
+  @Field(() => Number, { description: "Mex token quotePrevious24hPrice equivalent" })
+  @ApiProperty()
+  quotePrevious24hPrice: number = 0;
+
   @Field(() => String, { description: "Base id details." })
   @ApiProperty({ type: String, example: 'MEX-455c57' })
   baseId: string = '';

--- a/src/endpoints/mex/entities/mex.token.ts
+++ b/src/endpoints/mex/entities/mex.token.ts
@@ -21,4 +21,8 @@ export class MexToken {
   @Field(() => Float, { description: "Mex token current price." })
   @ApiProperty({ type: Number, example: 0.000206738758250580 })
   price: number = 0;
+
+  @Field(() => Float, { description: "Mex token previous24hPrice." })
+  @ApiProperty({ type: Number, example: 0.000206738758250580 })
+  previous24hPrice: number = 0;
 }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -99,12 +99,14 @@ export class MexPairService {
               name
               identifier
               decimals
+              previous24hPrice
               __typename
             }
             secondToken {
               name
               identifier
               decimals
+              previous24hPrice
               __typename
             }
             firstTokenPrice
@@ -171,6 +173,8 @@ export class MexPairService {
         symbol: pair.liquidityPoolToken.identifier.split('-')[0],
         name: pair.liquidityPoolToken.name,
         price: Number(pair.liquidityPoolTokenPriceUSD),
+        basePrevious24hPrice: Number(pair.firstToken.previous24hPrice),
+        quotePrevious24hPrice: Number(pair.secondToken.previous24hPrice),
         baseId: pair.firstToken.identifier,
         basePrice: Number(pair.firstTokenPriceUSD),
         baseSymbol: firstTokenSymbol,
@@ -193,6 +197,8 @@ export class MexPairService {
       symbol: pair.liquidityPoolToken.identifier.split('-')[0],
       name: pair.liquidityPoolToken.name,
       price: Number(pair.liquidityPoolTokenPriceUSD),
+      basePrevious24hPrice: Number(pair.secondToken.previous24hPrice),
+      quotePrevious24hPrice: Number(pair.firstToken.previous24hPrice),
       baseId: pair.secondToken.identifier,
       basePrice: Number(pair.secondTokenPriceUSD),
       baseSymbol: secondTokenSymbol,

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -174,8 +174,8 @@ export class MexTokenService {
         wegldToken.symbol = pair.baseSymbol;
         wegldToken.name = pair.baseName;
         wegldToken.price = pair.basePrice;
-        wegldToken.previous24hPrice = pair.basePrevious24hPrice,
-          mexTokens.push(wegldToken);
+        wegldToken.previous24hPrice = pair.basePrevious24hPrice;
+        mexTokens.push(wegldToken);
       }
 
       const mexToken = this.getMexToken(pair);

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -174,8 +174,8 @@ export class MexTokenService {
         wegldToken.symbol = pair.baseSymbol;
         wegldToken.name = pair.baseName;
         wegldToken.price = pair.basePrice;
-
-        mexTokens.push(wegldToken);
+        wegldToken.previous24hPrice = pair.basePrevious24hPrice,
+          mexTokens.push(wegldToken);
       }
 
       const mexToken = this.getMexToken(pair);
@@ -196,6 +196,7 @@ export class MexTokenService {
         symbol: pair.quoteSymbol,
         name: pair.quoteName,
         price: pair.quotePrice,
+        previous24hPrice: pair.quotePrevious24hPrice,
       };
     }
 
@@ -205,6 +206,7 @@ export class MexTokenService {
         symbol: pair.baseSymbol,
         name: pair.baseName,
         price: pair.basePrice,
+        previous24hPrice: pair.basePrevious24hPrice,
       };
     }
 
@@ -214,6 +216,7 @@ export class MexTokenService {
         symbol: pair.quoteSymbol,
         name: pair.quoteName,
         price: pair.quotePrice,
+        previous24hPrice: pair.quotePrevious24hPrice,
       };
     }
 


### PR DESCRIPTION
## Reasoning
- on exchange graphql for tokens/pairs was added new field `previous24hPrice`
  
## Proposed Changes
-  Add support for `basePrevious24hPrice` & `quotePrevious24hPrice`
-  Add support for token `previous24hPrice`

## How to test
- `mex/pairs` -> all pairs should contain `basePrevious24hPrice` and `quotePrevious24hPrice`
- `mex/tokens` -> should contain `previous24hPrice` key
