### PR TITLE
add generic proxy forward endpoint

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -38,5 +38,6 @@ export enum GatewayComponentRequest {
   trieStatistics = 'trieStatistics',
   transactionPool = 'transactionPool',
   gasConfigs = 'gasConfigs',
-  transactionProcessStatus = 'transactionProcessStatus'
+  transactionProcessStatus = 'transactionProcessStatus',
+  forward = 'forward'
 }

--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -23,6 +23,15 @@ export class ProxyController {
     private readonly pluginService: PluginService,
   ) { }
 
+  @Get('*')
+  async forwardRequest(@Req() request: Request) {
+    const url = request.url.startsWith('/') ? request.url.substring(1) : request.url;
+    return await this.forwardGateway(
+      url,
+      GatewayComponentRequest.forward,
+    );
+  }
+
   @Get('/address/:address')
   async getAddress(@Param('address', ParseAddressPipe) address: string) {
     return await this.gatewayGet(`address/${address}`, GatewayComponentRequest.addressDetails);
@@ -357,5 +366,9 @@ export class ProxyController {
       this.logger.error(`Unhandled exception when calling gateway url '${url}'`);
       throw new BadRequestException(`Unhandled exception when calling gateway url '${url}'`);
     }
+  }
+
+  private async forwardGateway(url: string, component: GatewayComponentRequest, errorHandler?: (error: any) => Promise<boolean>): Promise<any> {
+    return await this.gatewayGet(url, component, errorHandler);
   }
 }


### PR DESCRIPTION
## Reasoning
-  To facilitate the dynamic forwarding of requests to various endpoints of the `gateway`, we need to implement a generic endpoint. This will allow to handle requests flexibly, enabling it to interact with multiple endpoints of the gateway without the need for hardcoding specific routes in our `ProxyController`.
  
## Proposed Changes
- Add a `forwardGateway` method to the `ProxyController`. This method will handle incoming requests and forward them to the corresponding gateway endpoint

## How to test
-  Check any endpoint from gateway that is not hardcoded in Proxy Controller. 
Example:
- `network/ratings` -> should return network ratings
