### PR TITLE
fixed cron names

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -79,19 +79,19 @@ export class CacheWarmerService {
 
     if (this.apiConfigService.isStakingV4Enabled()) {
       const handleNodeAuctionInvalidationsCronJob = new CronJob(this.apiConfigService.getStakingV4CronExpression(), async () => await this.handleNodeAuctionInvalidations());
-      this.schedulerRegistry.addCronJob(this.handleNodeAuctionInvalidations.name, handleNodeAuctionInvalidationsCronJob);
+      this.schedulerRegistry.addCronJob('handleNodeAuctionInvalidations', handleNodeAuctionInvalidationsCronJob);
       handleNodeAuctionInvalidationsCronJob.start();
     }
 
     if (this.apiConfigService.isUpdateCollectionExtraDetailsEnabled()) {
       const handleUpdateCollectionExtraDetailsCronJob = new CronJob(CronExpression.EVERY_10_MINUTES, async () => await this.handleUpdateCollectionExtraDetails());
-      this.schedulerRegistry.addCronJob(this.handleUpdateCollectionExtraDetails.name, handleUpdateCollectionExtraDetailsCronJob);
+      this.schedulerRegistry.addCronJob('handleUpdateCollectionExtraDetails', handleUpdateCollectionExtraDetailsCronJob);
       handleUpdateCollectionExtraDetailsCronJob.start();
     }
 
     if (this.apiConfigService.isTransactionPoolCacheWarmerEnabled()) {
       const handleTransactionPoolCacheInvalidation = new CronJob(this.apiConfigService.getTransactionPoolCacheWarmerCronExpression(), async () => await this.handleTxPoolInvalidations());
-      this.schedulerRegistry.addCronJob(this.handleTxPoolInvalidations.name, handleTransactionPoolCacheInvalidation);
+      this.schedulerRegistry.addCronJob('handleTxPoolInvalidations', handleTransactionPoolCacheInvalidation);
       handleTransactionPoolCacheInvalidation.start();
     }
   }


### PR DESCRIPTION
## Reasoning
- calling `this.myFunction.name` actually does not return the function's name. never worked like this
  
## Proposed Changes
- instead of extracting the name dynamically for a cron job's name, specify it as a string

## How to test
- enable both staking v4 and transaction pool and cache warmer should start
