### PR TITLE
Identity owner fix

### DIFF
--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -82,12 +82,19 @@ export class KeybaseService {
         const providerMetadata = await this.providerService.getProviderMetadata(key);
         if (providerMetadata && providerMetadata.identity && providerMetadata.identity === identity) {
           await this.cachingService.set(CacheInfo.ConfirmedProvider(key).key, identity, CacheInfo.ConfirmedProvider(key).ttl);
+        }
 
-          // if the identity is confirmed from the smart contract, we consider all BLS keys within valid
+        // if the identity is confirmed from the smart contract, we consider all BLS keys within valid
+        try {
           const blses = await this.nodeService.getOwnerBlses(key);
+          this.logger.log(`Confirmed identity '${identity}' for address '${key}' with ${blses.length} BLS keys`);
+
           for (const bls of blses) {
             confirmations[bls] = identity;
           }
+        } catch (error) {
+          this.logger.error(`Failed to get BLS keys for address ${key}`);
+          this.logger.error(error);
         }
       } else if (blsIdentityDict[key] === identity && confirmations[key] === undefined) {
         confirmations[key] = identity;


### PR DESCRIPTION
## Reasoning
- node identity should be able to be removed and the identity should still be valid, since the owner should properly prove the ownership over those nodes
  
## Proposed Changes
- Take into account node owner also if not staking provider address

## How to test (mainnet)
- MultiversX Community Delegation nodes should have the `multiversx` identity correctly associated to them
