### PR TITLE
fix tx pool swagger docs

### DIFF
--- a/src/endpoints/pool/pool.controller.ts
+++ b/src/endpoints/pool/pool.controller.ts
@@ -16,7 +16,7 @@ export class PoolController {
 
   @Get("/pool")
   @ApiOperation({ summary: 'Transactions pool', description: 'Returns the transactions that are currently in the memory pool.' })
-  @ApiOkResponse({ type: [TransactionInPool], isArray: true })
+  @ApiOkResponse({ type: TransactionInPool, isArray: true })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'sender', description: 'Search in transaction pool by a specific sender', required: false })


### PR DESCRIPTION
## Reasoning
- tx pool endpoint has an issue in definind the Swagger response type
  
## Proposed Changes
- fixed swagger

## How to test
- `http://localhost:3001/#/pool/PoolController_getTransactionPool` - should display an array of transactions as the successful result type
