### PR TITLE
Support for MultiESDTNFTTransfer log type

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -136,7 +136,12 @@ export class TokenTransferService {
         if (!operation) {
           const action = this.getOperationEsdtActionByEventIdentifier(event.identifier);
           if (action) {
-            operation = this.getTransactionNftOperation(txHash, log, event, action, tokensProperties);
+            if (event.identifier === TransactionLogEventIdentifier.MultiESDTNFTTransfer) {
+              const multiESDTNFTOperations = this.getTransactionMultiESDTNFTOperations(txHash, log, event.address, event.topics, action, tokensProperties);
+              operations.push(...multiESDTNFTOperations);
+            } else {
+              operation = this.getTransactionNftOperation(txHash, log, event.address, event.topics, action, tokensProperties);
+            }
           }
         }
 
@@ -216,12 +221,33 @@ export class TokenTransferService {
     }
   }
 
-  private getTransactionNftOperation(txHash: string, log: TransactionLog, event: TransactionLogEvent, action: TransactionOperationAction, tokensProperties: { [key: string]: TokenTransferProperties | null }): TransactionOperation | undefined {
+  private getTransactionMultiESDTNFTOperations(txHash: string, log: TransactionLog, address: string, topics: string[], action: TransactionOperationAction, tokensProperties: { [key: string]: TokenTransferProperties | null }): TransactionOperation[] {
+    const operations: TransactionOperation[] = [];
+
+    const receiverTopic = topics.last();
+    for (let i = 0; i < (topics.length - 1) / 3; i++) {
+      const eventTopics = [
+        topics[i * 3],
+        topics[i * 3 + 1],
+        topics[i * 3 + 2],
+        receiverTopic,
+      ];
+
+      const operation = this.getTransactionNftOperation(txHash, log, address, eventTopics, action, tokensProperties);
+      if (operation) {
+        operations.push(operation);
+      }
+    }
+
+    return operations;
+  }
+
+  private getTransactionNftOperation(txHash: string, log: TransactionLog, address: string, topics: string[], action: TransactionOperationAction, tokensProperties: { [key: string]: TokenTransferProperties | null }): TransactionOperation | undefined {
     try {
-      let identifier = BinaryUtils.base64Decode(event.topics[0]);
-      const nonce = BinaryUtils.tryBase64ToHex(event.topics[1]);
-      const value = BinaryUtils.tryBase64ToBigInt(event.topics[2])?.toString();
-      const receiver = BinaryUtils.tryBase64ToAddress(event.topics[3]) ?? log.address;
+      let identifier = BinaryUtils.base64Decode(topics[0]);
+      const nonce = BinaryUtils.tryBase64ToHex(topics[1]);
+      const value = BinaryUtils.tryBase64ToBigInt(topics[2])?.toString();
+      const receiver = BinaryUtils.tryBase64ToAddress(topics[3]) ?? log.address;
       const properties = tokensProperties[identifier];
       const decimals = properties ? properties.decimals : undefined;
       const name = properties ? properties.name : undefined;
@@ -238,7 +264,7 @@ export class TokenTransferService {
 
       const type = nonce ? TransactionOperationType.nft : TransactionOperationType.esdt;
 
-      return { id: log.id ?? '', action, type, esdtType, collection, identifier, ticker, name, sender: event.address, receiver, value, decimals, svgUrl, senderAssets: undefined, receiverAssets: undefined };
+      return { id: log.id ?? '', action, type, esdtType, collection, identifier, ticker, name, sender: address, receiver, value, decimals, svgUrl, senderAssets: undefined, receiverAssets: undefined };
     } catch (error) {
       this.logger.error(`Error when parsing NFT transaction log for tx hash '${txHash}' with action '${action}' and topics: ${event.topics}`);
       this.logger.error(error);

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -46,6 +46,9 @@ type Account {
   """Current owner address."""
   ownerAddress: String!
 
+  """Owner Account Address assets details."""
+  ownerAssets: AccountAssets
+
   """Shard for the given account."""
   shard: Float!
 
@@ -212,6 +215,9 @@ type AccountDetailed {
 
   """Owner address for the given detailed account."""
   ownerAddress: String!
+
+  """Owner Account Address assets details."""
+  ownerAssets: AccountAssets
 
   """
   Returns smart contract results where the account is sender or receiver.


### PR DESCRIPTION
## Reasoning
- After the latest node update, when multiple transfers are performed, instead of emitting `n` logs for every transfer, one single log is emitted containing all transferred tokens
  
## Proposed Changes
- Accomodate api support for one single log with multiple transfers

## How to test (devnet)
- `/transactions/efd40156ee6dd6207c90b58fbbe8b5b02d268bb71dd75e75372eec6dfbdc3319` should also return an operation where 0.25 WTAO tokens are transferred back to `erd1rc5p5drg26vggn6jx9puv6xlgka5n6ajm6cer554tzguwfm6v5ys2pr3pc`
