### PR TITLE
withTxCount, withScrCount support in account list endpoint

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -13,7 +13,7 @@ import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.roles.filter";
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 
 @Injectable()
@@ -527,7 +527,7 @@ export class ElasticIndexerHelper {
     return elasticQuery;
   }
 
-  public buildAccountFilterQuery(filter: AccountFilter): ElasticQuery {
+  public buildAccountFilterQuery(filter: AccountQueryOptions): ElasticQuery {
     let elasticQuery = ElasticQuery.create();
 
     if (filter.ownerAddress) {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -21,7 +21,7 @@ import { Tag } from "../entities/tag";
 import { ElasticIndexerHelper } from "./elastic.indexer.helper";
 import { TokenType } from "../entities";
 import { SortCollections } from "src/endpoints/collections/entities/sort.collections";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountSort } from "src/endpoints/accounts/entities/account.sort";
 import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
@@ -36,7 +36,7 @@ export class ElasticIndexerService implements IndexerInterface {
     private readonly apiService: ApiService,
   ) { }
 
-  async getAccountsCount(filter: AccountFilter): Promise<number> {
+  async getAccountsCount(filter: AccountQueryOptions): Promise<number> {
     const query = this.indexerHelper.buildAccountFilterQuery(filter);
 
     return await this.elasticService.getCount('accounts', query);
@@ -380,7 +380,7 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('scresults', 'hash', elasticQuery);
   }
 
-  async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<any[]> {
+  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<any[]> {
     let elasticQuery = this.indexerHelper.buildAccountFilterQuery(filter);
 
     const sortOrder: ElasticSortOrder = !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -1,4 +1,4 @@
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { BlockFilter } from "src/endpoints/blocks/entities/block.filter";
 import { CollectionFilter } from "src/endpoints/collections/entities/collection.filter";
@@ -15,7 +15,7 @@ import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
 
 export interface IndexerInterface {
-  getAccountsCount(filter: AccountFilter): Promise<number>
+  getAccountsCount(filter: AccountQueryOptions): Promise<number>
 
   getScResultsCount(): Promise<number>
 
@@ -99,7 +99,7 @@ export interface IndexerInterface {
 
   getAccount(address: string): Promise<Account>
 
-  getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]>
+  getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<Account[]>
 
   getAccountContracts(pagination: QueryPagination, address: string): Promise<ScDeploy[]>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -14,7 +14,7 @@ import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 
@@ -26,7 +26,7 @@ export class IndexerService implements IndexerInterface {
   ) { }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccountsCount(filter: AccountFilter): Promise<number> {
+  async getAccountsCount(filter: AccountQueryOptions): Promise<number> {
     return await this.indexerInterface.getAccountsCount(filter);
   }
 
@@ -222,7 +222,7 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccounts(queryPagination: QueryPagination, filter: AccountFilter): Promise<Account[]> {
+  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<Account[]> {
     return await this.indexerInterface.getAccounts(queryPagination, filter);
   }
 

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -24,7 +24,7 @@ import { SettingsService } from "src/common/settings/settings.service";
 import { TokenService } from "src/endpoints/tokens/token.service";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { NftService } from "src/endpoints/nfts/nft.service";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { TokenType } from "src/common/indexer/entities";
 import { TokenDetailed } from "src/endpoints/tokens/entities/token.detailed";
 import { DataApiService } from "src/common/data-api/data-api.service";
@@ -195,7 +195,7 @@ export class CacheWarmerService {
   @Cron(CronExpression.EVERY_MINUTE)
   @Lock({ name: 'Accounts invalidations', verbose: true })
   async handleAccountInvalidations() {
-    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountFilter());
+    const accounts = await this.accountService.getAccountsRaw({ from: 0, size: 25 }, new AccountQueryOptions());
 
     const accountsCacheInfo = CacheInfo.Accounts({ from: 0, size: 25 });
     await this.invalidateKey(accountsCacheInfo.key, accounts, accountsCacheInfo.ttl);

--- a/src/crons/status.checker/status.checker.service.ts
+++ b/src/crons/status.checker/status.checker.service.ts
@@ -20,7 +20,7 @@ import { NetworkService } from "src/endpoints/network/network.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { TokenFilter } from "src/endpoints/tokens/entities/token.filter";
 import { NodeType } from "src/endpoints/nodes/entities/node.type";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 
 @Injectable()
 export class StatusCheckerService {
@@ -45,7 +45,7 @@ export class StatusCheckerService {
   @Cron(CronExpression.EVERY_MINUTE)
   async handleAccountsCount() {
     await Locker.lock('Status Checker Accounts Count', async () => {
-      const count = await this.elasticIndexerService.getAccountsCount(new AccountFilter());
+      const count = await this.elasticIndexerService.getAccountsCount(new AccountQueryOptions());
       MetricsService.setClusterComparisonValue('total_accounts', count);
     }, true);
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -48,7 +48,7 @@ import { DelegationService } from '../delegation/delegation.service';
 import { TokenType } from '../tokens/entities/token.type';
 import { ContractUpgrades } from './entities/contract.upgrades';
 import { AccountVerification } from './entities/account.verification';
-import { AccountFilter as AccountQueryOptions } from './entities/account.query.options';
+import { AccountQueryOptions } from './entities/account.query.options';
 import { AccountSort } from './entities/account.sort';
 import { AccountHistoryFilter } from './entities/account.history.filter';
 import { ParseArrayPipeOptions } from '@multiversx/sdk-nestjs-common/lib/pipes/entities/parse.array.options';
@@ -84,8 +84,10 @@ export class AccountController {
   @ApiQuery({ name: 'sort', description: 'Sort criteria (balance / timestamp)', required: false, enum: AccountSort })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'isSmartContract', description: 'Filter accounts by whether they are smart contract or not', required: false })
-  @ApiQuery({ name: 'withDeployInfo', description: 'Include deployedAt and deployTxHash fields in the result', required: false })
   @ApiQuery({ name: 'withOwnerAssets', description: 'Return a list accounts with owner assets', required: false })
+  @ApiQuery({ name: 'withDeployInfo', description: 'Include deployedAt and deployTxHash fields in the result', required: false })
+  @ApiQuery({ name: 'withTxCount', description: 'Include txCount field in the result', required: false })
+  @ApiQuery({ name: 'withScrCount', description: 'Include txCount field in the result', required: false })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -93,10 +95,12 @@ export class AccountController {
     @Query('sort', new ParseEnumPipe(AccountSort)) sort?: AccountSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
-    @Query("withDeployInfo", new ParseBoolPipe) withDeployInfo?: boolean,
     @Query("withOwnerAssets", new ParseBoolPipe) withOwnerAssets?: boolean,
+    @Query("withDeployInfo", new ParseBoolPipe) withDeployInfo?: boolean,
+    @Query("withTxCount", new ParseBoolPipe) withTxCount?: boolean,
+    @Query("withScrCount", new ParseBoolPipe) withScrCount?: boolean,
   ): Promise<Account[]> {
-    const queryOptions = new AccountQueryOptions({ ownerAddress, sort, order, isSmartContract, withOwnerAssets, withDeployInfo });
+    const queryOptions = new AccountQueryOptions({ ownerAddress, sort, order, isSmartContract, withOwnerAssets, withDeployInfo, withTxCount, withScrCount });
     queryOptions.validate(size);
 
     return this.accountService.getAccounts(

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -87,7 +87,7 @@ export class AccountController {
   @ApiQuery({ name: 'withOwnerAssets', description: 'Return a list accounts with owner assets', required: false })
   @ApiQuery({ name: 'withDeployInfo', description: 'Include deployedAt and deployTxHash fields in the result', required: false })
   @ApiQuery({ name: 'withTxCount', description: 'Include txCount field in the result', required: false })
-  @ApiQuery({ name: 'withScrCount', description: 'Include txCount field in the result', required: false })
+  @ApiQuery({ name: 'withScrCount', description: 'Include scrCount field in the result', required: false })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,

--- a/src/endpoints/accounts/entities/account.detailed.ts
+++ b/src/endpoints/accounts/entities/account.detailed.ts
@@ -1,5 +1,5 @@
 import { ComplexityEstimation } from "@multiversx/sdk-nestjs-common";
-import { Field, Float, ObjectType } from "@nestjs/graphql";
+import { Field, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { ScamInfo } from "src/common/entities/scam-info.dto";
 import { NftCollectionAccount } from "src/endpoints/collections/entities/nft.collection.account";
@@ -36,14 +36,6 @@ export class AccountDetailed extends Account {
   @Field(() => String, { description: 'Owner address for the given detailed account.' })
   @ApiProperty({ description: 'The address in bech 32 format of owner account' })
   ownerAddress: string = '';
-
-  @Field(() => Float, { description: 'Transactions count for the given detailed account.' })
-  @ApiProperty({ description: 'The number of transactions performed on this account' })
-  txCount?: number;
-
-  @Field(() => Float, { description: 'Smart contract results count for the given detailed account.' })
-  @ApiProperty({ description: 'The number of smart contract results of this account' })
-  scrCount: number = 0;
 
   @Field(() => Boolean, { description: 'If the given detailed account is upgradeable.', nullable: true })
   @ApiProperty({ description: 'Specific property flag for smart contract', type: Boolean })

--- a/src/endpoints/accounts/entities/account.query.options.ts
+++ b/src/endpoints/accounts/entities/account.query.options.ts
@@ -2,8 +2,8 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { AccountSort } from "./account.sort";
 import { BadRequestException } from "@nestjs/common";
 
-export class AccountFilter {
-  constructor(init?: Partial<AccountFilter>) {
+export class AccountQueryOptions {
+  constructor(init?: Partial<AccountQueryOptions>) {
     Object.assign(this, init);
   }
 
@@ -14,10 +14,20 @@ export class AccountFilter {
   isSmartContract?: boolean;
   withOwnerAssets?: boolean;
   withDeployInfo?: boolean;
+  withTxCount?: boolean;
+  withScrCount?: boolean;
 
   validate(size: number) {
     if (this.withDeployInfo && size > 25) {
       throw new BadRequestException('Size must be less than or equal to 25 when withDeployInfo is set');
+    }
+
+    if (this.withTxCount && size > 25) {
+      throw new BadRequestException('Size must be less than or equal to 25 when withTxCount is set');
+    }
+
+    if (this.withScrCount && size > 25) {
+      throw new BadRequestException('Size must be less than or equal to 25 when withScrCount is set');
     }
   }
 

--- a/src/endpoints/accounts/entities/account.ts
+++ b/src/endpoints/accounts/entities/account.ts
@@ -52,4 +52,12 @@ export class Account {
   @Field(() => Boolean, { description: 'If the given detailed account is verified.', nullable: true })
   @ApiProperty({ description: 'Specific property flag for smart contract', type: Boolean })
   isVerified?: boolean;
+
+  @Field(() => Float, { description: 'Transactions count for the given detailed account.' })
+  @ApiProperty({ description: 'The number of transactions performed on this account' })
+  txCount?: number;
+
+  @Field(() => Float, { description: 'Smart contract results count for the given detailed account.' })
+  @ApiProperty({ description: 'The number of smart contract results of this account' })
+  scrCount?: number;
 }

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -19,7 +19,7 @@ import { About } from './entities/about';
 import { PluginService } from 'src/common/plugins/plugin.service';
 import { SmartContractResultService } from '../sc-results/scresult.service';
 import { TokenService } from '../tokens/token.service';
-import { AccountFilter } from '../accounts/entities/account.query.options';
+import { AccountQueryOptions } from '../accounts/entities/account.query.options';
 import { DataApiService } from 'src/common/data-api/data-api.service';
 import { FeatureConfigs } from './entities/feature.configs';
 
@@ -232,7 +232,7 @@ export class NetworkService {
       this.gatewayService.getNetworkConfig(),
       this.gatewayService.getNetworkStatus(metaChainShard),
       this.blockService.getBlocksCount(new BlockFilter()),
-      this.accountService.getAccountsCount(new AccountFilter()),
+      this.accountService.getAccountsCount(new AccountQueryOptions()),
       this.transactionService.getTransactionCount(new TransactionFilter()),
       this.smartContractResultService.getScResultsCount(),
     ]);

--- a/src/graphql/entities/account/account.input.ts
+++ b/src/graphql/entities/account/account.input.ts
@@ -1,5 +1,5 @@
 import { Field, InputType, Float } from "@nestjs/graphql";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 
 @InputType({ description: "Input to retrieve the given accounts for." })
 export class GetAccountFilteredInput {
@@ -9,8 +9,8 @@ export class GetAccountFilteredInput {
 
   @Field(() => String, { name: "ownerAddress", description: "Owner address to retrieve for the given result set.", nullable: true })
   ownerAddress: string | undefined = undefined;
-  public static resolve(input: GetAccountFilteredInput): AccountFilter {
-    return new AccountFilter({
+  public static resolve(input: GetAccountFilteredInput): AccountQueryOptions {
+    return new AccountQueryOptions({
       ownerAddress: input.ownerAddress,
     });
   }

--- a/src/graphql/entities/account/account.query.ts
+++ b/src/graphql/entities/account/account.query.ts
@@ -5,7 +5,7 @@ import { AccountService } from "src/endpoints/accounts/account.service";
 import { GetAccountFilteredInput, GetAccountsInput } from "src/graphql/entities/account/account.input";
 import { ApplyComplexity } from "@multiversx/sdk-nestjs-common";
 import { QueryPagination } from "src/common/entities/query.pagination";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 
 @Resolver()
 export class AccountQuery {
@@ -15,12 +15,12 @@ export class AccountQuery {
   @ApplyComplexity({ target: Account })
   public async getAccounts(@Args("input", { description: "Input to retrieve the given accounts for." }) input: GetAccountsInput): Promise<Account[]> {
     return await this.accountService.getAccounts(
-      new QueryPagination({ from: input.from, size: input.size }), new AccountFilter({ ownerAddress: input.ownerAddress })
+      new QueryPagination({ from: input.from, size: input.size }), new AccountQueryOptions({ ownerAddress: input.ownerAddress })
     );
   }
 
   @Query(() => Float, { name: "accountsCount", description: "Retrieve all accounts count." })
   public async getAccountsCount(@Args("input", { description: "Input to retrieve the given accounts for." }) input: GetAccountFilteredInput): Promise<number> {
-    return await this.accountService.getAccountsCount(new AccountFilter({ ownerAddress: input.ownerAddress }));
+    return await this.accountService.getAccountsCount(new AccountQueryOptions({ ownerAddress: input.ownerAddress }));
   }
 }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -55,11 +55,17 @@ type Account {
   """Owner Account Address assets details."""
   ownerAssets: AccountAssets
 
+  """Smart contract results count for the given detailed account."""
+  scrCount: Float!
+
   """Shard for the given account."""
   shard: Float!
 
   """Timestamp of the block where the account was first indexed."""
   timestamp: Float!
+
+  """Transactions count for the given detailed account."""
+  txCount: Float!
 }
 
 """Account assets object type."""

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -15,7 +15,7 @@ import { AccountService } from "src/endpoints/accounts/account.service";
 import { Account } from "src/endpoints/accounts/entities/account";
 import { AccountDetailed } from "src/endpoints/accounts/entities/account.detailed";
 import { AccountEsdtHistory } from "src/endpoints/accounts/entities/account.esdt.history";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountHistory } from "src/endpoints/accounts/entities/account.history";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { ContractUpgrades } from "src/endpoints/accounts/entities/contract.upgrades";
@@ -182,7 +182,7 @@ describe('Account Service', () => {
 
   describe('getAccountsCount', () => {
     it('should call cachingService.getOrSet if filter.ownerAddress is not provided', async () => {
-      const filter: AccountFilter = { ownerAddress: undefined };
+      const filter: AccountQueryOptions = { ownerAddress: undefined };
       const expectedResult = 5;
 
       jest.spyOn(cacheService, 'getOrSet').mockResolvedValue(expectedResult);
@@ -210,7 +210,7 @@ describe('Account Service', () => {
     });
 
     it('should call cachingService.getOrSet if filter.isSmartContract is not provided', async () => {
-      const filter: AccountFilter = { isSmartContract: undefined };
+      const filter: AccountQueryOptions = { isSmartContract: undefined };
       const expectedResult = 3000;
 
       jest.spyOn(cacheService, 'getOrSet').mockResolvedValue(expectedResult);
@@ -918,7 +918,7 @@ describe('Account Service', () => {
     ];
 
     it('should use cache if no filter is applied and merge with account assets', async () => {
-      const filter = new AccountFilter();
+      const filter = new AccountQueryOptions();
 
       const mockCacheFunction = jest.fn();
       mockCacheFunction.mockResolvedValue(elasticIndexerMock);
@@ -935,7 +935,7 @@ describe('Account Service', () => {
     });
 
     it('should use cache if no filter is applied and merge with account assets', async () => {
-      const filter = new AccountFilter();
+      const filter = new AccountQueryOptions();
 
       const mockCacheFunction = jest.fn();
       mockCacheFunction.mockResolvedValue(elasticIndexerMock);
@@ -952,7 +952,7 @@ describe('Account Service', () => {
     });
 
     it('should return accounts with owner assets details when withOwnerAssets filter is applied', async () => {
-      const filter = new AccountFilter({ withOwnerAssets: true });
+      const filter = new AccountQueryOptions({ withOwnerAssets: true });
 
       jest.spyOn(service, 'getAccountsRaw').mockResolvedValue(accountsRawMock);
 

--- a/src/test/unit/services/transfers.spec.ts
+++ b/src/test/unit/services/transfers.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from "@nestjs/testing";
 import { IndexerService } from "src/common/indexer/indexer.service";
-import { AccountFilter } from "src/endpoints/accounts/entities/account.query.options";
+import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionStatus } from "src/endpoints/transactions/entities/transaction.status";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
@@ -50,7 +50,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by address ', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -63,7 +63,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by sender', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.sender = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -76,7 +76,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by senders', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.senders = [
         'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
         'erd15hmuycqw4mkaksfp0yu0auy548urd0wp6wyd4vtjkg3t6h9he5ystm2sv6'];
@@ -91,7 +91,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by receivers', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.receivers = [
         'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
         'erd15hmuycqw4mkaksfp0yu0auy548urd0wp6wyd4vtjkg3t6h9he5ystm2sv6'];
@@ -106,7 +106,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by token', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.token = 'WEGLD-bd4d79';
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -119,7 +119,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by functions', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.functions = ['claim_rewards', 'stake'];
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -132,7 +132,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by senderShard', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.senderShard = 2;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -145,7 +145,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by miniBlockHash', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.miniBlockHash = '9b0dafc6445b9195cb8a4266aa21517597e0ed3444f40f7a76b3a46903a7a7d5';
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -158,7 +158,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by hashes', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.hashes = [
         '9b0dafc6445b9195cb8a4266aa21517597e0ed3444f40f7a76b3a46903a7a7d5',
         'fab9173ab8835b0d34eb5fe27da2bcfde8ee3e2db4a0d5d6441f1afbee65f420'];
@@ -173,7 +173,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by status', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.status = TransactionStatus.success;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -186,7 +186,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by before', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.before = 1679690544;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -199,7 +199,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by after', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.before = 1579690544;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -212,7 +212,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by transaction type', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.type = TransactionType.Transaction;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -225,7 +225,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by SmartContractResult type', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.type = TransactionType.Transaction;
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -238,7 +238,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by tokens', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.tokens = ['UTK-2f80e9', 'WEGLD-bd4d79'];
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')
@@ -251,7 +251,7 @@ describe('Transfers Service', () => {
     });
 
     it('should return the count of transfers filtered by senderOrReceiver', async () => {
-      const filter: TransactionFilter = new AccountFilter();
+      const filter: TransactionFilter = new AccountQueryOptions();
       filter.senderOrReceiver = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
 
       const indexerServiceMock = jest.spyOn(service['indexerService'], 'getTransfersCount')


### PR DESCRIPTION
## Proposed Changes
- added possibility of requesting the `txCount` and `scrCount` fields in the account list endpoint

## How to test
- `/accounts?withTxCount=true&withScrCount=true` should return the `txCount` and `scrCount` fields
