### PR TITLE
SERVICES-2122: duplicated transfer value only logs

### DIFF
--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -142,6 +142,7 @@ export class TransactionGetService {
     const asyncCallbackEvents = transferValueOnlyEvents.filter(x => x.data == asyncCallbackEncoded);
 
     if (backTransferEvents.length === 1 && asyncCallbackEvents.length === 1 &&
+      backTransferEvents[0].topics.length > 1 &&
       JSON.stringify(backTransferEvents[0].topics) === JSON.stringify(asyncCallbackEvents[0].topics)
     ) {
       backTransferEvents[0].topics[0] = '0';

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -110,7 +110,7 @@ export class TransactionGetService {
           if (log.id === txHash) {
             transactionDetailed.logs = log;
           } else if (transactionDetailed.results) {
-            const foundScResult = transactionDetailed.results.find(({hash}) => log.id === hash);
+            const foundScResult = transactionDetailed.results.find(({ hash }) => log.id === hash);
             if (foundScResult) {
               foundScResult.logs = log;
             }
@@ -141,8 +141,8 @@ export class TransactionGetService {
 
   private hasDuplicateDataWithMatchingTopics(events: TransactionLogEvent[]): boolean {
     const identifier = "transferValueOnly";
-    const dataValue1 = BinaryUtils.base64Encode("BackTransfer");
-    const dataValue2 = BinaryUtils.base64Encode("AsyncCallback");
+    const backTransferEncoded = BinaryUtils.base64Encode("BackTransfer");
+    const asyncCallbackEncoded = BinaryUtils.base64Encode("AsyncCallback");
 
     const dataCounts: { [key: string]: number } = {};
     const topicMap: { [key: string]: string[] } = {};
@@ -163,10 +163,10 @@ export class TransactionGetService {
     }
 
     // Check if we have exactly two occurrences of each data value
-    if (dataCounts[dataValue1] === 1 && dataCounts[dataValue2] === 1) {
+    if (dataCounts[backTransferEncoded] === 1 && dataCounts[asyncCallbackEncoded] === 1) {
       // Check if the topics are the same for the two data values
-      const topics1 = topicMap[dataValue1];
-      const topics2 = topicMap[dataValue2];
+      const topics1 = topicMap[backTransferEncoded];
+      const topics2 = topicMap[asyncCallbackEncoded];
       return topics1.toString() === topics2.toString();
     }
 

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -149,7 +149,7 @@ export class TransactionGetService {
 
     // Count occurrences of each data value and store topics for each data value
     for (const event of events) {
-      const {identifier: eventId, data, topics} = event;
+      const { identifier: eventId, data, topics } = event;
 
       if (!eventId || !data || !topics || eventId !== identifier) {
         continue;


### PR DESCRIPTION
## Reasoning
- with the latest protocol release, misleading duplicated events can be returned in some edge cases
  
## Proposed Changes
- until a new protocol release, alter the logs to avoid misleading information

## How to test
- `http://localhost:3001/transactions/9577b1e88608495a5dc259dc2e313730f44871b859f575bc6e14f380df04ac15` when running on devnet should have the first topic of the event "transferValueOnly" with data field "QmFja1RyYW5zZmVy" set to "0"
- other transactions logs / events should not be affected
