### PR TITLE
Remove value from asyncCallbackEvent

### DIFF
--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -142,10 +142,10 @@ export class TransactionGetService {
     const asyncCallbackEvents = transferValueOnlyEvents.filter(x => x.data == asyncCallbackEncoded);
 
     if (backTransferEvents.length === 1 && asyncCallbackEvents.length === 1 &&
-      backTransferEvents[0].topics.length > 1 &&
+      asyncCallbackEvents[0].topics.length > 1 &&
       JSON.stringify(backTransferEvents[0].topics) === JSON.stringify(asyncCallbackEvents[0].topics)
     ) {
-      backTransferEvents[0].topics[0] = '0';
+      asyncCallbackEvents[0].topics[0] = '0';
     }
   }
 


### PR DESCRIPTION
## Proposed Changes
- Instead of removing the transferred value from `BackTransfer` event, remove it from `AsyncCallback`