### PR TITLE
Add token info in MultiESDTNFTTransfer operations

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -65,6 +65,12 @@ export class TokenTransferService {
         if (action) {
           identifiers.push(BinaryUtils.base64Decode(event.topics[0]));
         }
+
+        if (event.identifier === TransactionLogEventIdentifier.MultiESDTNFTTransfer) {
+          for (let i = 1; i < (event.topics.length - 1) / 3; i++) {
+            identifiers.push(BinaryUtils.base64Decode(event.topics[i * 3]));
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Reasoning
- Since the `MultiESDTNFTTransfer` operation now contains all tokens inside 1 log, the functionality that adds token identifiers needs to also be adjusted to contain all tokens from the same log
  
## Proposed Changes
- Loop over the remaining topics if the event type is `MultiESDTNFTTransfer` and extract the remaining token identifiers

## How to test (mainnet)
- `/transactions/5ad17620c9881f084564e15e619e828b0af41804566c12c3657c6c0cdd5051f0` should return `decimals`, `svgUrl`, `valueUSD`, `name`, `ticker` info for all transferred tokens
