### PR TITLE
Deep history for vm query

### DIFF
--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -37,6 +37,7 @@ export class GatewayService {
     GatewayComponentRequest.addressEsdt,
     GatewayComponentRequest.addressEsdtBalance,
     GatewayComponentRequest.addressNftByNonce,
+    GatewayComponentRequest.vmQuery,
   ]);
 
   constructor(
@@ -194,7 +195,9 @@ export class GatewayService {
 
   @LogPerformanceAsync(MetricsEvents.SetGatewayDuration, { argIndex: 1 })
   async createRaw(url: string, component: GatewayComponentRequest, data: any, errorHandler?: (error: any) => Promise<boolean>): Promise<any> {
-    return await this.apiService.post(`${this.getGatewayUrl(component)}/${url}`, data, new ApiSettings(), errorHandler);
+    const fullUrl = this.getFullUrl(component, url);
+
+    return await this.apiService.post(fullUrl, data, new ApiSettings(), errorHandler);
   }
 
   private getFullUrl(component: GatewayComponentRequest, suffix: string) {

--- a/src/endpoints/vm.query/vm.query.service.ts
+++ b/src/endpoints/vm.query/vm.query.service.ts
@@ -35,7 +35,7 @@ export class VmQueryService {
     };
   }
 
-  async vmQueryFullResult(contract: string, func: string, caller: string | undefined = undefined, args: string[] = [], value: string | undefined = undefined): Promise<any> {
+  async vmQueryFullResult(contract: string, func: string, caller: string | undefined = undefined, args: string[] = [], value: string | undefined = undefined, timestamp: number | undefined): Promise<any> {
     let key = `vm-query:${contract}:${func}`;
     if (caller) {
       key += `:${caller}`;
@@ -43,6 +43,10 @@ export class VmQueryService {
 
     if (args.length > 0) {
       key += `@${args.join('@')}`;
+    }
+
+    if (timestamp) {
+      key += `{${timestamp}}`;
     }
 
     const { localTtl, remoteTtl } = await this.computeTtls();

--- a/src/interceptors/deep-history.interceptor.ts
+++ b/src/interceptors/deep-history.interceptor.ts
@@ -24,7 +24,7 @@ export class DeepHistoryInterceptor implements NestInterceptor {
       return next.handle();
     }
 
-    const address = request.params.address;
+    const address = request.params.address ?? request.body.scAddress;
     if (!address) {
       return next.handle();
     }

--- a/src/test/unit/services/vmQuery.service.spec.ts
+++ b/src/test/unit/services/vmQuery.service.spec.ts
@@ -68,7 +68,7 @@ describe('VmQueryService', () => {
 
     it('should call CacheService.getOrSet with the correct arguments', async () => {
       jest.spyOn(gatewayService, 'createRaw').mockResolvedValue({ data: {} });
-      await service.vmQueryFullResult(contract, func, caller, args, value);
+      await service.vmQueryFullResult(contract, func, caller, args, value, undefined);
       expect(cacheService.getOrSet).toHaveBeenCalledWith(key, expect.any(Function), 10, 10);
     });
   });


### PR DESCRIPTION
## Proposed Changes
- extend deep history gateway support for the `/vm-values/query` endpoint

## How to test
- perform query to the `/query` or the `/vm-values/query` endpoints with `timestamp` parameter. The response headers should return the block nonce corresponding to the provided timestamp in the shard of the `scAddress` parameter
