### PR TITLE
Fixed import of ParseIntPipe

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -201,7 +201,7 @@ export class AccountController {
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('timestamp', new ParseIntPipe) _timestamp?: number,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<TokenWithBalance[]> {
     try {
       return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
@@ -232,7 +232,7 @@ export class AccountController {
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('timestamp', new ParseIntPipe) _timestamp?: number,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<number> {
     try {
       return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
@@ -255,7 +255,7 @@ export class AccountController {
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('timestamp', new ParseIntPipe) _timestamp?: number,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<number> {
     try {
       return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
@@ -274,7 +274,7 @@ export class AccountController {
   async getAccountToken(
     @Param('address', ParseAddressPipe) address: string,
     @Param('token', ParseTokenOrNftPipe) token: string,
-    @Query('timestamp', new ParseIntPipe) _timestamp?: number,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<TokenDetailedWithBalance> {
     const result = await this.tokenService.getTokenForAddress(address, token);
     if (!result) {

--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -6,7 +6,7 @@ import { GatewayService } from "src/common/gateway/gateway.service";
 import { Response, Request } from "express";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { PluginService } from "src/common/plugins/plugin.service";
-import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
+import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseIntPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
 import { CacheService, NoCache } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
@@ -197,7 +197,7 @@ export class ProxyController {
   @UseInterceptors(DeepHistoryInterceptor)
   async queryLegacy(
     @Body() query: VmQueryRequest,
-    @Query('timestamp') timestamp: number | undefined,
+    @Query('timestamp', ParseIntPipe) timestamp: number | undefined,
   ) {
     try {
       return await this.vmQueryService.vmQueryFullResult(query.scAddress, query.funcName, query.caller, query.args, query.value, timestamp);

--- a/src/endpoints/vm.query/vm.query.controller.ts
+++ b/src/endpoints/vm.query/vm.query.controller.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, Body, Controller, HttpStatus, ParseIntPipe, Post, Query, UseInterceptors } from "@nestjs/common";
+import { BadRequestException, Body, Controller, HttpStatus, Post, Query, UseInterceptors } from "@nestjs/common";
 import { ApiCreatedResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { VmQueryRequest } from "./entities/vm.query.request";
 import { VmQueryService } from "./vm.query.service";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
+import { ParseIntPipe } from "@multiversx/sdk-nestjs-common";
 
 @Controller()
 @ApiTags('query')


### PR DESCRIPTION
## Proposed Changes
- Fixed import of the ParseIntPipe, which should be imported from the multiversx package instead of the nestjs one

## How to test
- The `/query` endpoint should not fail