### PR TITLE
Deep history shard 0 fix

### DIFF
--- a/src/interceptors/deep-history.interceptor.ts
+++ b/src/interceptors/deep-history.interceptor.ts
@@ -34,7 +34,7 @@ export class DeepHistoryInterceptor implements NestInterceptor {
     }
 
     const shardId = await this.protocolService.getShardIdForAddress(address);
-    if (!shardId) {
+    if (shardId === undefined) {
       throw new BadRequestException('Could not determine shard based on the provided address');
     }
 


### PR DESCRIPTION
## Reasoning
- Deep history queries did not work correctly if the address was on shard 0 because of the falsy check which activated also for a number with value 0

## Proposed Changes
- change falsy check with undefined check

## How to test
- Use a deep history query with timestamp for an address on shard 0, which should work
