### PR TITLE
Staking add timestamp parameter to legacy staking

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -638,10 +638,24 @@ export class AccountController {
     return result;
   }
 
-  @Get("/accounts/:address/stake")
-  @ApiOperation({ summary: 'Account stake details', description: 'Summarizes total staked amount for the given provider, as well as when and how much unbond will be performed' })
+  @Get('/accounts/:address/stake')
+  @UseInterceptors(DeepHistoryInterceptor)
+  @ApiOperation({
+    summary: 'Account stake details',
+    description:
+      'Summarizes total staked amount for the given provider, as well as when and how much unbond will be performed',
+  })
+  @ApiQuery({
+    name: 'timestamp',
+    description: 'Retrieve entry from timestamp',
+    required: false,
+    type: Number,
+  })
   @ApiOkResponse({ type: ProviderStake })
-  async getAccountStake(@Param('address', ParseAddressPipe) address: string): Promise<ProviderStake> {
+  async getAccountStake(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
+  ): Promise<ProviderStake> {
     return await this.stakeService.getStakeForAddress(address);
   }
 
@@ -653,9 +667,14 @@ export class AccountController {
   }
 
   @Get("/accounts/:address/delegation-legacy")
+  @UseInterceptors(DeepHistoryInterceptor)
   @ApiOperation({ summary: 'Account legacy delegation details', description: 'Returns staking information related to the legacy delegation pool' })
   @ApiOkResponse({ type: AccountDelegationLegacy })
-  async getAccountDelegationLegacy(@Param('address', ParseAddressPipe) address: string): Promise<AccountDelegationLegacy> {
+  @ApiQuery({ name: 'timestamp', description: 'Retrieve entry from timestamp', required: false, type: Number })
+  async getAccountDelegationLegacy(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('timestamp', ParseIntPipe) _timestamp?: number,
+   ): Promise<AccountDelegationLegacy> {
     return await this.delegationLegacyService.getDelegationForAddress(address);
   }
 

--- a/src/endpoints/delegation.legacy/delegation.legacy.service.ts
+++ b/src/endpoints/delegation.legacy/delegation.legacy.service.ts
@@ -89,9 +89,10 @@ export class DelegationLegacyService {
       userActiveStake,
       userUnstakedStake,
       userDeferredPaymentStake,
-    ] = userStakeByTypeEncoded.map((encoded) => this.numberDecode(encoded));
+    ] = userStakeByTypeEncoded ? userStakeByTypeEncoded.map((encoded) => this.numberDecode(encoded)) : 
+      ['0', '0', '0', '0', '0',];
 
-    const claimableRewards = this.numberDecode(claimableRewardsEncoded[0]);
+    const claimableRewards = claimableRewardsEncoded ? this.numberDecode(claimableRewardsEncoded[0]) : '0';
 
     return {
       userWithdrawOnlyStake,

--- a/src/endpoints/delegation.legacy/delegation.legacy.service.ts
+++ b/src/endpoints/delegation.legacy/delegation.legacy.service.ts
@@ -90,7 +90,7 @@ export class DelegationLegacyService {
       userUnstakedStake,
       userDeferredPaymentStake,
     ] = userStakeByTypeEncoded ? userStakeByTypeEncoded.map((encoded) => this.numberDecode(encoded)) : 
-      ['0', '0', '0', '0', '0',];
+      ['0', '0', '0', '0', '0'];
 
     const claimableRewards = claimableRewardsEncoded ? this.numberDecode(claimableRewardsEncoded[0]) : '0';
 


### PR DESCRIPTION
## Reasoning
We need to support `timestamp` parameter to the Legacy Staking and Staking endpoints in the Accounts controller.
  
## Proposed Changes
- Add timestamp query parameter
- Validate legacy staking VMQuery result in case it is null or DeepHistory doesn't work
- 

## How to test
- Test the /stake and /legacy-delegation endpoints with an address and different timestamps
- 
- 
