### PR TITLE
add mexPairType token property

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -55,6 +55,7 @@ import { ParseArrayPipeOptions } from '@multiversx/sdk-nestjs-common/lib/pipes/e
 import { NodeStatusRaw } from '../nodes/entities/node.status';
 import { AccountKeyFilter } from './entities/account.key.filter';
 import { DeepHistoryInterceptor } from 'src/interceptors/deep-history.interceptor';
+import { MexPairType } from '../mex/entities/mex.pair.type';
 
 @Controller()
 @ApiTags('accounts')
@@ -190,6 +191,7 @@ export class AccountController {
   @ApiQuery({ name: 'identifiers', description: 'A comma-separated list of identifiers to filter by', required: false, type: String })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
   @ApiQuery({ name: 'timestamp', description: 'Retrieve entries from timestamp', required: false, type: Number })
+  @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
   @ApiOkResponse({ type: [TokenWithBalance] })
   async getAccountTokens(
     @Param('address', ParseAddressPipe) address: string,
@@ -202,9 +204,10 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<TokenWithBalance[]> {
     try {
-      return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
+      return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
     } catch (error) {
       this.logger.error(`Error in getAccountTokens for address ${address}`);
       this.logger.error(error);
@@ -223,6 +226,7 @@ export class AccountController {
   @ApiQuery({ name: 'identifiers', description: 'A comma-separated list of identifiers to filter by', required: false, type: String })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
   @ApiQuery({ name: 'timestamp', description: 'Retrieve entries from timestamp', required: false, type: Number })
+  @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
   @ApiOkResponse({ type: Number })
   async getTokenCount(
     @Param('address', ParseAddressPipe) address: string,
@@ -233,9 +237,10 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<number> {
     try {
-      return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
+      return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
     } catch (error) {
       this.logger.error(`Error in getTokenCount for address ${address}`);
       this.logger.error(error);
@@ -256,9 +261,10 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<number> {
     try {
-      return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
+      return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
     } catch (error) {
       this.logger.error(`Error in getTokenCount for address ${address}`);
       this.logger.error(error);
@@ -674,7 +680,7 @@ export class AccountController {
   async getAccountDelegationLegacy(
     @Param('address', ParseAddressPipe) address: string,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
-   ): Promise<AccountDelegationLegacy> {
+  ): Promise<AccountDelegationLegacy> {
     return await this.delegationLegacyService.getDelegationForAddress(address);
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -204,7 +204,7 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<TokenWithBalance[]> {
     try {
       return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
@@ -237,7 +237,7 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
     try {
       return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
@@ -261,7 +261,7 @@ export class AccountController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
     try {
       return await this.tokenService.getTokenCountForAddress(address, new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { Token } from "./token";
 import { TokenRoles } from "./token.roles";
+import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 
 @ObjectType("TokenDetailed", { description: "TokenDetailed object type." })
 export class TokenDetailed extends Token {
@@ -38,4 +39,8 @@ export class TokenDetailed extends Token {
   @Field(() => Boolean, { description: 'If the given NFT collection can transfer the underlying tokens by default.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   canTransfer: boolean | undefined = undefined;
+
+  @Field(() => MexPairType, { description: "Mex pair type details." })
+  @ApiProperty({ enum: MexPairType })
+  mexPairType: MexPairType = MexPairType.experimental;
 }

--- a/src/endpoints/tokens/entities/token.filter.ts
+++ b/src/endpoints/tokens/entities/token.filter.ts
@@ -24,5 +24,5 @@ export class TokenFilter {
 
   order?: SortOrder;
 
-  mexPairType?: MexPairType;
+  mexPairType?: MexPairType[];
 }

--- a/src/endpoints/tokens/entities/token.filter.ts
+++ b/src/endpoints/tokens/entities/token.filter.ts
@@ -1,6 +1,7 @@
 import { SortOrder } from "src/common/entities/sort.order";
 import { TokenType } from "src/common/indexer/entities";
 import { TokenSort } from "./token.sort";
+import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 
 export class TokenFilter {
   constructor(init?: Partial<TokenFilter>) {
@@ -22,4 +23,6 @@ export class TokenFilter {
   sort?: TokenSort;
 
   order?: SortOrder;
+
+  mexPairType?: MexPairType;
 }

--- a/src/endpoints/tokens/entities/token.with.balance.ts
+++ b/src/endpoints/tokens/entities/token.with.balance.ts
@@ -2,6 +2,7 @@ import { SwaggerUtils } from "@multiversx/sdk-nestjs-common";
 import { Field, Float, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { Token } from "./token";
+import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 
 @ObjectType("TokenWithBalance", { description: "NFT collection account object type." })
 export class TokenWithBalance extends Token {
@@ -20,4 +21,8 @@ export class TokenWithBalance extends Token {
 
   @ApiProperty({ type: String, nullable: true })
   attributes: string | undefined = undefined;
+
+  @Field(() => MexPairType, { description: "Mex pair type details." })
+  @ApiProperty({ enum: MexPairType })
+  mexPairType: MexPairType = MexPairType.experimental;
 }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -18,7 +18,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { TokenFilter } from "./entities/token.filter";
 import { TransactionFilter } from "../transactions/entities/transaction.filter";
 import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
-import { ParseAddressPipe, ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseTokenPipe, ParseAddressArrayPipe, ApplyComplexity } from "@multiversx/sdk-nestjs-common";
+import { ParseAddressPipe, ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseTokenPipe, ParseAddressArrayPipe, ApplyComplexity, ParseEnumArrayPipe } from "@multiversx/sdk-nestjs-common";
 import { TransactionDetailed } from "../transactions/entities/transaction.detailed";
 import { Response } from "express";
 import { TokenType } from "src/common/indexer/entities";
@@ -60,7 +60,7 @@ export class TokenController {
     @Query('sort', new ParseEnumPipe(TokenSort)) sort?: TokenSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<TokenDetailed[]> {
     return await this.tokenService.getTokens(
       new QueryPagination({ from, size }),
@@ -85,7 +85,7 @@ export class TokenController {
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
     return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
   }
@@ -99,7 +99,7 @@ export class TokenController {
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
-    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
+    @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
     return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
   }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -23,6 +23,7 @@ import { TransactionDetailed } from "../transactions/entities/transaction.detail
 import { Response } from "express";
 import { TokenType } from "src/common/indexer/entities";
 import { ParseArrayPipeOptions } from "@multiversx/sdk-nestjs-common/lib/pipes/entities/parse.array.options";
+import { MexPairType } from "../mex/entities/mex.pair.type";
 
 @Controller()
 @ApiTags('tokens')
@@ -47,6 +48,7 @@ export class TokenController {
   @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false, enum: SortTokens })
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
+  @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
   async getTokens(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -58,10 +60,11 @@ export class TokenController {
     @Query('sort', new ParseEnumPipe(TokenSort)) sort?: TokenSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<TokenDetailed[]> {
     return await this.tokenService.getTokens(
       new QueryPagination({ from, size }),
-      new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, sort, order })
+      new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, sort, order, mexPairType })
     );
   }
 
@@ -74,6 +77,7 @@ export class TokenController {
   @ApiQuery({ name: 'identifier', description: 'Search by token identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by multiple token identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
+  @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
   async getTokenCount(
     @Query('search') search?: string,
     @Query('name') name?: string,
@@ -81,8 +85,9 @@ export class TokenController {
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<number> {
-    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
+    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
   }
 
   @Get("/tokens/c")
@@ -94,8 +99,9 @@ export class TokenController {
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('mexPairType', new ParseEnumPipe(MexPairType)) mexPairType?: MexPairType,
   ): Promise<number> {
-    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT }));
+    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
   }
 
   @Get('/tokens/:identifier')

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -40,6 +40,7 @@ import { TrieOperationsTimeoutError } from "../esdt/exceptions/trie.operations.t
 import { TokenSupplyOptions } from "./entities/token.supply.options";
 import { TransferService } from "../transfers/transfer.service";
 import { MexPairService } from "../mex/mex.pair.service";
+import { MexPairType } from "../mex/entities/mex.pair.type";
 
 @Injectable()
 export class TokenService {
@@ -168,7 +169,7 @@ export class TokenService {
   }
 
   private sortTokens(tokens: TokenDetailed[], sort: TokenSort, order: SortOrder): TokenDetailed[] {
-    let criteria: (token: Token) => number;
+    let criteria: (token: TokenDetailed) => number;
 
     switch (sort) {
       case TokenSort.accounts:
@@ -181,7 +182,7 @@ export class TokenService {
         criteria = token => token.price ?? 0;
         break;
       case TokenSort.marketCap:
-        criteria = token => token.marketCap ?? 0;
+        criteria = token => token.mexPairType === MexPairType.experimental ? 0 : token.marketCap ?? 0;
         break;
       default:
         throw new Error(`Unsupported sorting criteria '${sort}'`);

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -40,7 +40,6 @@ import { TrieOperationsTimeoutError } from "../esdt/exceptions/trie.operations.t
 import { TokenSupplyOptions } from "./entities/token.supply.options";
 import { TransferService } from "../transfers/transfer.service";
 import { MexPairService } from "../mex/mex.pair.service";
-import { MexPairType } from "../mex/entities/mex.pair.type";
 
 @Injectable()
 export class TokenService {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -182,7 +182,7 @@ export class TokenService {
         criteria = token => token.price ?? 0;
         break;
       case TokenSort.marketCap:
-        criteria = token => token.mexPairType === MexPairType.experimental ? 0 : token.marketCap ?? 0;
+        criteria = token => token.marketCap ?? 0;
         break;
       default:
         throw new Error(`Unsupported sorting criteria '${sort}'`);

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -159,8 +159,9 @@ export class TokenService {
       tokens = this.sortTokens(tokens, filter.sort, filter.order ?? SortOrder.desc);
     }
 
-    if (filter.mexPairType) {
-      tokens = tokens.filter(token => token.mexPairType === filter.mexPairType);
+    const mexPairTypes = filter.mexPairType ?? [];
+    if (mexPairTypes.length > 0) {
+      tokens = tokens.filter(token => mexPairTypes.includes(token.mexPairType));
     }
 
     return tokens;

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -159,6 +159,10 @@ export class TokenService {
       tokens = this.sortTokens(tokens, filter.sort, filter.order ?? SortOrder.desc);
     }
 
+    if (filter.mexPairType) {
+      tokens = tokens.filter(token => token.mexPairType === filter.mexPairType);
+    }
+
     return tokens;
   }
 
@@ -793,8 +797,7 @@ export class TokenService {
         }
       }
     } catch (error) {
-      this.logger.error('Could not apply mex pair types');
-      this.logger.error(error);
+      this.logger.error('Could not apply mex pair types', error);
     }
   }
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3798,6 +3798,9 @@ type TokenWithBalanceAccountFlat {
   """Current market cap details."""
   marketCap: Float
 
+  """Mex pair type details."""
+  mexPairType: MexPairType!
+
   """Token minted details."""
   minted: String!
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3613,6 +3613,9 @@ type TokenDetailed {
   """Current market cap details."""
   marketCap: Float
 
+  """Mex pair type details."""
+  mexPairType: MexPairType!
+
   """Token minted amount details."""
   minted: String!
 

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -22,6 +22,7 @@ import { TokenProperties } from "src/endpoints/tokens/entities/token.properties"
 import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { TransferService } from "src/endpoints/transfers/transfer.service";
+import { MexPairService } from "src/endpoints/mex/mex.pair.service";
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -122,6 +123,12 @@ describe('Token Service', () => {
           provide: TransferService,
           useValue: {
             getTransfersCount: jest.fn(),
+          },
+        },
+        {
+          provide: MexPairService,
+          useValue: {
+            getAllMexPairs: jest.fn(),
           },
         },
       ],


### PR DESCRIPTION
## Reasoning
- To enhance token data with contextual exchange information, we need to include `mexPairType` indicating the category of each token within the ecosystem (e.g., core, community).
  
## Proposed Changes
- Implement `applyMexPairType` method that enriches an array of tokens with their respective `MexPairType` by leveraging the `mexPairService.getAllMexPairs` to fetch pair information and match each token with its pair type based on `baseId`.
- Integrate `applyMexPairType` within `getAllTokensRaw` method to apply `MexPairType` information to each token during the token fetching process.

## How to test
- `/tokens` -> every token should contain `mexPairType` property
- `/tokens/CRT-52decf` -> token details should contain `mexPairType` property
- `/tokens?mexPairType=core` -> should return all core tokens
- `/tokens/count?mexPairType=core` -> should return total core tokens count
- `/accounts/:address/tokens?mexPairType=core` -> should return all core tokens for a specific address