### PR TITLE
Exclude market cap from low liquidity tokens when sorting

### DIFF
--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -43,4 +43,12 @@ export class TokenDetailed extends Token {
   @Field(() => MexPairType, { description: "Mex pair type details." })
   @ApiProperty({ enum: MexPairType })
   mexPairType: MexPairType = MexPairType.experimental;
+
+  @Field(() => Number, { description: "Total value captured in liquidity pools." })
+  @ApiProperty({ type: Number, nullable: true })
+  totalLiquidity: number | undefined = undefined;
+
+  @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  isLowLiquidity: boolean | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -3,7 +3,6 @@ import { Field, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { Token } from "./token";
 import { TokenRoles } from "./token.roles";
-import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 
 @ObjectType("TokenDetailed", { description: "TokenDetailed object type." })
 export class TokenDetailed extends Token {
@@ -39,16 +38,4 @@ export class TokenDetailed extends Token {
   @Field(() => Boolean, { description: 'If the given NFT collection can transfer the underlying tokens by default.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   canTransfer: boolean | undefined = undefined;
-
-  @Field(() => MexPairType, { description: "Mex pair type details." })
-  @ApiProperty({ enum: MexPairType })
-  mexPairType: MexPairType = MexPairType.experimental;
-
-  @Field(() => Number, { description: "Total value captured in liquidity pools." })
-  @ApiProperty({ type: Number, nullable: true })
-  totalLiquidity: number | undefined = undefined;
-
-  @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
-  @ApiProperty({ type: Boolean, nullable: true })
-  isLowLiquidity: boolean | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -139,6 +139,10 @@ export class Token {
   @ApiProperty({ type: Number, nullable: true })
   totalLiquidity: number | undefined = undefined;
 
+  @Field(() => Number, { description: "Total traded value in the last 24h within the liquidity pools." })
+  @ApiProperty({ type: Number, nullable: true })
+  totalVolume24h: number | undefined = undefined;
+
   @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   isLowLiquidity: boolean | undefined = undefined;

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -3,6 +3,7 @@ import { Field, Float, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { TokenType } from "src/common/indexer/entities";
 import { TokenAssets } from "../../../common/assets/entities/token.assets";
+import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 
 @ObjectType("Token", { description: "Token object type." })
 export class Token {
@@ -129,4 +130,16 @@ export class Token {
   @Field(() => Number, { description: "Creation timestamp." })
   @ApiProperty({ type: Number, description: 'Creation timestamp' })
   timestamp: number | undefined = undefined;
+
+  @Field(() => MexPairType, { description: "Mex pair type details." })
+  @ApiProperty({ enum: MexPairType })
+  mexPairType: MexPairType = MexPairType.experimental;
+
+  @Field(() => Number, { description: "Total value captured in liquidity pools." })
+  @ApiProperty({ type: Number, nullable: true })
+  totalLiquidity: number | undefined = undefined;
+
+  @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  isLowLiquidity: boolean | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -883,6 +883,7 @@ export class TokenService {
         const pairs = filteredPairs.filter(x => x.baseId === token.identifier || x.quoteId === token.identifier);
         if (pairs.length > 0) {
           token.totalLiquidity = pairs.sum(x => x.totalValue / 2);
+          token.totalVolume24h = pairs.sum(x => x.volume24h ?? 0);
         }
       }
     } catch (error) {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -701,7 +701,7 @@ export class TokenService {
 
     const tokens = await this.getAllTokens();
     for (const token of tokens) {
-      if (token.price && token.marketCap) {
+      if (token.price && token.marketCap && !token.isLowLiquidity) {
         totalMarketCap += token.marketCap;
       }
     }
@@ -779,7 +779,11 @@ export class TokenService {
       }
     }
 
-    tokens = tokens.sortedDescending(token => token.assets ? 1 : 0, token => token.isLowLiquidity ? 0 : (token.marketCap ?? 0), token => token.transactions ?? 0);
+    tokens = tokens.sortedDescending(
+      token => token.assets ? 1 : 0,
+      token => token.isLowLiquidity ? 0 : (token.marketCap ?? 0),
+      token => token.transactions ?? 0,
+    );
 
     return tokens;
   }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -779,7 +779,7 @@ export class TokenService {
       }
     }
 
-    tokens = tokens.sortedDescending(token => token.assets ? 1 : 0, token => token.marketCap ?? 0, token => token.transactions ?? 0);
+    tokens = tokens.sortedDescending(token => token.assets ? 1 : 0, token => token.isLowLiquidity ? 0 : (token.marketCap ?? 0), token => token.transactions ?? 0);
 
     return tokens;
   }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3800,6 +3800,11 @@ type TokenWithBalanceAccountFlat {
   """Token initial minting details."""
   initialMinted: String!
 
+  """
+  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.
+  """
+  isLowLiquidity: Boolean
+
   """Token isPause property."""
   isPaused: Boolean!
 
@@ -3829,6 +3834,9 @@ type TokenWithBalanceAccountFlat {
 
   """Creation timestamp."""
   timestamp: Float!
+
+  """Total value captured in liquidity pools."""
+  totalLiquidity: Float!
 
   """Tokens transactions."""
   transactions: Float

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3607,6 +3607,11 @@ type TokenDetailed {
   """Token initial minted amount details."""
   initialMinted: String!
 
+  """
+  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.
+  """
+  isLowLiquidity: Boolean
+
   """Token isPause property."""
   isPaused: Boolean!
 
@@ -3642,6 +3647,9 @@ type TokenDetailed {
 
   """Creation timestamp."""
   timestamp: Float!
+
+  """Total value captured in liquidity pools."""
+  totalLiquidity: Float!
 
   """Tokens transactions."""
   transactions: Float


### PR DESCRIPTION
## Reasoning
- Tokens could have artificially inflated economics and display a very large market cap by providing a very small liquidity amount
  
## Proposed Changes
- Provide the total liquidity as a field on the token itself, for better visibility
- if the liquidity divided by the market cap on all pools is less than 1%, then we exclude it from sorting by market cap
- return an `isLowLiquidity` field in the token if the above condition is true

## How to test
- `/tokens` should not return in the first results tokens with high market cap, but low liquidity
- for the tokens with the criteria above, the `isLowLiquidity` field should be set to true
