### PR TITLE
rename transfersCount to transfers for token details

### DIFF
--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -69,7 +69,7 @@ export class Token {
 
   @Field(() => Float, { description: "Tokens transfers.", nullable: true })
   @ApiProperty({ type: Number, nullable: true })
-  transfersCount: number | undefined = undefined;
+  transfers: number | undefined = undefined;
 
   @Field(() => Float, { description: "Token accounts list." })
   @ApiProperty({ type: Number, nullable: true })

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -829,7 +829,7 @@ export class TokenService {
       tokens,
       token => CacheInfo.TokenTransfers(token.identifier).key,
       async token => await this.getTransfersCount(token),
-      (token, transfersCount) => token.transfersCount = transfersCount,
+      (token, transfers) => token.transfers = transfers,
       CacheInfo.TokenTransfers('').ttl,
     );
   }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3651,11 +3651,14 @@ type TokenDetailed {
   """Total value captured in liquidity pools."""
   totalLiquidity: Float!
 
+  """Total traded value in the last 24h within the liquidity pools."""
+  totalVolume24h: Float!
+
   """Tokens transactions."""
   transactions: Float
 
   """Tokens transfers."""
-  transfersCount: Float
+  transfers: Float
 
   """Token type."""
   type: TokenType!
@@ -3838,11 +3841,14 @@ type TokenWithBalanceAccountFlat {
   """Total value captured in liquidity pools."""
   totalLiquidity: Float!
 
+  """Total traded value in the last 24h within the liquidity pools."""
+  totalVolume24h: Float!
+
   """Tokens transactions."""
   transactions: Float
 
   """Tokens transfers."""
-  transfersCount: Float
+  transfers: Float
 
   """Token type."""
   type: TokenType!


### PR DESCRIPTION
## Reasoning
- To respect the already created convention, instead of the `transfersCount` attribute, we will change it to `transfers` 

  
## Proposed Changes
- Change `transfersCount` attribute to `transfers`

## How to test
- `tokens/MEX-455c57` -> check if `transfers` property is defined
- `tokens` -> every token should contain `transfers` property
