### PR TITLE
lower the percentage to 0.5% in liquidity requirement

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -893,6 +893,8 @@ export class TokenService {
   }
 
   private async applyMexPrices(tokens: TokenDetailed[]): Promise<void> {
+    const LOW_LIQUIDITY_THRESHOLD = 0.005;
+
     try {
       const indexedTokens = await this.mexTokenService.getMexPricesRaw();
       for (const token of tokens) {
@@ -908,7 +910,7 @@ export class TokenService {
             token.price = price.price;
             token.marketCap = price.price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
 
-            if (token.totalLiquidity && token.marketCap && token.totalLiquidity / token.marketCap < 0.01) {
+            if (token.totalLiquidity && token.marketCap && token.totalLiquidity / token.marketCap < LOW_LIQUIDITY_THRESHOLD) {
               token.isLowLiquidity = true;
             }
           }


### PR DESCRIPTION
## Reasoning
- Lowering the threshold from `1%` to `0.5%` allows for a more precise identification of tokens with genuinely low liquidity, ensuring that our liquidity checks are more aligned
-  Using a constant for the low liquidity threshold instead of a hardcoded numeric value makes the code easier to read and understand.
  
## Proposed Changes
- Change the liquidity check threshold from `1%` (previously hardcoded as `0.01`) to `0.5%` (now defined as `LOW_LIQUIDITY_THRESHOLD`), to better identify tokens with low liquidity.

## How to test
- `/tokens` -> verify the sorted tokens
