### PR TITLE
Forward index endpoints

### DIFF
--- a/src/endpoints/endpoints.controllers.module.ts
+++ b/src/endpoints/endpoints.controllers.module.ts
@@ -21,7 +21,7 @@ import { TagController } from "./nfttags/tag.controller";
 import { NodeController } from "./nodes/node.controller";
 import { ProcessNftsPublicController } from "./process-nfts/process.nfts.public.controller";
 import { ProviderController } from "./providers/provider.controller";
-import { ProxyController } from "./proxy/proxy.controller";
+import { GatewayProxyController } from "./proxy/gateway.proxy.controller";
 import { ProxyModule } from "./proxy/proxy.module";
 import { RoundController } from "./rounds/round.controller";
 import { SmartContractResultController } from "./sc-results/scresult.controller";
@@ -43,7 +43,7 @@ export class EndpointsControllersModule {
     const controllers: Type<any>[] = [
       AccountController, BlockController, CollectionController, DelegationController, DelegationLegacyController, IdentitiesController,
       KeysController, MiniBlockController, NetworkController, NftController, TagController, NodeController,
-      ProviderController, ProxyController, RoundController, SmartContractResultController, ShardController, StakeController, StakeController,
+      ProviderController, GatewayProxyController, RoundController, SmartContractResultController, ShardController, StakeController, StakeController,
       TokenController, TransactionController, UsernameController, VmQueryController, WaitingListController,
       HealthCheckController, DappConfigController, WebsocketController, TransferController,
       ProcessNftsPublicController, TransactionsBatchController,

--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -10,8 +10,7 @@ import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseIntPipe, ParseTra
 import { CacheService, NoCache } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
-import { ApiService, DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
 
 @Controller()
 @ApiTags('proxy')
@@ -25,8 +24,6 @@ export class GatewayProxyController {
     private readonly vmQueryService: VmQueryService,
     private readonly cachingService: CacheService,
     private readonly pluginService: PluginService,
-    private readonly apiService: ApiService,
-    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   @Get('/address/:address')
@@ -401,59 +398,5 @@ export class GatewayProxyController {
       GatewayComponentRequest.forward,
       queryParams
     );
-  }
-
-  @Get('/index/:collection/_search')
-  async forwardIndexSearchGet(
-    @Param('collection') collection: string,
-    @Req() request: Request,
-  ) {
-    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
-    const queryParams = request.query;
-
-    const { data } = await this.apiService.get(url, { params: queryParams });
-
-    return data;
-  }
-
-  @Get('/index/:collection/_count')
-  async forwardIndexCountGet(
-    @Param('collection') collection: string,
-    @Req() request: Request,
-  ) {
-    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
-    const queryParams = request.query;
-
-    const { data } = await this.apiService.get(url, { params: queryParams });
-
-    return data;
-  }
-
-  @Post('/index/:collection/_search')
-  async forwardIndexSearchPost(
-    @Param('collection') collection: string,
-    @Body() body: any,
-    @Req() request: Request,
-  ) {
-    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
-    const queryParams = request.query;
-
-    const { data } = await this.apiService.post(url, body, { params: queryParams });
-
-    return data;
-  }
-
-  @Post('/index/:collection/_count')
-  async forwardIndexCountPost(
-    @Param('collection') collection: string,
-    @Body() body: any,
-    @Req() request: Request,
-  ) {
-    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
-    const queryParams = request.query;
-
-    const { data } = await this.apiService.post(url, body, { params: queryParams });
-
-    return data;
   }
 }

--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -12,12 +12,13 @@ import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
 import { ApiService, DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
+
 @Controller()
 @ApiTags('proxy')
 @ApiExcludeController()
 @DisableFieldsInterceptorOnController()
-export class ProxyController {
-  private readonly logger = new OriginLogger(ProxyController.name);
+export class GatewayProxyController {
+  private readonly logger = new OriginLogger(GatewayProxyController.name);
 
   constructor(
     private readonly gatewayService: GatewayService,

--- a/src/endpoints/proxy/index.proxy.controller.ts
+++ b/src/endpoints/proxy/index.proxy.controller.ts
@@ -1,0 +1,70 @@
+import { Body, Controller, Get, Param, Post, Req } from "@nestjs/common";
+import { ApiExcludeController, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+import { ApiService, DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
+
+@Controller('index')
+@ApiTags('proxy')
+@ApiExcludeController()
+@DisableFieldsInterceptorOnController()
+export class IndexProxyController {
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly apiConfigService: ApiConfigService,
+  ) { }
+
+  @Get('/:collection/_search')
+  async forwardIndexSearchGet(
+    @Param('collection') collection: string,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.get(url, { params: queryParams });
+
+    return data;
+  }
+
+  @Get('/:collection/_count')
+  async forwardIndexCountGet(
+    @Param('collection') collection: string,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.get(url, { params: queryParams });
+
+    return data;
+  }
+
+  @Post('/:collection/_search')
+  async forwardIndexSearchPost(
+    @Param('collection') collection: string,
+    @Body() body: any,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.post(url, body, { params: queryParams });
+
+    return data;
+  }
+
+  @Post('/:collection/_count')
+  async forwardIndexCountPost(
+    @Param('collection') collection: string,
+    @Body() body: any,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.post(url, body, { params: queryParams });
+
+    return data;
+  }
+}

--- a/src/endpoints/proxy/proxy.controller.ts
+++ b/src/endpoints/proxy/proxy.controller.ts
@@ -10,7 +10,8 @@ import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseIntPipe, ParseTra
 import { CacheService, NoCache } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
-import { DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
+import { ApiService, DisableFieldsInterceptorOnController } from "@multiversx/sdk-nestjs-http";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
 @Controller()
 @ApiTags('proxy')
 @ApiExcludeController()
@@ -23,6 +24,8 @@ export class ProxyController {
     private readonly vmQueryService: VmQueryService,
     private readonly cachingService: CacheService,
     private readonly pluginService: PluginService,
+    private readonly apiService: ApiService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   @Get('/address/:address')
@@ -397,5 +400,59 @@ export class ProxyController {
       GatewayComponentRequest.forward,
       queryParams
     );
+  }
+
+  @Get('/index/:collection/_search')
+  async forwardIndexSearchGet(
+    @Param('collection') collection: string,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.get(url, { params: queryParams });
+
+    return data;
+  }
+
+  @Get('/index/:collection/_count')
+  async forwardIndexCountGet(
+    @Param('collection') collection: string,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.get(url, { params: queryParams });
+
+    return data;
+  }
+
+  @Post('/index/:collection/_search')
+  async forwardIndexSearchPost(
+    @Param('collection') collection: string,
+    @Body() body: any,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_search`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.post(url, body, { params: queryParams });
+
+    return data;
+  }
+
+  @Post('/index/:collection/_count')
+  async forwardIndexCountPost(
+    @Param('collection') collection: string,
+    @Body() body: any,
+    @Req() request: Request,
+  ) {
+    const url = `${this.apiConfigService.getElasticUrl()}/${collection}/_count`;
+    const queryParams = request.query;
+
+    const { data } = await this.apiService.post(url, body, { params: queryParams });
+
+    return data;
   }
 }

--- a/src/endpoints/proxy/proxy.module.ts
+++ b/src/endpoints/proxy/proxy.module.ts
@@ -1,7 +1,8 @@
 import { Module } from "@nestjs/common";
 import { PluginModule } from "src/plugins/plugin.module";
 import { VmQueryModule } from "../vm.query/vm.query.module";
-import { ProxyController } from "./proxy.controller";
+import { GatewayProxyController } from "./gateway.proxy.controller";
+import { IndexProxyController } from "./index.proxy.controller";
 
 @Module({
   imports: [
@@ -9,7 +10,8 @@ import { ProxyController } from "./proxy.controller";
     PluginModule,
   ],
   controllers: [
-    ProxyController,
+    GatewayProxyController,
+    IndexProxyController,
   ],
 })
 export class ProxyModule { }

--- a/src/interceptors/transaction.logging.interceptor.ts
+++ b/src/interceptors/transaction.logging.interceptor.ts
@@ -1,7 +1,7 @@
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
 import { Observable } from "rxjs";
-import { ProxyController } from "src/endpoints/proxy/proxy.controller";
+import { GatewayProxyController } from "src/endpoints/proxy/gateway.proxy.controller";
 import { TransactionController } from "src/endpoints/transactions/transaction.controller";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
@@ -52,7 +52,7 @@ export class TransactionLoggingInterceptor implements NestInterceptor {
     const request = context.getArgByIndex(0);
 
     const isCreateTransactionCall = context.getClass().name === TransactionController.name && context.getHandler().name === 'createTransaction';
-    const isSendTransactionCall = context.getClass().name === ProxyController.name && context.getHandler().name === 'transactionSend';
+    const isSendTransactionCall = context.getClass().name === GatewayProxyController.name && context.getHandler().name === 'transactionSend';
 
     if (isCreateTransactionCall || isSendTransactionCall) {
       const logBody = {


### PR DESCRIPTION
## Proposed Changes
- To ease with debugging, offer the possibility to access the ES instance that sits behind the api

## How to test
- GET `/index/logs/_search` should return logs
- GET `/index/logs/_count` should return logs count
- POST `/index/logs/_search` should return logs with query params set in body
- POST `/index/logs/_count` should return logs count with query params set in body
