### PR TITLE
Identities improvements

### DIFF
--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import { readdir } from 'fs/promises';
 import { AssetsService } from "../assets/assets.service";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
-import { Constants, OriginLogger, AddressUtils } from "@multiversx/sdk-nestjs-common";
+import { AddressUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { ApiConfigService } from "../api-config/api.config.service";
 
 @Injectable()
@@ -104,15 +104,8 @@ export class KeybaseService {
 
   async confirmIdentityProfiles(): Promise<void> {
     const identities = await this.getDistinctIdentities();
-
-    await this.cachingService.batchProcess(
-      identities,
-      identity => CacheInfo.IdentityProfile(identity).key,
-      // eslint-disable-next-line require-await
-      async identity => this.getProfile(identity),
-      Constants.oneDay(),
-      true
-    );
+    const keybaseIdentities = identities.map(identity => this.getProfile(identity));
+    await this.cachingService.set(CacheInfo.IdentityProfilesKeybases.key, keybaseIdentities, CacheInfo.IdentityProfilesKeybases.ttl);
   }
 
   getProfile(identity: string): KeybaseIdentity | null {

--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -8,6 +8,7 @@ import { readdir } from 'fs/promises';
 import { AssetsService } from "../assets/assets.service";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { Constants, OriginLogger, AddressUtils } from "@multiversx/sdk-nestjs-common";
+import { ApiConfigService } from "../api-config/api.config.service";
 
 @Injectable()
 export class KeybaseService {
@@ -20,6 +21,7 @@ export class KeybaseService {
     @Inject(forwardRef(() => ProviderService))
     private readonly providerService: ProviderService,
     private readonly assetsService: AssetsService,
+    private readonly apiConfigService: ApiConfigService,
   ) { }
 
   private async getDistinctIdentities(): Promise<string[]> {
@@ -139,9 +141,12 @@ export class KeybaseService {
       return null;
     }
 
+    const network = this.apiConfigService.getNetwork();
+    const folder = network === 'mainnet' ? '' : `/${network}`;
+
     return new KeybaseIdentity({
       identity,
-      avatar: `https://raw.githubusercontent.com/multiversx/mx-assets/master/identities/${identity}/logo.png`,
+      avatar: `https://raw.githubusercontent.com/multiversx/mx-assets/master${folder}/identities/${identity}/logo.png`,
       ...info,
     });
   }

--- a/src/endpoints/identities/identities.service.ts
+++ b/src/endpoints/identities/identities.service.ts
@@ -163,12 +163,13 @@ export class IdentitiesService {
 
     const identitiesDetailed: IdentityDetailed[] = [];
 
+    const keybaseIdentities = await this.cacheService.get<KeybaseIdentity[]>(CacheInfo.IdentityProfilesKeybases.key);
     for (const identity of distinctIdentities) {
       if (!identity) {
         continue;
       }
 
-      const keybaseIdentity = await this.cacheService.get<KeybaseIdentity>(CacheInfo.IdentityProfile(identity).key);
+      const keybaseIdentity = keybaseIdentities?.find(item => item.identity === identity);
       if (keybaseIdentity && keybaseIdentity.identity) {
         const identityDetailed = new IdentityDetailed();
         identityDetailed.avatar = keybaseIdentity.avatar;

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -104,13 +104,6 @@ export class CacheInfo {
     ttl: Constants.oneHour(),
   };
 
-  static IdentityProfile(key: string): CacheInfo {
-    return {
-      key: `identityProfile:${key}`,
-      ttl: Constants.oneMonth() * 6,
-    };
-  }
-
   static CurrentPrice: CacheInfo = {
     key: 'currentPrice',
     ttl: Constants.oneHour(),


### PR DESCRIPTION
## Proposed Changes
- network-specific avatar url
- store all identities under the same cache key to fix the issue of deleted identities still appearing

## How to test
- devnet or testnet-specific identities should reference in the `/identities` endpoint their corresponding avatars
- deleting a identity from assets should ensure that it's also deleted from the api
