### PR TITLE
Accounts token timestamp non mandatory for accounts endpoint swagger

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -277,6 +277,7 @@ export class AccountController {
   @UseInterceptors(DeepHistoryInterceptor)
   @ApiOkResponse({ type: TokenWithBalance })
   @ApiOperation({ summary: 'Account token details', description: 'Returns details about a specific fungible token from a given address' })
+  @ApiQuery({ name: 'timestamp', description: 'Retrieve entries from timestamp', required: false, type: Number })
   async getAccountToken(
     @Param('address', ParseAddressPipe) address: string,
     @Param('token', ParseTokenOrNftPipe) token: string,


### PR DESCRIPTION
## Reasoning
- Swagger API makes adding timestamp mandatory for accounts/:address/tokens/:token
  
## Proposed Changes
- Specify the swagger ApiQuery decorator to make it non-mandatory

## How to test
- check the swagger does not require it mandatory anymore
