### PR TITLE
add support for sender receiver scresults

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -550,7 +550,7 @@ export class ElasticIndexerHelper {
     return elasticQuery;
   }
 
-  public builResultsFilerQuery(filter: SmartContractResultFilter): ElasticQuery {
+  public builResultsFilterQuery(filter: SmartContractResultFilter): ElasticQuery {
     let elasticQuery = ElasticQuery.create();
 
     if (filter.miniBlockHash) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -15,6 +15,7 @@ import { TransactionFilter } from "src/endpoints/transactions/entities/transacti
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
+import { SmartContractResultFilter } from "src/endpoints/sc-results/entities/smart.contract.result.filter";
 
 @Injectable()
 export class ElasticIndexerHelper {
@@ -548,6 +549,37 @@ export class ElasticIndexerHelper {
 
     return elasticQuery;
   }
+
+  public builResultsFilerQuery(filter: SmartContractResultFilter): ElasticQuery {
+    let elasticQuery = ElasticQuery.create();
+
+    if (filter.miniBlockHash) {
+      elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlockHash', filter.miniBlockHash)]);
+    }
+
+    if (filter.originalTxHashes) {
+      elasticQuery = elasticQuery.withShouldCondition(filter.originalTxHashes.map(originalTxHash => QueryType.Match('originalTxHash', originalTxHash)));
+    }
+
+    if (filter.sender) {
+      elasticQuery = elasticQuery.withShouldCondition(QueryType.Match('sender', filter.sender));
+    }
+
+    if (filter.receiver) {
+      elasticQuery = elasticQuery.withShouldCondition(QueryType.Match('receiver', filter.receiver));
+    }
+
+    if (filter.functions && filter.functions.length > 0 && this.apiConfigService.getIsIndexerV3FlagActive()) {
+      if (filter.functions.length === 1 && filter.functions[0] === '') {
+        elasticQuery = elasticQuery.withMustNotExistCondition('function');
+      } else {
+        elasticQuery = this.applyFunctionFilter(elasticQuery, filter.functions);
+      }
+    }
+
+    return elasticQuery;
+  }
+
 
   public applyFunctionFilter(elasticQuery: ElasticQuery, functions: string[]) {
     const functionConditions = [];

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -43,7 +43,7 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResultsCount(filter: SmartContractResultFilter): Promise<number> {
-    const query = this.indexerHelper.builResultsFilerQuery(filter);
+    const query = this.indexerHelper.builResultsFilterQuery(filter);
     return await this.elasticService.getCount('scresults', query);
   }
 
@@ -351,7 +351,7 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResults(pagination: QueryPagination, filter: SmartContractResultFilter): Promise<any[]> {
-    const elasticQuery: ElasticQuery = this.indexerHelper.builResultsFilerQuery(filter)
+    const elasticQuery: ElasticQuery = this.indexerHelper.builResultsFilterQuery(filter)
       .withPagination(pagination);
 
     const results = await this.elasticService.getList('scresults', 'hash', elasticQuery);

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -350,25 +350,10 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResults(pagination: QueryPagination, filter: SmartContractResultFilter): Promise<any[]> {
-    let query = ElasticQuery.create().withPagination(pagination);
+    const elasticQuery: ElasticQuery = this.indexerHelper.builResultsFilerQuery(filter)
+      .withPagination(pagination);
 
-    if (filter.miniBlockHash) {
-      query = query.withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlockHash', filter.miniBlockHash)]);
-    }
-
-    if (filter.originalTxHashes) {
-      query = query.withShouldCondition(filter.originalTxHashes.map(originalTxHash => QueryType.Match('originalTxHash', originalTxHash)));
-    }
-
-    if (filter.sender) {
-      query = query.withShouldCondition(QueryType.Match('sender', filter.sender));
-    }
-
-    if (filter.receiver) {
-      query = query.withShouldCondition(QueryType.Match('receiver', filter.receiver));
-    }
-
-    const results = await this.elasticService.getList('scresults', 'hash', query);
+    const results = await this.elasticService.getList('scresults', 'hash', elasticQuery);
 
     for (const result of results) {
       this.processTransaction(result);

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -360,6 +360,14 @@ export class ElasticIndexerService implements IndexerInterface {
       query = query.withShouldCondition(filter.originalTxHashes.map(originalTxHash => QueryType.Match('originalTxHash', originalTxHash)));
     }
 
+    if (filter.sender) {
+      query = query.withShouldCondition(QueryType.Match('sender', filter.sender));
+    }
+
+    if (filter.receiver) {
+      query = query.withShouldCondition(QueryType.Match('receiver', filter.receiver));
+    }
+
     const results = await this.elasticService.getList('scresults', 'hash', query);
 
     for (const result of results) {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -42,8 +42,9 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getCount('accounts', query);
   }
 
-  async getScResultsCount(): Promise<number> {
-    return await this.elasticService.getCount('scresults');
+  async getScResultsCount(filter: SmartContractResultFilter): Promise<number> {
+    const query = this.indexerHelper.builResultsFilerQuery(filter);
+    return await this.elasticService.getCount('scresults', query);
   }
 
   async getAccountContractsCount(address: string): Promise<number> {

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -17,7 +17,7 @@ import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBl
 export interface IndexerInterface {
   getAccountsCount(filter: AccountQueryOptions): Promise<number>
 
-  getScResultsCount(): Promise<number>
+  getScResultsCount(filter: SmartContractResultFilter): Promise<number>
 
   getAccountContractsCount(address: string): Promise<number>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -31,8 +31,8 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getScResultsCount(): Promise<number> {
-    return await this.indexerInterface.getScResultsCount();
+  async getScResultsCount(filter: SmartContractResultFilter): Promise<number> {
+    return await this.indexerInterface.getScResultsCount(filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -78,7 +78,7 @@ export class PostgresIndexerService implements IndexerInterface {
     throw new Error("Method not implemented.");
   }
 
-  async getScResultsCount(): Promise<number> {
+  async getScResultsCount(_filter: SmartContractResultFilter): Promise<number> {
     return await this.scResultsRepository.count();
   }
 

--- a/src/crons/status.checker/status.checker.service.ts
+++ b/src/crons/status.checker/status.checker.service.ts
@@ -23,6 +23,7 @@ import { NodeType } from "src/endpoints/nodes/entities/node.type";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { StatusCheckerThresholds } from 'src/common/api-config/entities/status-checker-thresholds';
+import { SmartContractResultFilter } from 'src/endpoints/sc-results/entities/smart.contract.result.filter';
 
 @Injectable()
 export class StatusCheckerService {
@@ -96,7 +97,7 @@ export class StatusCheckerService {
   @Cron(CronExpression.EVERY_MINUTE)
   async handleResultsCount() {
     await Locker.lock('Status Checker: Results Count', async () => {
-      const count = await this.elasticIndexerService.getScResultsCount();
+      const count = await this.elasticIndexerService.getScResultsCount(new SmartContractResultFilter());
       MetricsService.setClusterComparisonValue('total_results', count);
     }, true);
   }

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -23,6 +23,7 @@ import { AccountQueryOptions } from '../accounts/entities/account.query.options'
 import { DataApiService } from 'src/common/data-api/data-api.service';
 import { FeatureConfigs } from './entities/feature.configs';
 import { IndexerService } from 'src/common/indexer/indexer.service';
+import { SmartContractResultFilter } from '../sc-results/entities/smart.contract.result.filter';
 
 @Injectable()
 export class NetworkService {
@@ -218,7 +219,7 @@ export class NetworkService {
       this.blockService.getBlocksCount(new BlockFilter()),
       this.accountService.getAccountsCount(new AccountQueryOptions()),
       this.transactionService.getTransactionCount(new TransactionFilter()),
-      this.smartContractResultService.getScResultsCount(),
+      this.smartContractResultService.getScResultsCount(new SmartContractResultFilter()),
     ]);
 
     const { erd_num_shards_without_meta: shards, erd_round_duration: refreshRate } = networkConfig;

--- a/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
@@ -5,4 +5,7 @@ export class SmartContractResultFilter {
 
   miniBlockHash?: string;
   originalTxHashes?: string[];
+  sender?: string;
+  receiver?: string;
+  function?: string[];
 }

--- a/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
@@ -7,5 +7,5 @@ export class SmartContractResultFilter {
   originalTxHashes?: string[];
   sender?: string;
   receiver?: string;
-  function?: string[];
+  functions?: string[];
 }

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -1,4 +1,4 @@
-import { ParseArrayPipe, ParseIntPipe, ParseBlockHashPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
+import { ParseArrayPipe, ParseIntPipe, ParseBlockHashPipe, ParseTransactionHashPipe, ParseAddressPipe } from "@multiversx/sdk-nestjs-common";
 import { Controller, DefaultValuePipe, Get, NotFoundException, Param, Query } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { SmartContractResult } from "./entities/smart.contract.result";
@@ -17,16 +17,20 @@ export class SmartContractResultController {
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'miniBlockHash', description: 'The hash of the parent miniBlock', required: false })
   @ApiQuery({ name: 'originalTxHashes', description: 'Original transaction hashes', required: false })
+  @ApiQuery({ name: 'sender', description: 'Sender address', required: false })
+  @ApiQuery({ name: 'receiver', description: 'Receiver address', required: false })
   @ApiOkResponse({ type: [SmartContractResult] })
   getScResults(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
     @Query('originalTxHashes', ParseArrayPipe, ParseTransactionHashPipe) originalTxHashes?: string[],
+    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('receiver', ParseAddressPipe) receiver?: string,
   ): Promise<SmartContractResult[]> {
     return this.scResultService.getScResults(
       new QueryPagination({ from, size }),
-      new SmartContractResultFilter({ miniBlockHash, originalTxHashes }));
+      new SmartContractResultFilter({ miniBlockHash, originalTxHashes, sender, receiver }));
   }
 
   @Get("/results/count")

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -39,8 +39,15 @@ export class SmartContractResultController {
   @Get("/results/count")
   @ApiOperation({ summary: 'Smart contracts count', description: 'Returns total number of smart contracts results' })
   @ApiOkResponse({ type: Number })
-  getScResultsCount(): Promise<number> {
-    return this.scResultService.getScResultsCount();
+  @ApiQuery({ name: 'sender', description: 'Sender address', required: false })
+  @ApiQuery({ name: 'receiver', description: 'Receiver address', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter results by function name', required: false })
+  getScResultsCount(
+    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('receiver', ParseAddressPipe) receiver?: string,
+    @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
+  ): Promise<number> {
+    return this.scResultService.getScResultsCount(new SmartContractResultFilter({ sender, receiver, functions }));
   }
 
   @Get("/results/:scHash")

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -5,6 +5,7 @@ import { SmartContractResult } from "./entities/smart.contract.result";
 import { SmartContractResultService } from "./scresult.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { SmartContractResultFilter } from "./entities/smart.contract.result.filter";
+import { ParseArrayPipeOptions } from "@multiversx/sdk-nestjs-common/lib/pipes/entities/parse.array.options";
 
 @Controller()
 @ApiTags('results')
@@ -19,6 +20,7 @@ export class SmartContractResultController {
   @ApiQuery({ name: 'originalTxHashes', description: 'Original transaction hashes', required: false })
   @ApiQuery({ name: 'sender', description: 'Sender address', required: false })
   @ApiQuery({ name: 'receiver', description: 'Receiver address', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter results by function name', required: false })
   @ApiOkResponse({ type: [SmartContractResult] })
   getScResults(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -27,10 +29,11 @@ export class SmartContractResultController {
     @Query('originalTxHashes', ParseArrayPipe, ParseTransactionHashPipe) originalTxHashes?: string[],
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
+    @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
   ): Promise<SmartContractResult[]> {
     return this.scResultService.getScResults(
       new QueryPagination({ from, size }),
-      new SmartContractResultFilter({ miniBlockHash, originalTxHashes, sender, receiver }));
+      new SmartContractResultFilter({ miniBlockHash, originalTxHashes, sender, receiver, functions }));
   }
 
   @Get("/results/count")

--- a/src/endpoints/sc-results/scresult.service.ts
+++ b/src/endpoints/sc-results/scresult.service.ts
@@ -52,8 +52,8 @@ export class SmartContractResultService {
     return smartContractResult;
   }
 
-  async getScResultsCount(): Promise<number> {
-    return await this.indexerService.getScResultsCount();
+  async getScResultsCount(filter: SmartContractResultFilter): Promise<number> {
+    return await this.indexerService.getScResultsCount(filter);
   }
 
   async getAccountScResults(address: string, pagination: QueryPagination): Promise<SmartContractResult[]> {

--- a/src/graphql/entities/smart.contract.result/smart.contract.result.query.ts
+++ b/src/graphql/entities/smart.contract.result/smart.contract.result.query.ts
@@ -26,7 +26,7 @@ export class SmartContractResultQuery {
 
   @Query(() => Float, { name: "resultsCount", description: "Returns total number of smart contracts." })
   public async getScResultsCount(): Promise<number> {
-    return await this.smartContractResultService.getScResultsCount();
+    return await this.smartContractResultService.getScResultsCount(new SmartContractResultFilter());
   }
 
   @Query(() => SmartContractResult, { name: "result", description: "Retrieve the smart contract details for the given input.", nullable: true })

--- a/src/test/unit/services/scresults.spec.ts
+++ b/src/test/unit/services/scresults.spec.ts
@@ -3,6 +3,7 @@ import { AssetsService } from "src/common/assets/assets.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { SmartContractResult } from "src/endpoints/sc-results/entities/smart.contract.result";
+import { SmartContractResultFilter } from "src/endpoints/sc-results/entities/smart.contract.result.filter";
 import { SmartContractResultService } from "src/endpoints/sc-results/scresult.service";
 import { TransactionActionService } from "src/endpoints/transactions/transaction-action/transaction.action.service";
 
@@ -66,7 +67,7 @@ describe('TagService', () => {
     it('should return total smart contracts count', async () => {
       jest.spyOn(indexerService, 'getScResultsCount').mockResolvedValue(10000);
 
-      const result = await service.getScResultsCount();
+      const result = await service.getScResultsCount(new SmartContractResultFilter);
 
       expect(result).toStrictEqual(10000);
       expect(indexerService.getScResultsCount).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Reasoning
- to be able to sort sc-results after sender or receiver we need to add specific filters 
- also, adding support for functions filter to be able to return all sc results for a specific function
- also, adding support for results count filters
  
## Proposed Changes
- Add `sender` and `receiver` filters 
- Add `functions` filter of type array
- Add `sender`, `receiver`, `functions` count filters

## How to test ( Mainnet )
- `/results?sender=erd1qqqqqqqqqqqqqpgqjq0h2hy6ppj5yze2t3gr6kadvaahkljch77qynjfg8` -> should return all scresults where sender is `erd1qqqqqqqqqqqqqpgqjq0h2hy6ppj5yze2t3gr6kadvaahkljch77qynjfg8`
- `/results?receiver= erd132v69stv7kc3t6xpdz6upn5w9v400ekka8hc0cjz06250jcjd8zq9gcjs8 ` -> should return all scresults where receiver is `erd132v69stv7kc3t6xpdz6upn5w9v400ekka8hc0cjz06250jcjd8zq9gcjs8 `
- `/results?functions=register` -> should return all register results 
- `/results/count?sender=erd1qqqqqqqqqqqqqpgqjq0h2hy6ppj5yze2t3gr6kadvaahkljch77qynjfg8` -> should return total sc results for a specific sender
- `/results/count?receiver=erd132v69stv7kc3t6xpdz6upn5w9v400ekka8hc0cjz06250jcjd8zq9gcjs8` -> should return total sc results for a specific receiver