### PR TITLE
make non mandatory with latest info field in swagger

### DIFF
--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -19,6 +19,7 @@ export class ProviderController {
   @ApiQuery({ name: 'owner', description: 'Search by owner', required: false })
   @ApiQuery({ name: 'providers', description: 'Search by multiple providers address', required: false })
   @ApiQuery({ name: 'withIdentityInfo', description: 'Returns identity data for providers', required: false })
+  @ApiQuery({ name: 'withLatestInfo', description: 'Returns providers details with latest info', required: false })
   async getProviders(
     @Query('identity') identity?: string,
     @Query('owner', ParseAddressPipe) owner?: string,


### PR DESCRIPTION
## Reasoning
- Swagger API makes adding `withLatestInfo` filter mandatory for `/providers`

  
## Proposed Changes
- specify the swagger ApiQuery decorator to make it non-mandatory


## How to test
- check the swagger does not require it mandatory anymore
