### PR TITLE
Support for custom api version for about endpoint

### DIFF
--- a/src/endpoints/network/entities/about.ts
+++ b/src/endpoints/network/entities/about.ts
@@ -9,8 +9,8 @@ export class About {
   }
 
   @Field(() => String, { description: "Application Version details." })
-  @ApiProperty({ type: String })
-  appVersion: string = '';
+  @ApiProperty({ type: String, nullable: true })
+  appVersion: string | undefined = undefined;
 
   @Field(() => String, { description: "Plugins Version details." })
   @ApiProperty({ type: String, nullable: true })

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -297,30 +297,36 @@ export class NetworkService {
   }
 
   async getAboutRaw(): Promise<About> {
-    const appVersion = require('child_process')
-      .execSync('git rev-parse HEAD')
-      .toString().trim();
+    let appVersion: string | undefined = undefined;
+    let pluginsVersion: string | undefined = undefined;
 
-    let pluginsVersion = require('child_process')
-      .execSync('git rev-parse HEAD', { cwd: 'src/plugins' })
-      .toString().trim();
+    let apiVersion = process.env['API_VERSION'];
+    if (!apiVersion) {
+      apiVersion = require('child_process')
+        .execSync('git tag --points-at HEAD')
+        .toString().trim();
 
-    let apiVersion = require('child_process')
-      .execSync('git tag --points-at HEAD')
-      .toString().trim();
+      if (!apiVersion) {
+        apiVersion = require('child_process')
+          .execSync('git describe --tags --abbrev=0')
+          .toString().trim();
+
+        if (apiVersion) {
+          apiVersion = apiVersion + '-next';
+        }
+      }
+
+      appVersion = require('child_process')
+        .execSync('git rev-parse HEAD')
+        .toString().trim();
+
+      pluginsVersion = require('child_process')
+        .execSync('git rev-parse HEAD', { cwd: 'src/plugins' })
+        .toString().trim();
+    }
 
     if (pluginsVersion === appVersion) {
       pluginsVersion = undefined;
-    }
-
-    if (!apiVersion) {
-      apiVersion = require('child_process')
-        .execSync('git describe --tags --abbrev=0')
-        .toString().trim();
-
-      if (apiVersion) {
-        apiVersion = apiVersion + '-next';
-      }
     }
 
     const features = new FeatureConfigs({


### PR DESCRIPTION
## Reasoning
- External api providers maybe don't have git installed or start the service from a private repository where the application / plugins commit hash is not relevant, in which case a custom version can be read from the environment variables
  
## Proposed Changes
- support for returning api version from a custom environment variable
- if the git commands somehow fail, still return the other relevant information

## How to test
- when starting the service with `API_VERSION` environment variable, it should be reflected in the `/about` endpoint
