### PR TITLE
GraphQL requests with timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "mongodb": "^3.6.4",
         "mysql2": "^2.3.3",
         "nest-winston": "^1.6.2",
+        "node-fetch": "^2.6.7",
         "node-object-hash": "^2.3.10",
         "pg": "^8.7.3",
         "prom-client": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "mongodb": "^3.6.4",
     "mysql2": "^2.3.3",
     "nest-winston": "^1.6.2",
+    "node-fetch": "^2.6.7",
     "node-object-hash": "^2.3.10",
     "pg": "^8.7.3",
     "prom-client": "^14.0.1",

--- a/src/common/graphql/graphql.service.ts
+++ b/src/common/graphql/graphql.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "../api-config/api.config.service";
 import { GraphQLClient } from 'graphql-request';
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
+import fetch, { RequestInit } from 'node-fetch';
 
 @Injectable()
 export class GraphQlService {
@@ -11,9 +12,9 @@ export class GraphQlService {
     private readonly apiConfigService: ApiConfigService
   ) { }
 
-  async getData(query: string, variables?: any): Promise<any> {
-    const MAIAR_EXCHANGE_URL = this.apiConfigService.getExchangeServiceUrlMandatory();
-    const graphqlClient = new GraphQLClient(MAIAR_EXCHANGE_URL, {
+  async getExchangeServiceData(query: string, variables?: any): Promise<any> {
+    const exchangeServiceUrl = this.apiConfigService.getExchangeServiceUrlMandatory();
+    const graphqlClient = new GraphQLClient(exchangeServiceUrl, {
       fetch: this.createFetchWithTimeout(60_000),
     });
 
@@ -36,9 +37,8 @@ export class GraphQlService {
   }
 
   async getNftServiceData(query: string, variables: any): Promise<any> {
-    const NFT_MARKETPLACE_URL = this.apiConfigService.getMarketplaceServiceUrl();
-
-    const graphqlClient = new GraphQLClient(NFT_MARKETPLACE_URL, {
+    const nftMarketplaceUrl = this.apiConfigService.getMarketplaceServiceUrl();
+    const graphqlClient = new GraphQLClient(nftMarketplaceUrl, {
       fetch: this.createFetchWithTimeout(60_0000),
     });
 

--- a/src/common/graphql/graphql.service.ts
+++ b/src/common/graphql/graphql.service.ts
@@ -13,7 +13,9 @@ export class GraphQlService {
 
   async getData(query: string, variables?: any): Promise<any> {
     const MAIAR_EXCHANGE_URL = this.apiConfigService.getExchangeServiceUrlMandatory();
-    const graphqlClient = new GraphQLClient(MAIAR_EXCHANGE_URL);
+    const graphqlClient = new GraphQLClient(MAIAR_EXCHANGE_URL, {
+      fetch: this.createFetchWithTimeout(60_000),
+    });
 
     try {
       const data = variables
@@ -36,7 +38,9 @@ export class GraphQlService {
   async getNftServiceData(query: string, variables: any): Promise<any> {
     const NFT_MARKETPLACE_URL = this.apiConfigService.getMarketplaceServiceUrl();
 
-    const graphqlClient = new GraphQLClient(NFT_MARKETPLACE_URL);
+    const graphqlClient = new GraphQLClient(NFT_MARKETPLACE_URL, {
+      fetch: this.createFetchWithTimeout(60_0000),
+    });
 
     try {
       const data = await graphqlClient.request(query, variables);
@@ -52,5 +56,15 @@ export class GraphQlService {
 
       return null;
     }
+  }
+
+  private createFetchWithTimeout(timeout: number) {
+    return (url: string, init?: RequestInit) => {
+      const controller = new AbortController();
+      const id = setTimeout(() => controller.abort(), timeout);
+      const initWithSignal = { ...init, signal: controller.signal };
+
+      return fetch(url, initWithSignal).finally(() => clearTimeout(id));
+    };
   }
 }

--- a/src/endpoints/mex/mex.economics.service.ts
+++ b/src/endpoints/mex/mex.economics.service.ts
@@ -50,7 +50,7 @@ export class MexEconomicsService {
       }
     `;
 
-    const response: any = await this.graphQlService.getData(query, variables);
+    const response: any = await this.graphQlService.getExchangeServiceData(query, variables);
     if (!response) {
       throw new BadRequestException('Could not fetch MEX economics data from MEX microservice');
     }

--- a/src/endpoints/mex/mex.farm.service.ts
+++ b/src/endpoints/mex/mex.farm.service.ts
@@ -150,7 +150,7 @@ export class MexFarmService {
       }
     `;
 
-    const response: any = await this.graphQlService.getData(query, {});
+    const response: any = await this.graphQlService.getExchangeServiceData(query, {});
     if (!response) {
       return [];
     }
@@ -189,7 +189,7 @@ export class MexFarmService {
         }
       }`;
 
-    const response: any = await this.graphQlService.getData(query, {});
+    const response: any = await this.graphQlService.getExchangeServiceData(query, {});
     if (!response) {
       return [];
     }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -77,7 +77,7 @@ export class MexPairService {
         }
       }`;
 
-      const pairsLimitResult: any = await this.graphQlService.getData(pairsLimit);
+      const pairsLimitResult: any = await this.graphQlService.getExchangeServiceData(pairsLimit);
       const totalPairs = pairsLimitResult?.factory?.pairCount;
 
       const variables = {
@@ -128,7 +128,7 @@ export class MexPairService {
         }
       `;
 
-      const result: any = await this.graphQlService.getData(query, variables);
+      const result: any = await this.graphQlService.getExchangeServiceData(query, variables);
       if (!result) {
         return [];
       }

--- a/src/endpoints/mex/mex.settings.service.ts
+++ b/src/endpoints/mex/mex.settings.service.ts
@@ -154,7 +154,7 @@ export class MexSettingsService {
     }
     `;
 
-    const response = await this.graphQlService.getData(query, variables);
+    const response = await this.graphQlService.getExchangeServiceData(query, variables);
     if (!response) {
       return null;
     }

--- a/src/test/unit/services/graphql.service.spec.ts
+++ b/src/test/unit/services/graphql.service.spec.ts
@@ -36,7 +36,7 @@ describe('GraphQlService', () => {
     it('should return data if the request is successful', async () => {
       const mockData = { key: 'value' };
       jest.spyOn(mockGraphQLClient, 'request').mockResolvedValueOnce(mockData);
-      const result = await service.getData('query', {});
+      const result = await service.getExchangeServiceData('query', {});
       expect(result).toStrictEqual(mockData);
     });
 
@@ -45,7 +45,7 @@ describe('GraphQlService', () => {
       jest.spyOn(service['logger'], 'error').mockImplementation(() =>
         "Unexpected error when running graphql query");
 
-      const result = await service.getData('query', {});
+      const result = await service.getExchangeServiceData('query', {});
       expect(result).toBeNull();
     });
   });


### PR DESCRIPTION
## Reasoning
- in some situations, graphql requests can have timeouts and the graphql-request library waits forever for the response to come
  
## Proposed Changes
- implement a custom fetch function in the graphql service to have a reasonable timeout (60 seconds)

## How to test
- replace the exchange / nft marketplace url with a bigger timeout than 60 seconds (e.g. https://httpbin.org/delay/90) and make sure the user aborted error occurs after 60 seconds without having to wait for the full 90 seconds
