### PR TITLE
add lowLiquidityThresholdPercent property

### DIFF
--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -155,11 +155,11 @@ export class Token {
   @ApiProperty({ type: Number, nullable: true })
   totalVolume24h: number | undefined = undefined;
 
-  @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
+  @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   isLowLiquidity: boolean | undefined = undefined;
 
-  @Field(() => Number, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .', nullable: true })
+  @Field(() => Number, { description: 'If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity and display threshold percent .', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   lowLiquidityThresholdPercent: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -158,4 +158,8 @@ export class Token {
   @Field(() => Boolean, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   isLowLiquidity: boolean | undefined = undefined;
+
+  @Field(() => Number, { description: 'If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  lowLiquidityThresholdPercent: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -947,8 +947,9 @@ export class TokenService {
             token.price = price.price;
             token.marketCap = price.price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
 
-            if (token.totalLiquidity && token.marketCap && token.totalLiquidity / token.marketCap < LOW_LIQUIDITY_THRESHOLD) {
+            if (token.totalLiquidity && token.marketCap && (token.totalLiquidity / token.marketCap < LOW_LIQUIDITY_THRESHOLD)) {
               token.isLowLiquidity = true;
+              token.lowLiquidityThresholdPercent = LOW_LIQUIDITY_THRESHOLD * 100;
             }
           }
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3653,6 +3653,11 @@ type TokenDetailed {
   """Token isPause property."""
   isPaused: Boolean!
 
+  """
+  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .
+  """
+  lowLiquidityThresholdPercent: Float
+
   """Current market cap details."""
   marketCap: Float
 
@@ -3857,6 +3862,11 @@ type TokenWithBalanceAccountFlat {
 
   """Token isPause property."""
   isPaused: Boolean!
+
+  """
+  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .
+  """
+  lowLiquidityThresholdPercent: Float
 
   """Current market cap details."""
   marketCap: Float

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -3646,7 +3646,7 @@ type TokenDetailed {
   initialMinted: String!
 
   """
-  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.
+  If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity.
   """
   isLowLiquidity: Boolean
 
@@ -3654,7 +3654,7 @@ type TokenDetailed {
   isPaused: Boolean!
 
   """
-  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .
+  If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity and display threshold percent .
   """
   lowLiquidityThresholdPercent: Float
 
@@ -3856,7 +3856,7 @@ type TokenWithBalanceAccountFlat {
   initialMinted: String!
 
   """
-  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity.
+  If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity.
   """
   isLowLiquidity: Boolean
 
@@ -3864,7 +3864,7 @@ type TokenWithBalanceAccountFlat {
   isPaused: Boolean!
 
   """
-  If the liquidity to market cap ratio is less than 1%, we consider it as low liquidity and display threshold percent .
+  If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity and display threshold percent .
   """
   lowLiquidityThresholdPercent: Float
 


### PR DESCRIPTION
## Reasoning
- Need to ensure fixed display value for liquidity conditions
- Simplify the codebase for easier maintenance and readability
- Improve predictability in UI behavior regarding liquidity thresholds
  
## Proposed Changes
- Set `lowLiquidityThresholdPercent` to a fixed value of `0.5%` for tokens classified as having low liquidity.

## How to test
- `tokens/SHARD-99a172` -> `lowLiquidityThresholdPercent` should be defined with value 0.5
- `tokens` -> search for `lowLiquidityThresholdPercent` and check if specific tokens contains `lowLiquidityThresholdPercent`