### PR TITLE
add provider delegators

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -435,6 +435,13 @@ export class ElasticIndexerService implements IndexerInterface {
 
     return await this.elasticService.getList('delegators', "contract", elasticQuery);
   }
+
+  async getProviderDelegatorsCount(address: string): Promise<number> {
+    const elasticQuery: ElasticQuery = ElasticQuery.create()
+      .withCondition(QueryConditionOptions.must, [QueryType.Match("contract", address)]);
+
+    return await this.elasticService.getCount('delegators', elasticQuery);
+  }
   async getAccountHistory(address: string, pagination: QueryPagination, filter?: AccountHistoryFilter): Promise<any[]> {
     const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter)
       .withPagination(pagination)

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -433,7 +433,7 @@ export class ElasticIndexerService implements IndexerInterface {
       .withCondition(QueryConditionOptions.must, [QueryType.Match("contract", address)])
       .withSort([{ name: 'activeStake', order: ElasticSortOrder.descending }]);
 
-    return await this.elasticService.getList('delegators', "contract", elasticQuery);
+    return await this.elasticService.getList("delegators", "contract", elasticQuery);
   }
 
   async getProviderDelegatorsCount(address: string): Promise<number> {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -427,6 +427,14 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('scdeploys', "contract", elasticQuery);
   }
 
+  async getProviderDelegators(address: string, pagination: QueryPagination): Promise<any[]> {
+    const elasticQuery: ElasticQuery = ElasticQuery.create()
+      .withPagination(pagination)
+      .withCondition(QueryConditionOptions.must, [QueryType.Match("contract", address)])
+      .withSort([{ name: 'activeStake', order: ElasticSortOrder.descending }]);
+
+    return await this.elasticService.getList('delegators', "contract", elasticQuery);
+  }
   async getAccountHistory(address: string, pagination: QueryPagination, filter?: AccountHistoryFilter): Promise<any[]> {
     const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter)
       .withPagination(pagination)

--- a/src/common/indexer/entities/provider.delegators.ts
+++ b/src/common/indexer/entities/provider.delegators.ts
@@ -1,0 +1,7 @@
+export class ProviderDelegators {
+  contract: string = '';
+  address: string = '';
+  activeStake: string = '';
+  activeStakeNum: number = 0;
+  timestamp: number = 0;
+}

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -108,6 +108,8 @@ export interface IndexerInterface {
 
   getProviderDelegators(address: string, pagination: QueryPagination): Promise<ProviderDelegators[]>
 
+  getProviderDelegatorsCount(address: string): Promise<number>
+
   getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number>
 
   getAccountTokenHistoryCount(address: string, tokenIdentifier: string, filter?: AccountHistoryFilter): Promise<number>

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -13,6 +13,7 @@ import { TransactionFilter } from "src/endpoints/transactions/entities/transacti
 import { TokenAssets } from "../assets/entities/token.assets";
 import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
+import { ProviderDelegators } from "./entities/provider.delegators";
 
 export interface IndexerInterface {
   getAccountsCount(filter: AccountQueryOptions): Promise<number>
@@ -104,6 +105,8 @@ export interface IndexerInterface {
   getAccountContracts(pagination: QueryPagination, address: string): Promise<ScDeploy[]>
 
   getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]>
+
+  getProviderDelegators(address: string, pagination: QueryPagination): Promise<ProviderDelegators[]>
 
   getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -243,6 +243,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getProviderDelegatorsCount(address: string): Promise<number> {
+    return await this.indexerInterface.getProviderDelegatorsCount(address);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number> {
     return await this.indexerInterface.getAccountHistoryCount(address, filter);
   }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -17,6 +17,7 @@ import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.filter";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
+import { ProviderDelegators } from "./entities/provider.delegators";
 
 @Injectable()
 export class IndexerService implements IndexerInterface {
@@ -234,6 +235,11 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]> {
     return await this.indexerInterface.getAccountHistory(address, pagination, filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getProviderDelegators(address: string, pagination: QueryPagination): Promise<ProviderDelegators[]> {
+    return await this.indexerInterface.getProviderDelegators(address, pagination);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -51,6 +51,9 @@ export class PostgresIndexerService implements IndexerInterface {
     private readonly validatorPublicKeysRepository: Repository<ValidatorPublicKeysDb>,
     private readonly indexerHelper: PostgresIndexerHelper,
   ) { }
+  getProviderDelegatorsCount(_address: string): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
 
   getProviderDelegators(_address: string, _pagination: QueryPagination): Promise<ProviderDelegators[]> {
     throw new Error("Method not implemented.");

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -18,6 +18,7 @@ import { Collection, ScResult, Account, MiniBlock, Tag, TokenType, Block } from 
 import { IndexerInterface } from "../indexer.interface";
 import { AccountDb, AccountsEsdtDb, BlockDb, LogDb, MiniBlockDb, ReceiptDb, RoundInfoDb, ScDeployInfoDb, ScResultDb, TagDb, TokenInfoDb, TransactionDb, ValidatorPublicKeysDb } from "./entities";
 import { PostgresIndexerHelper } from "./postgres.indexer.helper";
+import { ProviderDelegators } from "../entities/provider.delegators";
 
 @Injectable()
 export class PostgresIndexerService implements IndexerInterface {
@@ -50,6 +51,10 @@ export class PostgresIndexerService implements IndexerInterface {
     private readonly validatorPublicKeysRepository: Repository<ValidatorPublicKeysDb>,
     private readonly indexerHelper: PostgresIndexerHelper,
   ) { }
+
+  getProviderDelegators(_address: string, _pagination: QueryPagination): Promise<ProviderDelegators[]> {
+    throw new Error("Method not implemented.");
+  }
   getVersion(): Promise<string | undefined> {
     throw new Error("Method not implemented.");
   }

--- a/src/endpoints/providers/entities/provider.accounts.ts
+++ b/src/endpoints/providers/entities/provider.accounts.ts
@@ -1,0 +1,16 @@
+import { Field } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ProviderAccounts {
+  constructor(init?: Partial<ProviderAccounts>) {
+    Object.assign(this, init);
+  }
+
+  @Field(() => String, { description: 'Address details.' })
+  @ApiProperty({ type: String, nullable: true, example: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz' })
+  address: string = '';
+
+  @Field(() => String, { description: 'Stake details.' })
+  @ApiProperty({ type: String, nullable: true, example: '9999109666430000000' })
+  stake: string = '';
+}

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpException, HttpStatus, Param, Query, Res } from "@nestjs/common";
+import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, ParseIntPipe, Query, Res } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { ProviderService } from "./provider.service";
 import { Provider } from "./entities/provider";
@@ -6,6 +6,8 @@ import { ParseAddressArrayPipe, ParseAddressPipe, ParseBoolPipe } from "@multive
 import { ProviderFilter } from "./entities/provider.filter";
 import { Response } from "express";
 import { ProviderQueryOptions } from "./entities/provider.query.options";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { ProviderAccounts } from "./entities/provider.accounts";
 
 @Controller()
 @ApiTags('providers')
@@ -31,6 +33,25 @@ export class ProviderController {
 
     return await this.providerService.getProviders(
       new ProviderFilter({ identity, providers, owner }), options);
+  }
+
+  @Get('/providers/:address/accounts')
+  @ApiOperation({ summary: 'Provider', description: 'Returns provider delegators for a given address' })
+  @ApiOkResponse({ type: Provider })
+  @ApiNotFoundResponse({ description: 'Provider not found' })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  async getProviderAccounts(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,): Promise<ProviderAccounts[]> {
+    const provider = await this.providerService.getProviderAccounts(address, new QueryPagination({ from, size }));
+
+    if (provider === undefined) {
+      throw new HttpException(`Provider '${address}' not found`, HttpStatus.NOT_FOUND);
+    }
+
+    return provider;
   }
 
   @Get('/providers/:address')

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -54,6 +54,19 @@ export class ProviderController {
     return provider;
   }
 
+  @Get('/providers/:address/accounts/count')
+  @ApiOperation({ summary: 'Provider', description: 'Returns provider total delegators' })
+  @ApiOkResponse({ type: Provider })
+  @ApiNotFoundResponse({ description: 'Provider not found' })
+  async getProviderAccountsCount(@Param('address', ParseAddressPipe) address: string): Promise<number> {
+    const provider = await this.providerService.getProviderAccountsCount(address);
+    if (provider === undefined) {
+      throw new HttpException(`Provider '${address}' not found`, HttpStatus.NOT_FOUND);
+    }
+
+    return provider;
+  }
+
   @Get('/providers/:address')
   @ApiOperation({ summary: 'Provider', description: 'Returns provider details for a given address' })
   @ApiOkResponse({ type: Provider })

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -36,7 +36,7 @@ export class ProviderController {
   }
 
   @Get('/providers/:address/accounts')
-  @ApiOperation({ summary: 'Provider', description: 'Returns provider delegators for a given address' })
+  @ApiOperation({ summary: 'Provider', description: 'Returns provider delegators accounts for a given provider address' })
   @ApiOkResponse({ type: Provider })
   @ApiNotFoundResponse({ description: 'Provider not found' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
@@ -55,7 +55,7 @@ export class ProviderController {
   }
 
   @Get('/providers/:address/accounts/count')
-  @ApiOperation({ summary: 'Provider', description: 'Returns provider total delegators' })
+  @ApiOperation({ summary: 'Provider', description: 'Returns provider total number of delegators' })
   @ApiOkResponse({ type: Provider })
   @ApiNotFoundResponse({ description: 'Provider not found' })
   async getProviderAccountsCount(@Param('address', ParseAddressPipe) address: string): Promise<number> {

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -9,11 +9,14 @@ import { CacheInfo } from "src/utils/cache.info";
 import { ProviderFilter } from "./entities/provider.filter";
 import { Provider } from "./entities/provider";
 import { AddressUtils, BinaryUtils, Constants } from "@multiversx/sdk-nestjs-common";
-import { ApiService } from "@multiversx/sdk-nestjs-http";
+import { ApiService, ApiUtils } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { IdentitiesService } from "../identities/identities.service";
 import { ProviderQueryOptions } from "./entities/provider.query.options";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
+import { ProviderAccounts } from "./entities/provider.accounts";
 
 @Injectable()
 export class ProviderService {
@@ -27,7 +30,8 @@ export class ProviderService {
     private readonly nodeService: NodeService,
     private readonly apiService: ApiService,
     @Inject(forwardRef(() => IdentitiesService))
-    private readonly identitiesService: IdentitiesService
+    private readonly identitiesService: IdentitiesService,
+    private readonly elasticIndexerService: ElasticIndexerService
   ) { }
 
   async getProvider(address: string): Promise<Provider | undefined> {
@@ -454,6 +458,18 @@ export class ProviderService {
     }
 
     return null;
+  }
+
+  async getProviderAccounts(address: string, queryPagination: QueryPagination): Promise<ProviderAccounts[]> {
+    const elasticResults = await this.elasticIndexerService.getProviderDelegators(address, queryPagination);
+    if (!elasticResults) {
+      return [];
+    }
+
+    return elasticResults.map(account => ApiUtils.mergeObjects(new ProviderAccounts(), {
+      address: account.address,
+      stake: account.activeStake,
+    }));
   }
 
   async getFilteredProviders(filter: ProviderFilter): Promise<Provider[]> {

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -472,6 +472,10 @@ export class ProviderService {
     }));
   }
 
+  async getProviderAccountsCount(address: string): Promise<number> {
+    return await this.elasticIndexerService.getProviderDelegatorsCount(address);
+  }
+
   async getFilteredProviders(filter: ProviderFilter): Promise<Provider[]> {
     let providers = await this.getProvidersWithStakeInformation();
 

--- a/src/test/unit/services/providers.spec.ts
+++ b/src/test/unit/services/providers.spec.ts
@@ -65,6 +65,7 @@ describe('ProviderService', () => {
           provide: ElasticIndexerService,
           useValue: {
             getProviderDelegators: jest.fn(),
+            getProviderDelegatorsCount: jest.fn(),
           },
         },
       ],
@@ -241,6 +242,18 @@ describe('ProviderService', () => {
 
       expect(elasticIndexerService.getProviderDelegators).toHaveBeenCalled();
       expect(results).toStrictEqual([]);
+    });
+  });
+
+  describe('getProviderAccountsCount', () => {
+    it('should return total delegators count for a given provider', async () => {
+      const contract = 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu';
+      jest.spyOn(elasticIndexerService, 'getProviderDelegatorsCount').mockResolvedValue(100);
+
+      const results = await service.getProviderAccountsCount(contract);
+
+      expect(elasticIndexerService.getProviderDelegatorsCount).toHaveBeenCalled();
+      expect(results).toStrictEqual(100);
     });
   });
 });

--- a/src/test/unit/services/providers.spec.ts
+++ b/src/test/unit/services/providers.spec.ts
@@ -2,6 +2,8 @@ import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { ApiService } from "@multiversx/sdk-nestjs-http";
 import { Test } from "@nestjs/testing";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
 import { IdentitiesService } from "src/endpoints/identities/identities.service";
 import { NodeService } from "src/endpoints/nodes/node.service";
 import { ProviderService } from "src/endpoints/providers/provider.service";
@@ -11,6 +13,7 @@ describe('ProviderService', () => {
   let service: ProviderService;
   let vmQuery: VmQueryService;
   let apiService: ApiService;
+  let elasticIndexerService: ElasticIndexerService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -58,12 +61,19 @@ describe('ProviderService', () => {
             getIdentity: jest.fn(),
           },
         },
+        {
+          provide: ElasticIndexerService,
+          useValue: {
+            getProviderDelegators: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = moduleRef.get<ProviderService>(ProviderService);
     vmQuery = moduleRef.get<VmQueryService>(VmQueryService);
     apiService = moduleRef.get<ApiService>(ApiService);
+    elasticIndexerService = moduleRef.get<ElasticIndexerService>(ElasticIndexerService);
   });
 
   it('service should be defined', () => {
@@ -207,4 +217,58 @@ describe('ProviderService', () => {
       expect(results).toEqual([]);
     });
   });
+
+  describe('getProviderAccounts', () => {
+    it('should return a list of delegators for a given provider', async () => {
+      const contract = 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu';
+      const elasticProviderDelegatorsMock = createElasticMockDelegators(25, contract);
+      jest.spyOn(elasticIndexerService, 'getProviderDelegators').mockResolvedValue(elasticProviderDelegatorsMock);
+
+      const results = await service.getProviderAccounts(contract, new QueryPagination({}));
+      expect(elasticIndexerService.getProviderDelegators).toHaveBeenCalled();
+
+      for (const result of results) {
+        expect(result.address).toBeDefined();
+        expect(result.stake).toBeDefined();
+      }
+    });
+
+    it('should return [] if no delegators are available from elastic from given contract address', async () => {
+      const contract = 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrhlllls062tu4';
+      jest.spyOn(elasticIndexerService, 'getProviderDelegators').mockResolvedValue([]);
+
+      const results = await service.getProviderAccounts(contract, new QueryPagination());
+
+      expect(elasticIndexerService.getProviderDelegators).toHaveBeenCalled();
+      expect(results).toStrictEqual([]);
+    });
+  });
 });
+
+function createElasticMockDelegators(numberOfAccounts: number, contract: string | null) {
+  return Array.from({ length: numberOfAccounts }, (_, index) => {
+
+    return {
+      contract: contract || generateMockAddress(),
+      address: generateMockAddress(),
+      activeStake: generateRandomBalance(),
+      activeStakeNum: generateRandomBalance(),
+      timestamp: Math.floor(Date.now() / 1000) - index * 1000,
+    };
+  });
+}
+
+function generateRandomBalance() {
+  return (Math.floor(Math.random() * 1000000) + 100000).toString();
+}
+
+function generateMockAddress() {
+  const desiredLength = 62 - 'erd1'.length;
+  let address = 'erd1';
+
+  while (address.length < desiredLength + 'erd1'.length) {
+    address += Math.random().toString(36).substring(2);
+  }
+
+  return address.substring(0, desiredLength + 'erd1'.length);
+}


### PR DESCRIPTION
  
## Proposed Changes
- Created a new query in `elastic search service` to be able to return for a given provider address all delegators ( `address`, `stake`) / delegators count
- Created a new method `getProviderDelegators` in `ProviderService` to be able to retrieve all informations from elastic
- Created a new controller `providers/:contractAddress/accounts` that contains also `query pagination` filter
- Added new unit tests for `getProviderDelegators` method

## How to test
- `providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu/accounts` -> return a list of 25 delegators
- `providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu/accounts?size=1` -> return a list of 1 delegator
- `providers/erd1eztdqz4cvs23w65a50d2h2g7xer5kyjy9w33pmkrrwy0usn46u6qcryt7g/accounts` -> should return [ ]
- `providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc0llllsayxegu/accounts/count` -> return total delegators count