### PR TITLE
add extra pair fields hasFarms hasDualFarms tradesCount

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from "@nestjs/graphql";
+import { Field, Float, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { MexPairState } from "./mex.pair.state";
 import { MexPairType } from "./mex.pair.type";
@@ -89,4 +89,16 @@ export class MexPair {
   @Field(() => String, { description: "Mex pair exchange details.", nullable: true })
   @ApiProperty({ type: String, example: 'jungledex' })
   exchange: MexPairExchange | undefined;
+
+  @Field(() => Boolean, { description: "Has farm pair details.", nullable: true })
+  @ApiProperty({ type: Boolean, example: false })
+  hasFarms: boolean | undefined;
+
+  @Field(() => Boolean, { description: "Has dual farm pair details.", nullable: true })
+  @ApiProperty({ type: Boolean, example: false })
+  hasDualFarms: boolean | undefined;
+
+  @Field(() => Float, { description: "Pair trades count details.", nullable: true })
+  @ApiProperty({ type: Number, example: 100 })
+  tradesCount: number | undefined;
 }

--- a/src/endpoints/mex/entities/mex.pairs..filter.ts
+++ b/src/endpoints/mex/entities/mex.pairs..filter.ts
@@ -5,4 +5,6 @@ export class MexPairsFilter {
     Object.assign(this, init);
   }
   exchange?: MexPairExchange;
+  hasFarms?: boolean;
+  hasDualFarms?: boolean;
 }

--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -11,7 +11,7 @@ import { MexTokenService } from "./mex.token.service";
 import { MexFarmService } from './mex.farm.service';
 import { MexFarm } from './entities/mex.farm';
 import { QueryPagination } from 'src/common/entities/query.pagination';
-import { ParseIntPipe, ParseTokenPipe, ParseEnumPipe } from '@multiversx/sdk-nestjs-common';
+import { ParseIntPipe, ParseTokenPipe, ParseEnumPipe, ParseBoolPipe } from '@multiversx/sdk-nestjs-common';
 import { MexPairExchange } from './entities/mex.pair.exchange';
 import { MexPairsFilter } from './entities/mex.pairs..filter';
 
@@ -57,8 +57,10 @@ export class MexController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('exchange', new ParseEnumPipe(MexPairExchange)) exchange?: MexPairExchange,
+    @Query('hasFarms', new ParseBoolPipe()) hasFarms?: boolean,
+    @Query('hasDualFarms', new ParseBoolPipe()) hasDualFarms?: boolean,
   ): Promise<MexPair[]> {
-    const filter = new MexPairsFilter({ exchange });
+    const filter = new MexPairsFilter({ exchange, hasFarms, hasDualFarms });
     return await this.mexPairsService.getMexPairs(new QueryPagination({ from, size }), filter);
   }
 

--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -59,7 +59,7 @@ export class MexController {
     @Query('exchange', new ParseEnumPipe(MexPairExchange)) exchange?: MexPairExchange,
   ): Promise<MexPair[]> {
     const filter = new MexPairsFilter({ exchange });
-    return await this.mexPairsService.getMexPairs(from, size, filter);
+    return await this.mexPairsService.getMexPairs(new QueryPagination({ from, size }), filter);
   }
 
   @Get("/mex/pairs/count")

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -12,6 +12,7 @@ import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { MexPairExchange } from "./entities/mex.pair.exchange";
 import { MexPairsFilter } from "./entities/mex.pairs..filter";
+import { QueryPagination } from "src/common/entities/query.pagination";
 
 @Injectable()
 export class MexPairService {
@@ -30,9 +31,10 @@ export class MexPairService {
     await this.cachingService.setLocal(CacheInfo.MexPairs.key, pairs, Constants.oneSecond() * 30);
   }
 
-  async getMexPairs(from: number, size: number, filter?: MexPairsFilter): Promise<any> {
+  async getMexPairs(pagination: QueryPagination, filter?: MexPairsFilter): Promise<any> {
     let allMexPairs = await this.getAllMexPairs();
     allMexPairs = this.applyFilters(allMexPairs, filter);
+    const { from, size } = pagination;
 
     return allMexPairs.slice(from, from + size);
   }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -270,6 +270,14 @@ export class MexPairService {
       filteredPairs = filteredPairs.filter(pair => pair.exchange === filter.exchange);
     }
 
+    if (typeof filter.hasFarms === 'boolean') {
+      filteredPairs = filteredPairs.filter(pair => pair.hasFarms === filter.hasFarms);
+    }
+
+    if (typeof filter.hasDualFarms === 'boolean') {
+      filteredPairs = filteredPairs.filter(pair => pair.hasDualFarms === filter.hasDualFarms);
+    }
+
     return filteredPairs;
   }
 }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -123,6 +123,9 @@ export class MexPairService {
             type
             lockedValueUSD
             volumeUSD24h
+            hasFarms
+            hasDualFarms
+            tradesCount
             __typename
           }
         }
@@ -188,6 +191,9 @@ export class MexPairService {
         state,
         type,
         exchange,
+        hasFarms: pair.hasFarms,
+        hasDualFarms: pair.hasDualFarms,
+        tradesCount: pair.tradesCount,
       };
     }
 
@@ -212,6 +218,9 @@ export class MexPairService {
       state,
       type,
       exchange,
+      hasFarms: pair.hasFarms,
+      hasDualFarms: pair.hasDualFarms,
+      tradesCount: pair.tradesCount,
     };
   }
 

--- a/src/graphql/entities/xexchange/mex.pairs/mex.pairs.query.ts
+++ b/src/graphql/entities/xexchange/mex.pairs/mex.pairs.query.ts
@@ -3,6 +3,7 @@ import { Args, Resolver, Query } from "@nestjs/graphql";
 import { MexPair } from "src/endpoints/mex/entities/mex.pair";
 import { MexPairService } from "src/endpoints/mex/mex.pair.service";
 import { GetMexTokenPairsByQuotePairIdInput, GetMexTokenPairsInput } from "./mex.pairs.input";
+import { QueryPagination } from "src/common/entities/query.pagination";
 
 @Resolver()
 export class MexTokenPairsQuery {
@@ -10,7 +11,7 @@ export class MexTokenPairsQuery {
 
   @Query(() => [MexPair], { name: "mexPairs", description: "Retrieve all mex token pairs listed on xExchange for the given input." })
   public async getMexPairs(@Args("input", { description: "Input to retrieve the given tokens for." }) input: GetMexTokenPairsInput): Promise<MexPair[]> {
-    return await this.mexTokenPairService.getMexPairs(input.from, input.size);
+    return await this.mexTokenPairService.getMexPairs(new QueryPagination({ from: input.from, size: input.size }));
   }
 
   @Query(() => MexPair, { name: "mexPair", description: "Retrieve one mex pair listed on xExchange for the given input." })

--- a/src/test/unit/controllers/mex.controller.spec.ts
+++ b/src/test/unit/controllers/mex.controller.spec.ts
@@ -68,7 +68,7 @@ describe('MexController', () => {
         .expect(200);
 
       expect(mexPairServiceMocks.getMexPairs).toHaveBeenCalledWith(
-        0, 25, { "exchange": undefined }
+        new QueryPagination({ from: 0, size: 25 }), { "exchange": undefined, "hasFarms": undefined, "hasDualFarms": undefined }
       );
     });
 
@@ -81,7 +81,7 @@ describe('MexController', () => {
         .expect(200);
 
       expect(mexPairServiceMocks.getMexPairs).toHaveBeenCalledWith(
-        0, 5, { "exchange": undefined }
+        new QueryPagination({ from: 0, size: 5 }), { "exchange": undefined, "hasFarms": undefined, "hasDualFarms": undefined }
       );
     });
 
@@ -94,7 +94,7 @@ describe('MexController', () => {
         .expect(200);
 
       expect(mexPairServiceMocks.getMexPairs).toHaveBeenCalledWith(
-        0, 5, { "exchange": MexPairExchange.xexchange }
+        new QueryPagination({ from: 0, size: 5 }), { "exchange": MexPairExchange.xexchange }
       );
     });
 
@@ -107,7 +107,7 @@ describe('MexController', () => {
         .expect(200);
 
       expect(mexPairServiceMocks.getMexPairs).toHaveBeenCalledWith(
-        0, 5, { "exchange": MexPairExchange.unknown }
+        new QueryPagination({ from: 0, size: 5 }), { "exchange": MexPairExchange.unknown, "hasFarms": undefined, "hasDualFarms": undefined }
       );
     });
 


### PR DESCRIPTION
 
## Proposed Changes
- include new extra pair fields: `hasFarms` `hasDualFarms` `tradesCount`

## How to test
- `/mex/pairs` -> `hasFarms` `hasDualFarms` `tradesCount` -> should be defined

