### PR TITLE
Staking v4 improvements

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -135,12 +135,6 @@ export class CacheWarmerService {
 
   @Lock({ name: 'Node auction invalidations', verbose: true })
   async handleNodeAuctionInvalidations() {
-    const nodes = await this.nodeService.getAllNodes();
-    const auctions = await this.gatewayService.getValidatorAuctions();
-
-    await this.nodeService.processAuctions(nodes, auctions);
-    await this.invalidateKey(CacheInfo.Nodes.key, nodes, CacheInfo.Nodes.ttl);
-
     const nodesAuctions = await this.nodeService.getAllNodesAuctionsRaw();
     await this.invalidateKey(CacheInfo.NodesAuctions.key, nodesAuctions, CacheInfo.NodesAuctions.ttl);
   }

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -135,6 +135,9 @@ export class CacheWarmerService {
 
   @Lock({ name: 'Node auction invalidations', verbose: true })
   async handleNodeAuctionInvalidations() {
+    // wait randomly between 1 and 2 seconds to avoid all nodes refreshing at the same time
+    await new Promise(resolve => setTimeout(resolve, 1000 + 1000 * Math.random()));
+
     const nodesAuctions = await this.nodeService.getAllNodesAuctionsRaw();
     await this.invalidateKey(CacheInfo.NodesAuctions.key, nodesAuctions, CacheInfo.NodesAuctions.ttl);
   }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -393,7 +393,7 @@ export class NodeService {
   }
 
   async processAuctions(nodes: Node[], auctions: Auction[]) {
-    const minimumAuctionStake = await this.stakeService.getMinimumAuctionStake();
+    const minimumAuctionStake = await this.stakeService.getMinimumAuctionStake(auctions);
     const dangerZoneThreshold = BigInt(minimumAuctionStake) * BigInt(105) / BigInt(100);
     for (const node of nodes) {
       let position = 1;
@@ -731,20 +731,6 @@ export class NodeService {
 
   async getAllNodesAuctionsRaw(): Promise<NodeAuction[]> {
     const allNodes = await this.getNodes(new QueryPagination({ size: 10000 }), new NodeFilter({ status: NodeStatus.auction }));
-
-    const auctions = await this.gatewayService.getValidatorAuctions();
-    const auctionNodesMap = new Map();
-
-    for (const auction of auctions) {
-      if (auction.nodes) {
-        for (const auctionNode of auction.nodes) {
-          auctionNodesMap.set(auctionNode.blsKey, {
-            auctionTopUp: auction.qualifiedTopUp,
-            qualified: auctionNode.qualified,
-          });
-        }
-      }
-    }
 
     const groupedNodes = allNodes.groupBy(node => (node.provider || node.owner) + ':' + (BigInt(node.stake).toString()) + (BigInt(node.topUp).toString()), true);
 

--- a/src/endpoints/stake/stake.service.ts
+++ b/src/endpoints/stake/stake.service.ts
@@ -20,6 +20,7 @@ import { GlobalStake } from "./entities/global.stake";
 import { ValidatorInfoResult } from "./entities/validator.info.result";
 import { NodeFilter } from "../nodes/entities/node.filter";
 import { BlockService } from "../blocks/block.service";
+import { Auction } from "src/common/gateway/entities/auction";
 
 @Injectable()
 export class StakeService {
@@ -72,8 +73,9 @@ export class StakeService {
       });
     }
 
-    const minimumAuctionQualifiedTopUp = await this.getMinimumAuctionTopUp();
-    const minimumAuctionQualifiedStake = await this.getMinimumAuctionStake();
+    const auctions = await this.gatewayService.getValidatorAuctions();
+    const minimumAuctionQualifiedTopUp = this.getMinimumAuctionTopUp(auctions);
+    const minimumAuctionQualifiedStake = this.getMinimumAuctionStake(auctions);
     const auctionValidators = await this.nodeService.getNodeCount(new NodeFilter({ auctioned: true }));
     const qualifiedAuctionValidators = await this.nodeService.getNodeCount(new NodeFilter({ isQualified: true }));
 
@@ -360,9 +362,7 @@ export class StakeService {
     return data;
   }
 
-  async getMinimumAuctionTopUp(): Promise<string | undefined> {
-    const auctions = await this.gatewayService.getValidatorAuctions();
-
+  getMinimumAuctionTopUp(auctions: Auction[]): string | undefined {
     if (auctions.length === 0) {
       return undefined;
     }
@@ -382,9 +382,9 @@ export class StakeService {
     return minimumAuctionTopUp;
   }
 
-  async getMinimumAuctionStake(): Promise<string> {
+  getMinimumAuctionStake(auctions: Auction[]): string {
     const MINIMUM_STAKE_AMOUNT = 2500000000000000000000;
-    const minimumAuctionTopUp = await this.getMinimumAuctionTopUp();
+    const minimumAuctionTopUp = this.getMinimumAuctionTopUp(auctions);
     const baseStake = BigInt(MINIMUM_STAKE_AMOUNT);
     const topUp = minimumAuctionTopUp ? BigInt(minimumAuctionTopUp) : BigInt(0);
 

--- a/src/test/unit/services/stake.spec.ts
+++ b/src/test/unit/services/stake.spec.ts
@@ -166,7 +166,7 @@ describe('Stake Service', () => {
 
       jest.spyOn(stakeService, 'getValidators').mockResolvedValue(validators);
       jest.spyOn(stakeService['gatewayService'], 'getNetworkEconomics').mockResolvedValue(economicsMocks);
-      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockResolvedValue(expectedMinimumAuctionQualifiedTopUp);
+      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockReturnValue(expectedMinimumAuctionQualifiedTopUp);
       jest.spyOn(stakeService, 'getNakamotoCoefficient').mockResolvedValue(expectedNakamotoCoefficient);
       jest.spyOn(apiConfigService, 'isStakingV4Enabled').mockReturnValue(true);
       jest.spyOn(apiConfigService, 'getStakingV4ActivationEpoch').mockReturnValue(1395);
@@ -204,16 +204,16 @@ describe('Stake Service', () => {
   });
 
   describe('getMinimumAuctionTopUp', () => {
-    it('should return undefined when there are no auctions', async () => {
+    it('should return undefined when there are no auctions', () => {
       const response = { auctionList: [] };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp([]);
 
       expect(minimumAuctionTopUp).toBeUndefined();
     });
 
-    it('should return "0" when all qualifiedTopUp are zero', async () => {
+    it('should return "0" when all qualifiedTopUp are zero', () => {
       const response = {
         auctionList: [
           {
@@ -246,12 +246,12 @@ describe('Stake Service', () => {
       };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp(response.auctionList);
 
       expect(minimumAuctionTopUp).toStrictEqual("0");
     });
 
-    it('should return the smallest positive qualifiedTopUp', async () => {
+    it('should return the smallest positive qualifiedTopUp', () => {
       const response = {
         auctionList: [
           {
@@ -284,12 +284,12 @@ describe('Stake Service', () => {
       };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp(response.auctionList);
 
       expect(minimumAuctionTopUp).toEqual('2300000000000000000000');
     });
 
-    it('should only consider qualified nodes', async () => {
+    it('should only consider qualified nodes', () => {
       const response = {
         auctionList: [
           {
@@ -322,12 +322,12 @@ describe('Stake Service', () => {
       };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp(response.auctionList);
 
       expect(minimumAuctionTopUp).toEqual('3000000000000000000000');
     });
 
-    it('should correctly calculate minimum auction topup even if values come sorted wrongly', async () => {
+    it('should correctly calculate minimum auction topup even if values come sorted wrongly', () => {
       const response = {
         auctionList: [
           {
@@ -360,12 +360,12 @@ describe('Stake Service', () => {
       };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp(response.auctionList);
 
       expect(minimumAuctionTopUp).toEqual('2500000000000000000000');
     });
 
-    it('Should return correctly minimum auction topup if all values are selected', async () => {
+    it('Should return correctly minimum auction topup if all values are selected', () => {
       const response = {
         auctionList: [
           {
@@ -407,38 +407,123 @@ describe('Stake Service', () => {
               },
             ],
           },
-
         ],
       };
       jest.spyOn(gatewayService, 'getValidatorAuctions').mockResolvedValue(response.auctionList);
 
-      const minimumAuctionTopUp = await stakeService.getMinimumAuctionTopUp();
+      const minimumAuctionTopUp = stakeService.getMinimumAuctionTopUp(response.auctionList);
 
       expect(minimumAuctionTopUp).toEqual('2500000000000000000000');
     });
   });
 
   describe('getMinimumAuctionStake', () => {
-    it('should return 2500 when getMinimumAuctionTopUp is undefined', async () => {
-      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockResolvedValue(undefined);
+    it('should return 2500 when getMinimumAuctionTopUp is undefined', () => {
+      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockReturnValue('');
 
-      const result = await stakeService.getMinimumAuctionStake();
+      const result = stakeService.getMinimumAuctionStake([]);
 
       expect(result).toEqual('2500000000000000000000');
     });
 
-    it('should return the sum of 2500 and a positive minimum auction top up', async () => {
-      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockResolvedValue('500');
+    it('should return the sum of 2500 and a positive minimum auction top up', () => {
+      const response = {
+        auctionList: [
+          {
+            qualifiedTopUp: '2500000000000000000000',
+            owner: "erd1netql0lyhcyd8ugpcfrchr60273rjemr5thug9g0fgxqa9ep5yeqvj7qfv",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "bc832a1c856963abd94b3bc28ce25473a47078e0a397fd2aad7e1c853352e5c8b6926075e31d0ca8fefcadeb652f3005aca644cf62d11c4a679aed8c9eb4c0d91bd2135a9af3ed285afd2a44c4d4e8741600b4ac8431681530bb018d251dac99",
+                qualified: true,
+              },
+            ],
+          },
+          {
+            qualifiedTopUp: '3000000000000000000000',
+            owner: "erd1crmrdw7dgkcmj6a045yjcq3ehvzyntegtn6pu9ttnl35l9kcmjjqsf5v59",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "a5e971635917fd89c76f7967a1d2a5d83e18219126f85933b46ac7af3afba8a3d46479bf151b7e56c4379c3b9d756e0161e2d59bfbb4a7b9b33dfa7952735132a350fb32ab38dacbed85ca8f0d5ccf046a8e68eff2cddf5fe317a34ec8dee40e",
+                qualified: false,
+              },
+            ],
+          },
+          {
+            qualifiedTopUp: '2300000000000000000000',
+            owner: "erd1crmrdw7dgkcmj6a045yjcq3ehvzyntegtn6pu9ttnl35l9kcmjjqsf5v59",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "a5e971635917fd89c76f7967a1d2a5d83e18219126f85933b46ac7af3afba8a3d46479bf151b7e56c4379c3b9d756e0161e2d59bfbb4a7b9b33dfa7952735132a350fb32ab38dacbed85ca8f0d5ccf046a8e68eff2cddf5fe317a34ec8dee40e",
+                qualified: false,
+              },
+            ],
+          },
+        ],
+      };
+      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockReturnValue('500');
 
-      const result = await stakeService.getMinimumAuctionStake();
+      const result = stakeService.getMinimumAuctionStake(response.auctionList);
 
       expect(result).toEqual('2500000000000000000500');
     });
 
-    it('should correctly handle large minimum auction top up values', async () => {
-      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockResolvedValue('1000000');
+    it('should correctly handle large minimum auction top up values', () => {
+      const response = {
+        auctionList: [
+          {
+            qualifiedTopUp: '2500000000000000000000',
+            owner: "erd1netql0lyhcyd8ugpcfrchr60273rjemr5thug9g0fgxqa9ep5yeqvj7qfv",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "bc832a1c856963abd94b3bc28ce25473a47078e0a397fd2aad7e1c853352e5c8b6926075e31d0ca8fefcadeb652f3005aca644cf62d11c4a679aed8c9eb4c0d91bd2135a9af3ed285afd2a44c4d4e8741600b4ac8431681530bb018d251dac99",
+                qualified: true,
+              },
+            ],
+          },
+          {
+            qualifiedTopUp: '3000000000000000000000',
+            owner: "erd1crmrdw7dgkcmj6a045yjcq3ehvzyntegtn6pu9ttnl35l9kcmjjqsf5v59",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "a5e971635917fd89c76f7967a1d2a5d83e18219126f85933b46ac7af3afba8a3d46479bf151b7e56c4379c3b9d756e0161e2d59bfbb4a7b9b33dfa7952735132a350fb32ab38dacbed85ca8f0d5ccf046a8e68eff2cddf5fe317a34ec8dee40e",
+                qualified: false,
+              },
+            ],
+          },
+          {
+            qualifiedTopUp: '2300000000000000000000',
+            owner: "erd1crmrdw7dgkcmj6a045yjcq3ehvzyntegtn6pu9ttnl35l9kcmjjqsf5v59",
+            numStakedNodes: 1,
+            totalTopUp: "0",
+            topUpPerNode: "0",
+            nodes: [
+              {
+                blsKey: "a5e971635917fd89c76f7967a1d2a5d83e18219126f85933b46ac7af3afba8a3d46479bf151b7e56c4379c3b9d756e0161e2d59bfbb4a7b9b33dfa7952735132a350fb32ab38dacbed85ca8f0d5ccf046a8e68eff2cddf5fe317a34ec8dee40e",
+                qualified: false,
+              },
+            ],
+          },
+        ],
+      };
+      jest.spyOn(stakeService, 'getMinimumAuctionTopUp').mockReturnValue('1000000');
 
-      const result = await stakeService.getMinimumAuctionStake();
+      const result = stakeService.getMinimumAuctionStake(response.auctionList);
 
       expect(result).toEqual('2500000000000001000000');
     });


### PR DESCRIPTION
## Proposed Changes
- removed code that is not used
- less calls to the `/validator/auction` endpoint on gateway
- in order to limit the number of concurrent calls, apply a small random delay before performing the fetching of node auctions
