### PR TITLE
Validator auction query fixes

### DIFF
--- a/src/endpoints/identities/entities/stake.info.ts
+++ b/src/endpoints/identities/entities/stake.info.ts
@@ -6,6 +6,7 @@ export class StakeInfo {
   score?: number;
   validators?: number;
   queued?: number;
+  auctioned?: number;
   stake?: string;
   topUp?: string;
   locked: string = '0';

--- a/src/endpoints/identities/identities.module.ts
+++ b/src/endpoints/identities/identities.module.ts
@@ -3,12 +3,14 @@ import { KeybaseModule } from "src/common/keybase/keybase.module";
 import { NetworkModule } from "../network/network.module";
 import { NodeModule } from "../nodes/node.module";
 import { IdentitiesService } from "./identities.service";
+import { BlockModule } from "../blocks/block.module";
 
 @Module({
   imports: [
     forwardRef(() => NodeModule),
     forwardRef(() => NetworkModule),
     forwardRef(() => KeybaseModule),
+    forwardRef(() => BlockModule),
   ],
   providers: [
     IdentitiesService,

--- a/src/endpoints/identities/identities.service.ts
+++ b/src/endpoints/identities/identities.service.ts
@@ -13,6 +13,8 @@ import { StakeInfo } from "./entities/stake.info";
 import { NodeType } from "../nodes/entities/node.type";
 import { NodeStatus } from "../nodes/entities/node.status";
 import { IdentitySortCriteria } from "./entities/identity.sort.criteria";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { BlockService } from "../blocks/block.service";
 
 @Injectable()
 export class IdentitiesService {
@@ -21,7 +23,9 @@ export class IdentitiesService {
     private readonly nodeService: NodeService,
     private readonly cacheService: CacheService,
     @Inject(forwardRef(() => NetworkService))
-    private readonly networkService: NetworkService
+    private readonly networkService: NetworkService,
+    private readonly apiConfigService: ApiConfigService,
+    private readonly blockService: BlockService,
   ) { }
 
   async getIdentity(identifier: string): Promise<Identity | undefined> {
@@ -131,13 +135,17 @@ export class IdentitiesService {
     return distribution;
   }
 
-  private getStakeInfoForIdentity(identity: IdentityDetailed, totalLocked: bigint): StakeInfo {
+  private getStakeInfoForIdentity(identity: IdentityDetailed, totalLocked: bigint, currentEpoch: number): StakeInfo {
     const nodes = identity.nodes ?? [];
 
     const stake = nodes.sumBigInt(x => BigInt(x.stake ? x.stake : '0'));
     const topUp = nodes.sumBigInt(x => BigInt(x.topUp ? x.topUp : '0'));
     const locked = stake + topUp;
     const stakePercent = totalLocked > 0 ? (locked * BigInt(10000)) / totalLocked : 0;
+
+    const qualifiedAuctionNodes = nodes.filter(x => x.type === NodeType.validator && x.status === NodeStatus.auction && x.auctionQualified === true);
+    const unqualifiedAuctionNodes = nodes.filter(x => x.type === NodeType.validator && x.status === NodeStatus.auction && x.auctionQualified === false);
+    const isStakingV4ActivationEpoch = this.apiConfigService.isStakingV4Enabled() && currentEpoch === this.apiConfigService.getStakingV4ActivationEpoch();
 
     const stakeInfo = new StakeInfo({
       score: nodes.sum(x => x.ratingModifier),
@@ -149,6 +157,7 @@ export class IdentitiesService {
       distribution: this.getStakeDistributionForIdentity(locked, identity),
       validators: nodes.filter(x => x.type === NodeType.validator && x.status !== NodeStatus.inactive).length,
       queued: nodes.filter(x => x.type === NodeType.validator && x.status === NodeStatus.queued).length,
+      auctioned: isStakingV4ActivationEpoch ? qualifiedAuctionNodes.length + unqualifiedAuctionNodes.length : unqualifiedAuctionNodes.length,
     });
 
     stakeInfo.sort = stakeInfo.locked && stakeInfo.locked !== '0' ? parseInt(stakeInfo.locked.slice(0, -18)) : 0;
@@ -206,6 +215,7 @@ export class IdentitiesService {
 
     const { locked: totalLocked } = this.computeTotalStakeAndTopUp(nodes);
     const { baseApr, topUpApr } = await this.networkService.getApr();
+    const currentEpoch = await this.blockService.getCurrentEpoch();
 
     let identities: Identity[] = identitiesDetailed.map((identityDetailed: IdentityDetailed) => {
       if (identityDetailed.nodes && identityDetailed.nodes.length) {
@@ -218,7 +228,7 @@ export class IdentitiesService {
         identity.twitter = identityDetailed.twitter;
         identity.location = identityDetailed.location;
 
-        const stakeInfo = this.getStakeInfoForIdentity(identityDetailed, BigInt(parseInt(totalLocked)));
+        const stakeInfo = this.getStakeInfoForIdentity(identityDetailed, BigInt(parseInt(totalLocked)), currentEpoch);
         identity.score = stakeInfo.score;
         identity.validators = stakeInfo.validators;
         identity.stake = stakeInfo.stake;
@@ -230,7 +240,7 @@ export class IdentitiesService {
         if (identity.stake && identity.topUp) {
           const stakeReturn = new BigNumber(identity.stake.slice(0, -18)).multipliedBy(new BigNumber(baseApr));
           const topUpReturn = identity.topUp !== '0' ? new BigNumber(identity.topUp.slice(0, -18)).multipliedBy(new BigNumber(topUpApr)) : new BigNumber(0);
-          const annualReturn = stakeReturn.plus(topUpReturn).multipliedBy((identity.validators ?? 0) - (stakeInfo.queued ?? 0)).dividedBy(identity.validators ?? 0);
+          const annualReturn = stakeReturn.plus(topUpReturn).multipliedBy((identity.validators ?? 0) - (stakeInfo.queued ?? 0) - (stakeInfo.auctioned ?? 0)).dividedBy(identity.validators ?? 0);
           const aprStr = new BigNumber(annualReturn).multipliedBy(100).div(identity.locked.slice(0, -18)).toString();
           identity.apr = Number(aprStr).toRounded(2);
         }

--- a/src/endpoints/stake/stake.service.ts
+++ b/src/endpoints/stake/stake.service.ts
@@ -73,7 +73,7 @@ export class StakeService {
       });
     }
 
-    const auctions = await this.gatewayService.getValidatorAuctions();
+    const auctions = await this.nodeService.getValidatorAuctions();
     const minimumAuctionQualifiedTopUp = this.getMinimumAuctionTopUp(auctions);
     const minimumAuctionQualifiedStake = this.getMinimumAuctionStake(auctions);
     const auctionValidators = await this.nodeService.getNodeCount(new NodeFilter({ auctioned: true }));

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -645,4 +645,9 @@ export class CacheInfo {
     key: 'nodesAuctions',
     ttl: Constants.oneMinute(),
   };
+
+  static ValidatorAuctions: CacheInfo = {
+    key: 'validatorAuctions',
+    ttl: Constants.oneHour(),
+  };
 }


### PR DESCRIPTION
## Proposed Changes
- Implemented a fault-tolerant way of fetching validator auctions until a proper fix is deployed on the node / gateway
- Adjusted APR of identities by taking into account auction unqualified nodes

## How to test
- even if the gateway returns an empty array on the validator auction endpoint, the most recently fetched value should be returned
- identities that have nodes in auction should have their APR correspondingly lowered
