### PR TITLE
add node waiting epochs left proxy

### DIFF
--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -6,7 +6,7 @@ import { GatewayService } from "src/common/gateway/gateway.service";
 import { Response, Request } from "express";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { PluginService } from "src/common/plugins/plugin.service";
-import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseIntPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
+import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseBlsHashPipe, ParseIntPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
 import { CacheService, NoCache } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
@@ -246,6 +246,13 @@ export class GatewayProxyController {
     } catch (error: any) {
       throw new BadRequestException(error.response.data);
     }
+  }
+
+  @Get('/node/waiting-epochs-left/:bls')
+  async getNodeWaitingEpochsLeft(
+    @Param('bls', ParseBlsHashPipe) bls: string,
+  ) {
+    return await this.gatewayGet(`node/waiting-epochs-left/${bls}`, GatewayComponentRequest.getNodeWaitingEpochsLeft);
   }
 
   @Get('/validator/statistics')


### PR DESCRIPTION
## Reasoning
- new node endpoint is available in gateway.multiversx.com
  
## Proposed Changes
- Proxy forward node/waiting-epochs-left/:bls endpoint


## How to test(mainnet)
- `node/waiting-epochs-left/ccea9c6d5bb3833dcb90358d9585d1dddb113523d049ec93762774e620c38dabbf1868fb7b61712c3e573d788203270e0efffc97f33af38e7f46b216d04694b13c49e91f33c1bfda000634fde3557c65390065f0d5a8a211020dfa36f5c72f90` -> should return ` "epochsLeft": 3`