### PR TITLE
add applications endpoints

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -629,12 +629,17 @@ export class ElasticIndexerHelper {
     return elasticQuery;
   }
 
-  public buildScDeploysContracts(filter: ApplicationFilter): ElasticQuery {
+  buildApplicationFilter(filter: ApplicationFilter): ElasticQuery {
     let elasticQuery = ElasticQuery.create();
 
-    if (filter.before || filter.after) {
-      elasticQuery = elasticQuery.withDateRangeFilter('timestamp', filter.before, filter.after);
+    if (filter.after) {
+      elasticQuery = elasticQuery.withRangeFilter('timestamp', new RangeGreaterThanOrEqual(filter.after));
     }
+
+    if (filter.before) {
+      elasticQuery = elasticQuery.withRangeFilter('timestamp', new RangeLowerThanOrEqual(filter.before));
+    }
+
     return elasticQuery;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -16,6 +16,7 @@ import { TransactionType } from "src/endpoints/transactions/entities/transaction
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { SmartContractResultFilter } from "src/endpoints/sc-results/entities/smart.contract.result.filter";
+import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
 
 @Injectable()
 export class ElasticIndexerHelper {
@@ -625,6 +626,15 @@ export class ElasticIndexerHelper {
       }
     }
 
+    return elasticQuery;
+  }
+
+  public buildScDeploysContracts(filter: ApplicationFilter): ElasticQuery {
+    let elasticQuery = ElasticQuery.create();
+
+    if (filter.before || filter.after) {
+      elasticQuery = elasticQuery.withDateRangeFilter('timestamp', filter.before, filter.after);
+    }
     return elasticQuery;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -915,24 +915,18 @@ export class ElasticIndexerService implements IndexerInterface {
     return blocks.at(0);
   }
 
-  async getAllScDeploysContracts(filter: ApplicationFilter): Promise<any[]> {
-    const elasticQuery = this.indexerHelper.buildScDeploysContracts(filter)
-      .withPagination({ from: 0, size: 1000 })
+  async getApplications(filter: ApplicationFilter, pagination: QueryPagination): Promise<any[]> {
+    const elasticQuery = this.indexerHelper.buildApplicationFilter(filter)
+      .withPagination(pagination)
       .withFields(['address', 'deployer', 'currentOwner', 'initialCodeHash', 'timestamp'])
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
 
-    const contracts: any[] = [];
-
-    // eslint-disable-next-line require-await
-    const scrollHandler = async (items: any[]) => {
-      contracts.push(...items);
-    };
-    await this.elasticService.getScrollableList('scdeploys', 'address', elasticQuery, scrollHandler);
-
-    return contracts;
+    return await this.elasticService.getList('scdeploys', 'address', elasticQuery);
   }
-  async getAllScDeploysContractsCount(): Promise<number> {
-    const elasticQuery = ElasticQuery.create();
+
+  async getApplicationCount(filter: ApplicationFilter): Promise<number> {
+    const elasticQuery = this.indexerHelper.buildApplicationFilter(filter);
+
     return await this.elasticService.getCount('scdeploys', elasticQuery);
   }
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -15,6 +15,7 @@ import { QueryPagination } from "../entities/query.pagination";
 import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
 import { AccountAssets } from "../assets/entities/account.assets";
 import { ProviderDelegators } from "./entities/provider.delegators";
+import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
 
 export interface IndexerInterface {
   getAccountsCount(filter: AccountQueryOptions): Promise<number>
@@ -172,4 +173,8 @@ export interface IndexerInterface {
   getBlockByTimestampAndShardId(timestamp: number, shardId: number): Promise<Block | undefined>
 
   getVersion(): Promise<string | undefined>
+
+  getAllScDeploysContracts(filter: ApplicationFilter): Promise<any[]>
+
+  getAllScDeploysContractsCount(): Promise<number>
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -174,7 +174,7 @@ export interface IndexerInterface {
 
   getVersion(): Promise<string | undefined>
 
-  getAllScDeploysContracts(filter: ApplicationFilter): Promise<any[]>
+  getApplications(filter: ApplicationFilter, pagination: QueryPagination): Promise<any[]>
 
-  getAllScDeploysContractsCount(): Promise<number>
+  getApplicationCount(filter: ApplicationFilter): Promise<number>
 }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -420,12 +420,12 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAllScDeploysContracts(filter: ApplicationFilter): Promise<any[]> {
-    return await this.indexerInterface.getAllScDeploysContracts(filter);
+  async getApplications(filter: ApplicationFilter, pagination: QueryPagination): Promise<any[]> {
+    return await this.indexerInterface.getApplications(filter, pagination);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAllScDeploysContractsCount(): Promise<number> {
-    return await this.indexerInterface.getAllScDeploysContractsCount();
+  async getApplicationCount(filter: ApplicationFilter): Promise<number> {
+    return await this.indexerInterface.getApplicationCount(filter);
   }
 }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -19,6 +19,7 @@ import { MiniBlockFilter } from "src/endpoints/miniblocks/entities/mini.block.fi
 import { AccountHistoryFilter } from "src/endpoints/accounts/entities/account.history.filter";
 import { AccountAssets } from "../assets/entities/account.assets";
 import { ProviderDelegators } from "./entities/provider.delegators";
+import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
 
 @Injectable()
 export class IndexerService implements IndexerInterface {
@@ -416,5 +417,15 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getVersion(): Promise<string | undefined> {
     return await this.indexerInterface.getVersion();
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAllScDeploysContracts(filter: ApplicationFilter): Promise<any[]> {
+    return await this.indexerInterface.getAllScDeploysContracts(filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAllScDeploysContractsCount(): Promise<number> {
+    return await this.indexerInterface.getAllScDeploysContractsCount();
   }
 }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -20,6 +20,7 @@ import { AccountDb, AccountsEsdtDb, BlockDb, LogDb, MiniBlockDb, ReceiptDb, Roun
 import { PostgresIndexerHelper } from "./postgres.indexer.helper";
 import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { ProviderDelegators } from "../entities/provider.delegators";
+import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
 
 @Injectable()
 export class PostgresIndexerService implements IndexerInterface {
@@ -52,6 +53,12 @@ export class PostgresIndexerService implements IndexerInterface {
     private readonly validatorPublicKeysRepository: Repository<ValidatorPublicKeysDb>,
     private readonly indexerHelper: PostgresIndexerHelper,
   ) { }
+  getAllScDeploysContractsCount(): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+  getAllScDeploysContracts(_filter: ApplicationFilter): Promise<any[]> {
+    throw new Error("Method not implemented.");
+  }
   getProviderDelegatorsCount(_address: string): Promise<number> {
     throw new Error("Method not implemented.");
   }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -53,10 +53,10 @@ export class PostgresIndexerService implements IndexerInterface {
     private readonly validatorPublicKeysRepository: Repository<ValidatorPublicKeysDb>,
     private readonly indexerHelper: PostgresIndexerHelper,
   ) { }
-  getAllScDeploysContractsCount(): Promise<number> {
+  getApplicationCount(): Promise<number> {
     throw new Error("Method not implemented.");
   }
-  getAllScDeploysContracts(_filter: ApplicationFilter): Promise<any[]> {
+  getApplications(_filter: ApplicationFilter): Promise<any[]> {
     throw new Error("Method not implemented.");
   }
   getProviderDelegatorsCount(_address: string): Promise<number> {

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -33,8 +33,6 @@ import { PoolService } from "src/endpoints/pool/pool.service";
 import * as JsonDiff from "json-diff";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { StakeService } from "src/endpoints/stake/stake.service";
-import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
-import { ApplicationService } from "src/endpoints/applications/application.service";
 
 @Injectable()
 export class CacheWarmerService {
@@ -68,7 +66,6 @@ export class CacheWarmerService {
     private readonly blockService: BlockService,
     private readonly poolService: PoolService,
     private readonly stakeService: StakeService,
-    private readonly applicationService: ApplicationService
   ) {
     this.configCronJob(
       'handleTokenAssetsInvalidations',
@@ -393,14 +390,6 @@ export class CacheWarmerService {
         }
       }
     }
-  }
-
-  @Cron(CronExpression.EVERY_10_MINUTES)
-  @Lock({ name: 'Applications invalidations', verbose: true })
-  async handleApplicationInvalidations() {
-    const applications = await this.applicationService.getApplicationsRaw({ from: 0, size: 25 }, new ApplicationFilter);
-    const applicationsCacheInfo = CacheInfo.Applications({ from: 0, size: 25 });
-    await this.invalidateKey(applicationsCacheInfo.key, applications, applicationsCacheInfo.ttl);
   }
 
   private async invalidateKey(key: string, data: any, ttl: number) {

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -33,6 +33,8 @@ import { PoolService } from "src/endpoints/pool/pool.service";
 import * as JsonDiff from "json-diff";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { StakeService } from "src/endpoints/stake/stake.service";
+import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
+import { ApplicationService } from "src/endpoints/applications/application.service";
 
 @Injectable()
 export class CacheWarmerService {
@@ -66,6 +68,7 @@ export class CacheWarmerService {
     private readonly blockService: BlockService,
     private readonly poolService: PoolService,
     private readonly stakeService: StakeService,
+    private readonly applicationService: ApplicationService
   ) {
     this.configCronJob(
       'handleTokenAssetsInvalidations',
@@ -390,6 +393,14 @@ export class CacheWarmerService {
         }
       }
     }
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  @Lock({ name: 'Applications invalidations', verbose: true })
+  async handleApplicationInvalidations() {
+    const applications = await this.applicationService.getApplicationsRaw({ from: 0, size: 25 }, new ApplicationFilter);
+    const applicationsCacheInfo = CacheInfo.Applications({ from: 0, size: 25 });
+    await this.invalidateKey(applicationsCacheInfo.key, applications, applicationsCacheInfo.ttl);
   }
 
   private async invalidateKey(key: string, data: any, ttl: number) {

--- a/src/crons/elastic.updater/elastic.updater.service.ts
+++ b/src/crons/elastic.updater/elastic.updater.service.ts
@@ -9,7 +9,6 @@ import { BatchUtils, Lock, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 import { IndexerService } from "src/common/indexer/indexer.service";
 
-
 @Injectable()
 export class ElasticUpdaterService {
   private readonly logger = new OriginLogger(ElasticUpdaterService.name);

--- a/src/endpoints/applications/application.controller.ts
+++ b/src/endpoints/applications/application.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, DefaultValuePipe, Get, Query } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { ApplicationService } from "./application.service";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { ApplicationFilter } from "./entities/application.filter";
+import { ParseIntPipe } from "@multiversx/sdk-nestjs-common";
+import { Application } from "./entities/application";
+
+@Controller()
+@ApiTags('applications')
+export class ApplicationController {
+  constructor(
+    private readonly applicationService: ApplicationService
+  ) { }
+
+  @Get("applications")
+  @ApiOperation({ summary: 'Applications details', description: 'Returns all smart contracts available on blockchain. By default it returns 25 smart contracts' })
+  @ApiOkResponse({ type: [Application] })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  async getApplications(
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+  ): Promise<any[]> {
+    return await this.applicationService.getApplications(
+      new QueryPagination({ size, from }),
+      new ApplicationFilter({ before, after })
+    );
+  }
+
+  @Get("applications/count")
+  @ApiOperation({ summary: 'Applications count', description: 'Returns total number of smart contracts' })
+  @ApiOkResponse({ type: Number })
+  async getApplicationsCount(): Promise<number> {
+    return await this.applicationService.getApplicationsCount();
+  }
+}

--- a/src/endpoints/applications/application.controller.ts
+++ b/src/endpoints/applications/application.controller.ts
@@ -35,7 +35,14 @@ export class ApplicationController {
   @Get("applications/count")
   @ApiOperation({ summary: 'Applications count', description: 'Returns total number of smart contracts' })
   @ApiOkResponse({ type: Number })
-  async getApplicationsCount(): Promise<number> {
-    return await this.applicationService.getApplicationsCount();
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  async getApplicationsCount(
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+  ): Promise<number> {
+    const filter = new ApplicationFilter({ before, after });
+
+    return await this.applicationService.getApplicationsCount(filter);
   }
 }

--- a/src/endpoints/applications/application.module.ts
+++ b/src/endpoints/applications/application.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { ElasticIndexerModule } from "src/common/indexer/elastic/elastic.indexer.module";
+import { ApplicationService } from "./application.service";
+
+@Module({
+  imports: [
+    ElasticIndexerModule,
+  ],
+  providers: [
+    ApplicationService,
+  ],
+  exports: [
+    ApplicationService,
+  ],
+})
+export class ApplicationModule { }

--- a/src/endpoints/applications/application.service.ts
+++ b/src/endpoints/applications/application.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from "@nestjs/common";
+import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
+import { Application } from "./entities/application";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { CacheService } from "@multiversx/sdk-nestjs-cache";
+import { CacheInfo } from "src/utils/cache.info";
+import { ApplicationFilter } from "./entities/application.filter";
+
+@Injectable()
+export class ApplicationService {
+  constructor(
+    private readonly elasticIndexerService: ElasticIndexerService,
+    private readonly cacheService: CacheService
+  ) { }
+
+  async getApplications(queryPagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
+    if (filter.isSet()) {
+      return await this.cacheService.getOrSet(
+        CacheInfo.Applications(queryPagination).key,
+        async () => await this.getApplicationsRaw(queryPagination, filter),
+        CacheInfo.Applications(queryPagination).ttl
+      );
+    }
+    return await this.getApplicationsRaw(queryPagination, filter);
+  }
+
+  async getApplicationsRaw(queryPagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
+    const elasticResults = await this.elasticIndexerService.getAllScDeploysContracts(filter);
+    const { from, size } = queryPagination;
+
+    if (!elasticResults) {
+      return [];
+    }
+
+    const applications: Application[] = elasticResults.map(item => ({
+      contract: item.address,
+      deployer: item.deployer,
+      owner: item.currentOwner,
+      codeHash: item.initialCodeHash,
+      timestamp: item.timestamp,
+    }));
+
+    return applications.slice(from, from + size);
+  }
+
+  async getApplicationsCount(): Promise<number> {
+    return await this.elasticIndexerService.getAllScDeploysContractsCount();
+  }
+}

--- a/src/endpoints/applications/application.service.ts
+++ b/src/endpoints/applications/application.service.ts
@@ -2,32 +2,16 @@ import { Injectable } from "@nestjs/common";
 import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
 import { Application } from "./entities/application";
 import { QueryPagination } from "src/common/entities/query.pagination";
-import { CacheService } from "@multiversx/sdk-nestjs-cache";
-import { CacheInfo } from "src/utils/cache.info";
 import { ApplicationFilter } from "./entities/application.filter";
 
 @Injectable()
 export class ApplicationService {
   constructor(
     private readonly elasticIndexerService: ElasticIndexerService,
-    private readonly cacheService: CacheService
   ) { }
 
-  async getApplications(queryPagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
-    if (filter.isSet()) {
-      return await this.cacheService.getOrSet(
-        CacheInfo.Applications(queryPagination).key,
-        async () => await this.getApplicationsRaw(queryPagination, filter),
-        CacheInfo.Applications(queryPagination).ttl
-      );
-    }
-    return await this.getApplicationsRaw(queryPagination, filter);
-  }
-
-  async getApplicationsRaw(queryPagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
-    const elasticResults = await this.elasticIndexerService.getAllScDeploysContracts(filter);
-    const { from, size } = queryPagination;
-
+  async getApplications(pagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
+    const elasticResults = await this.elasticIndexerService.getApplications(filter, pagination);
     if (!elasticResults) {
       return [];
     }
@@ -40,10 +24,10 @@ export class ApplicationService {
       timestamp: item.timestamp,
     }));
 
-    return applications.slice(from, from + size);
+    return applications;
   }
 
-  async getApplicationsCount(): Promise<number> {
-    return await this.elasticIndexerService.getAllScDeploysContractsCount();
+  async getApplicationsCount(filter: ApplicationFilter): Promise<number> {
+    return await this.elasticIndexerService.getApplicationCount(filter);
   }
 }

--- a/src/endpoints/applications/entities/application.filter.ts
+++ b/src/endpoints/applications/entities/application.filter.ts
@@ -1,0 +1,13 @@
+export class ApplicationFilter {
+  constructor(init?: Partial<ApplicationFilter>) {
+    Object.assign(this, init);
+  }
+
+  after?: number;
+  before?: number;
+
+  isSet(): boolean {
+    return this.after !== undefined ||
+      this.before !== undefined;
+  }
+}

--- a/src/endpoints/applications/entities/application.ts
+++ b/src/endpoints/applications/entities/application.ts
@@ -1,0 +1,29 @@
+import { Field, Float, ObjectType } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+
+@ObjectType("Application", { description: "Application object type." })
+export class Application {
+  constructor(init?: Partial<Application>) {
+    Object.assign(this, init);
+  }
+
+  @Field(() => String, { description: "Contract address details." })
+  @ApiProperty({ type: String })
+  contract: string = '';
+
+  @Field(() => String, { description: "Deployer address details." })
+  @ApiProperty({ type: String })
+  deployer: string = '';
+
+  @Field(() => String, { description: "Owner address details." })
+  @ApiProperty({ type: String })
+  owner: string = '';
+
+  @Field(() => String, { description: "Code hash details." })
+  @ApiProperty({ type: String })
+  codeHash: string = '';
+
+  @Field(() => Float, { description: "Timestamp details." })
+  @ApiProperty({ type: Number })
+  timestamp: number = 0;
+}

--- a/src/endpoints/endpoints.controllers.module.ts
+++ b/src/endpoints/endpoints.controllers.module.ts
@@ -37,6 +37,7 @@ import { WaitingListController } from "./waiting-list/waiting.list.controller";
 import { WebsocketController } from "./websocket/websocket.controller";
 import { PoolController } from "./pool/pool.controller";
 import { TpsController } from "./tps/tps.controller";
+import { ApplicationController } from "./applications/application.controller";
 
 @Module({})
 export class EndpointsControllersModule {
@@ -47,7 +48,7 @@ export class EndpointsControllersModule {
       ProviderController, GatewayProxyController, RoundController, SmartContractResultController, ShardController, StakeController, StakeController,
       TokenController, TransactionController, UsernameController, VmQueryController, WaitingListController,
       HealthCheckController, DappConfigController, WebsocketController, TransferController,
-      ProcessNftsPublicController, TransactionsBatchController,
+      ProcessNftsPublicController, TransactionsBatchController, ApplicationController,
     ];
 
     const isMarketplaceFeatureEnabled = configuration().features?.marketplace?.enabled ?? false;

--- a/src/endpoints/endpoints.services.module.ts
+++ b/src/endpoints/endpoints.services.module.ts
@@ -34,6 +34,7 @@ import { WaitingListModule } from "./waiting-list/waiting.list.module";
 import { WebsocketModule } from "./websocket/websocket.module";
 import { PoolModule } from "./pool/pool.module";
 import { TpsModule } from "./tps/tps.module";
+import { ApplicationModule } from "./applications/application.module";
 
 @Module({
   imports: [
@@ -73,13 +74,14 @@ import { TpsModule } from "./tps/tps.module";
     NftMarketplaceModule,
     TransactionsBatchModule,
     TpsModule,
+    ApplicationModule,
   ],
   exports: [
     AccountModule, CollectionModule, BlockModule, DelegationModule, DelegationLegacyModule, IdentitiesModule, KeysModule,
     MiniBlockModule, NetworkModule, NftModule, NftMediaModule, TagModule, NodeModule, ProviderModule,
     RoundModule, SmartContractResultModule, ShardModule, StakeModule, TokenModule, RoundModule, TransactionModule, UsernameModule, VmQueryModule,
     WaitingListModule, EsdtModule, BlsModule, DappConfigModule, TransferModule, PoolModule, TransactionActionModule, WebsocketModule, MexModule,
-    ProcessNftsModule, NftMarketplaceModule, TransactionsBatchModule, TpsModule,
+    ProcessNftsModule, NftMarketplaceModule, TransactionsBatchModule, TpsModule, ApplicationModule,
   ],
 })
 export class EndpointsServicesModule { }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -2061,6 +2061,12 @@ type MexPair {
   """Mex pair exchange details."""
   exchange: String
 
+  """Has dual farm pair details."""
+  hasDualFarms: Boolean
+
+  """Has farm pair details."""
+  hasFarms: Boolean
+
   """Id details."""
   id: String!
 
@@ -2093,6 +2099,9 @@ type MexPair {
 
   """Total value details."""
   totalValue: String!
+
+  """Pair trades count details."""
+  tradesCount: Float
 
   """Mex pair type details."""
   type: MexPairType!

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -664,4 +664,11 @@ export class CacheInfo {
     key: 'validatorAuctions',
     ttl: Constants.oneHour(),
   };
+
+  static Applications(queryPagination: QueryPagination): CacheInfo {
+    return {
+      key: `applications:${queryPagination.from}:${queryPagination.size}`,
+      ttl: Constants.oneHour(),
+    };
+  }
 }


### PR DESCRIPTION
  
## Proposed Changes
- Created a new endpoint called `applications` to be able to return all deployed smart contracts details 
- Created a new endpoint called `applications/count` to be able to return total deployed smart contracts 
- All applications are sorted by timestamp descending

## How to test
- `/applications` -> should return a list of smart contracts
- `/applications?size=10` -> should return a list of 10 smart contracts
- `/applications?after=1716389130` -> should return only the smart contracts deployd after 1716389130 timestamp
- `/applications/count` -> should return total smart contracts count
