### PR TITLE
Default pagination for auction list

### DIFF
--- a/src/endpoints/nodes/node.controller.ts
+++ b/src/endpoints/nodes/node.controller.ts
@@ -146,7 +146,7 @@ export class NodeController {
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   async getNodesAuctions(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
-    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('size', new DefaultValuePipe(10000), ParseIntPipe) size: number,
     @Query('sort', new ParseEnumPipe(NodeSortAuction)) sort?: NodeSortAuction,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<NodeAuction[]> {


### PR DESCRIPTION
## Proposed Changes
- Apply a default pagination of 10000 entries for the nodes/auctions endpoint

## How to test
- The `nodes/auctions` endpoint should return all auctions if no size is specified
