### PR TITLE
Improved caching for validator auctions

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -221,7 +221,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
   async getTransaction(txHash: string): Promise<any> {
     const transaction = await this.elasticService.getItem('operations', 'txHash', txHash);
-    if (transaction.type !== 'normal') {
+    if (transaction?.type !== 'normal') {
       return undefined;
     }
 
@@ -236,7 +236,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
   async getScResult(scHash: string): Promise<any> {
     const result = await this.elasticService.getItem('operations', 'hash', scHash);
-    if (result.type !== 'unsigned') {
+    if (result?.type !== 'unsigned') {
       return undefined;
     }
 


### PR DESCRIPTION
## Proposed Changes
- Return from the cache if the remotely fetched validator auctions are less than 80% of what's in the cache
- The proxified endpoint `/validator/auction` returns primarily from the cache in order to alleviate access to the gateway

## How to test
- if the gateway returns less than 80% of the auctions that are in the cache, still return them from the cache
- make sure that the proxified endpoint validator auction always returns from the cache and does not perform requests to the gateway
