### PR TITLE
Load smart contract result in transaction endpoint, do not fail if esdt loading failed

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -221,9 +221,9 @@ export class ElasticIndexerService implements IndexerInterface {
 
   async getTransaction(txHash: string): Promise<any> {
     const transaction = await this.elasticService.getItem('operations', 'txHash', txHash);
-    if (transaction?.type !== 'normal') {
-      return undefined;
-    }
+    // if (transaction?.type !== 'normal') {
+    //   return undefined;
+    // }
 
     this.processTransaction(transaction);
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -221,9 +221,6 @@ export class ElasticIndexerService implements IndexerInterface {
 
   async getTransaction(txHash: string): Promise<any> {
     const transaction = await this.elasticService.getItem('operations', 'txHash', txHash);
-    // if (transaction?.type !== 'normal') {
-    //   return undefined;
-    // }
 
     this.processTransaction(transaction);
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -32,18 +32,24 @@ export class EsdtService {
   ) { }
 
   async getEsdtTokenProperties(identifier: string): Promise<TokenProperties | undefined> {
-    const properties = await this.cachingService.getOrSet(
-      CacheInfo.EsdtProperties(identifier).key,
-      async () => await this.getEsdtTokenPropertiesRaw(identifier),
-      Constants.oneWeek(),
-      CacheInfo.EsdtProperties(identifier).ttl
-    );
+    try {
+      const properties = await this.cachingService.getOrSet(
+        CacheInfo.EsdtProperties(identifier).key,
+        async () => await this.getEsdtTokenPropertiesRaw(identifier),
+        Constants.oneWeek(),
+        CacheInfo.EsdtProperties(identifier).ttl
+      );
 
-    if (!properties) {
+      if (!properties) {
+        return undefined;
+      }
+
+      return properties;
+    } catch (error) {
+      this.logger.error(`Error when getting esdt token properties for identifier: ${identifier}`);
+      this.logger.error(error);
       return undefined;
     }
-
-    return properties;
   }
 
   async getCollectionProperties(identifier: string): Promise<TokenProperties | undefined> {

--- a/src/endpoints/sc-results/scresult.service.ts
+++ b/src/endpoints/sc-results/scresult.service.ts
@@ -8,9 +8,12 @@ import { TransactionType } from "../transactions/entities/transaction.type";
 import { TransactionActionService } from "../transactions/transaction-action/transaction.action.service";
 import { SmartContractResult } from "./entities/smart.contract.result";
 import { SmartContractResultFilter } from "./entities/smart.contract.result.filter";
+import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 
 @Injectable()
 export class SmartContractResultService {
+  private readonly logger = new OriginLogger(SmartContractResultService.name);
+
   constructor(
     private readonly indexerService: IndexerService,
     @Inject(forwardRef(() => TransactionActionService))
@@ -28,7 +31,12 @@ export class SmartContractResultService {
       const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
       transaction.type = TransactionType.SmartContractResult;
 
-      smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+      try {
+        smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+      } catch (error) {
+        this.logger.error(`Failed to get transaction action for smart contract result with hash '${smartContractResult.hash}'`);
+        this.logger.error(error);
+      }
 
       smartContractResult.senderAssets = accountAssets[smartContractResult.sender];
       smartContractResult.receiverAssets = accountAssets[smartContractResult.receiver];
@@ -47,7 +55,12 @@ export class SmartContractResultService {
     const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
     transaction.type = TransactionType.SmartContractResult;
 
-    smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+    try {
+      smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+    } catch (error) {
+      this.logger.error(`Failed to get transaction action for smart contract result with hash '${smartContractResult.hash}'`);
+      this.logger.error(error);
+    }
 
     return smartContractResult;
   }
@@ -65,7 +78,12 @@ export class SmartContractResultService {
       const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
       transaction.type = TransactionType.SmartContractResult;
 
-      smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+      try {
+        smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+      } catch (error) {
+        this.logger.error(`Failed to get transaction action for smart contract result with hash '${smartContractResult.hash}'`);
+        this.logger.error(error);
+      }
     }
 
     return smartContractResults;


### PR DESCRIPTION
## Proposed Changes
- Added possibility of loading a transaction even if a smart contract result hash is provided
- if esdt loading fails with hard error, just return it as undefined
- loading of smart contract action with try/catch so it doesn't fail the loading of the whole entry

## How to test
- test loading of a sovereign chain scr as if it was a transaction and make sure it doesn't fail
