### PR TITLE
Fixed original tx hashes query

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -496,7 +496,6 @@ export class ElasticIndexerService implements IndexerInterface {
     const nonce: ElasticSortProperty = { name: 'nonce', order: sortOrder };
 
     const elasticQuery = this.indexerHelper.buildTransactionFilterQuery(filter, address)
-      .withMustMatchCondition('type', 'normal')
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
 
@@ -587,7 +586,7 @@ export class ElasticIndexerService implements IndexerInterface {
       .withMustMatchCondition('type', 'unsigned')
       .withPagination({ from: 0, size: 10000 })
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.ascending }])
-      .withTerms(new TermsQuery('originalTxHash', hashes));
+      .withMustMultiShouldCondition(hashes, hash => QueryType.Match('originalTxHash', hash));
 
     return await this.elasticService.getList('operations', 'scHash', elasticQuery);
   }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -521,7 +521,7 @@ export class TransactionService {
 
       const senderBlockHashes: string[] = miniBlocks.map(x => x.senderBlockHash);
       const receiverBlockHashes: string[] = miniBlocks.map(x => x.receiverBlockHash);
-      const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].distinct();
+      const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].distinct().filter(x => x);
 
       const blocks = await this.indexerService.getBlocks({ hashes: blockHashes }, { from: 0, size: blockHashes.length });
       const indexedBlocks = blocks.toRecord<Block>(x => x.hash);


### PR DESCRIPTION
## Proposed Changes
- When fetching transactions with originalTxHashes parameter, an internal ES error appeared

## How to test (devnet)
- `/transactions?hashes=ffd1417ee22f55803fe3c0b8134ca65067fd21ef5f0dafca73ea71be09befc77&withScResults=true` should not crash
