### PR TITLE
Fix transactions queries

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -496,7 +496,6 @@ export class ElasticIndexerService implements IndexerInterface {
     const nonce: ElasticSortProperty = { name: 'nonce', order: sortOrder };
 
     const elasticQuery = this.indexerHelper.buildTransactionFilterQuery(filter, address)
-      .withMustMatchCondition('type', 'normal')
       .withPagination({ from: pagination.from, size: pagination.size })
       .withSort([timestamp, nonce]);
 
@@ -587,7 +586,7 @@ export class ElasticIndexerService implements IndexerInterface {
       .withMustMatchCondition('type', 'unsigned')
       .withPagination({ from: 0, size: 10000 })
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.ascending }])
-      .withTerms(new TermsQuery('originalTxHash', hashes));
+      .withMustMultiShouldCondition(hashes, hash => QueryType.Match('originalTxHash', hash));
 
     return await this.elasticService.getList('operations', 'scHash', elasticQuery);
   }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -521,7 +521,7 @@ export class TransactionService {
 
       const senderBlockHashes: string[] = miniBlocks.map(x => x.senderBlockHash);
       const receiverBlockHashes: string[] = miniBlocks.map(x => x.receiverBlockHash);
-      const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].distinct();
+      const blockHashes = [...senderBlockHashes, ...receiverBlockHashes].distinct().filter(x => x);
 
       const blocks = await this.indexerService.getBlocks({ hashes: blockHashes }, { from: 0, size: blockHashes.length });
       const indexedBlocks = blocks.toRecord<Block>(x => x.hash);


### PR DESCRIPTION
## Proposed Changes
- Fixed elasticsearch queries that were throwing errors when using some more special arguments

## How to test
- `/transactions?withLogs=true` should not fail
- `/transactions?withOperations=true` should not fail
- `/transactions?withBlockInfo=true` should not fail
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85/transactions?withOperations=true&withLogs=true&withBlockInfo=true` -> should not fail
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85/transactions?withBlockInfo=true` -> should not fail
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85/transfers?withBlockInfo=true` -> should not fail