### PR TITLE
Add mex-pairs endpoint

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -63,7 +63,7 @@ export class MexController {
   }
 
   @Get("/mex-pairs")
-  @ApiOperation({ summary: 'xExchange pairs', description: 'Returns active liquidity pools available on xExchange' })
+  @ApiOperation({ summary: 'xExchange pairs', description: 'Returns active liquidity pools available on xExchange', deprecated: true })
   @ApiOkResponse({ type: [MexPair] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })

--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -62,6 +62,21 @@ export class MexController {
     return await this.mexPairsService.getMexPairs(from, size, filter);
   }
 
+  @Get("/mex-pairs")
+  @ApiOperation({ summary: 'xExchange pairs', description: 'Returns active liquidity pools available on xExchange' })
+  @ApiOkResponse({ type: [MexPair] })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'exchange', description: 'Filter by exchange', required: false, enum: MexPairExchange })
+  async getMexPairsTemp(
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('exchange', new ParseEnumPipe(MexPairExchange)) exchange?: MexPairExchange,
+  ): Promise<MexPair[]> {
+    const filter = new MexPairsFilter({ exchange });
+    return await this.mexPairsService.getMexPairs(from, size, filter);
+  }
+
   @Get("/mex/pairs/count")
   @ApiOperation({ summary: 'Maiar Exchange pairs count', description: 'Returns active liquidity pools count available on Maiar Exchange' })
   @ApiQuery({ name: 'exchange', description: 'Filter by exchange', required: false, enum: MexPairExchange })


### PR DESCRIPTION
## Reasoning
- coinmarketcap still uses the `mex-pairs` endpoint to fetch exchange pairs, so we have to maintain this for a while
  
## Proposed Changes
- add back the `/mex-pairs` endpoint

## How to test
- `/mex-pairs` should return the same data as `mex/pairs`
