### PR TITLE
add MetaESDT collection assets name

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -23,6 +23,7 @@ import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { TrieOperationsTimeoutError } from "./exceptions/trie.operations.timeout.error";
 import { CacheInfo } from "src/utils/cache.info";
+import { AssetsService } from "src/common/assets/assets.service";
 
 @Injectable()
 export class EsdtAddressService {
@@ -40,6 +41,7 @@ export class EsdtAddressService {
     private readonly nftExtendedAttributesService: NftExtendedAttributesService,
     @Inject(forwardRef(() => CollectionService))
     private readonly collectionService: CollectionService,
+    private readonly assetsService: AssetsService
   ) {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
   }
@@ -292,7 +294,13 @@ export class EsdtAddressService {
         nft.type = collectionDetails.type;
 
         if (nft.type === NftType.MetaESDT) {
+          const assets = await this.assetsService.getTokenAssets(nft.collection);
+          if (assets && assets.name) {
+            nft.name = assets.name;
+          }
+
           nft.decimals = collectionDetails.decimals;
+
           // @ts-ignore
           delete nft.royalties;
           // @ts-ignore

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -336,8 +336,6 @@ export class EsdtAddressService {
         }
       }
 
-
-
       return false;
     });
 


### PR DESCRIPTION
## Proposed Changes
- Override old value for MetaESDT token.name with new value from token assets if exist

## How to test
- `tokens/XMEX-82f2f4` -> MetaESDT should have name: "xMEX"
- `accounts/erd1x39tc3q3nn72ecjnmcz7x0qp09kp97t080x99dgyhx7zh95j0n4szskhlv/nfts?type=MetaESDT&collections=XMEX-82f2f4` -> every collection should have name: "xMex" retrieve from assets