### PR TITLE
Remove caching and validation of validator auctions

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -383,28 +383,13 @@ export class NodeService {
     await this.applyNodeStakeInfo(nodes);
 
     if (this.apiConfigService.isStakingV4Enabled()) {
-      const auctions = await this.getValidatorAuctions();
+      const auctions = await this.gatewayService.getValidatorAuctions();
       await this.processAuctions(nodes, auctions);
     }
 
     await this.applyNodeUnbondingPeriods(nodes);
 
     return nodes;
-  }
-
-  async getValidatorAuctions(): Promise<Auction[]> {
-    const auctionsFromCache = await this.cacheService.getRemote<Auction[]>(CacheInfo.ValidatorAuctions.key) ?? [];
-
-    const auctions = await this.gatewayService.getValidatorAuctions();
-    if (auctions.length === 0 || auctions.length < auctionsFromCache.length * 0.8) {
-      this.logger.log(`Auctions array of ${auctions.length} returned. Using cache.`);
-      return auctionsFromCache;
-    }
-
-    this.logger.log(`Auctions array of ${auctions.length} returned. Using remote.`);
-    await this.cacheService.setRemote(CacheInfo.ValidatorAuctions.key, auctions, CacheInfo.ValidatorAuctions.ttl);
-
-    return auctions;
   }
 
   async processAuctions(nodes: Node[], auctions: Auction[]) {

--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -280,16 +280,6 @@ export class GatewayProxyController {
   @NoCache()
   async getValidatorAuction(@Res() res: Response) {
     try {
-      const auctions = await this.cachingService.getRemote<Auction[]>(CacheInfo.ValidatorAuctions.key);
-      if (auctions) {
-        res.type('application/json').send({
-          data: {
-            auctionList: auctions,
-          },
-        });
-        return;
-      }
-
       const result = await this.gatewayService.getRaw('validator/auction', GatewayComponentRequest.validatorAuction);
 
       res.type('application/json').send(result.data);

--- a/src/endpoints/stake/stake.service.ts
+++ b/src/endpoints/stake/stake.service.ts
@@ -73,7 +73,7 @@ export class StakeService {
       });
     }
 
-    const auctions = await this.nodeService.getValidatorAuctions();
+    const auctions = await this.gatewayService.getValidatorAuctions();
     const minimumAuctionQualifiedTopUp = this.getMinimumAuctionTopUp(auctions);
     const minimumAuctionQualifiedStake = this.getMinimumAuctionStake(auctions);
     const auctionValidators = await this.nodeService.getNodeCount(new NodeFilter({ auctioned: true }));


### PR DESCRIPTION
## Proposed Changes
- Remove the caching mechanism and validation for auctions to address the issue of partial auctions being returned by the gateway

## How to test
- `/validator/auctions` should always fetch the data from the gateway without intermediate caching
- `/nodes/auctions` should process the validator auctions without caching and validation in the code
