### PR TITLE
add support for mex - pair/token extra fields

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from "@nestjs/graphql";
+import { Field, Float, ObjectType } from "@nestjs/graphql";
 import { ApiProperty } from "@nestjs/swagger";
 import { MexPairState } from "./mex.pair.state";
 import { MexPairType } from "./mex.pair.type";
@@ -37,6 +37,14 @@ export class MexPair {
   @Field(() => Number, { description: "Mex token quotePrevious24hPrice equivalent" })
   @ApiProperty()
   quotePrevious24hPrice: number = 0;
+
+  @Field(() => Number, { description: "Mex token basePrevious24hVolume equivalent" })
+  @ApiProperty()
+  basePrevious24hVolume: number = 0;
+
+  @Field(() => Number, { description: "Mex token quotePrevious24hVolume equivalent" })
+  @ApiProperty()
+  quotePrevious24hVolume: number = 0;
 
   @Field(() => String, { description: "Base id details." })
   @ApiProperty({ type: String, example: 'MEX-455c57' })
@@ -89,4 +97,20 @@ export class MexPair {
   @Field(() => String, { description: "Mex pair exchange details.", nullable: true })
   @ApiProperty({ type: String, example: 'jungledex' })
   exchange: MexPairExchange | undefined;
+
+  @Field(() => Boolean, { description: "Mex pair has farm details.", nullable: true })
+  @ApiProperty({ type: Boolean, example: false })
+  hasFarms: boolean | undefined;
+
+  @Field(() => Boolean, { description: "Mex pair has dual farm details.", nullable: true })
+  @ApiProperty({ type: Boolean, example: false })
+  hasDualFarms: boolean | undefined;
+
+  @Field(() => Float, { description: "Mex pair total trades count.", nullable: true })
+  @ApiProperty({ type: Number, example: 10000 })
+  tradesCount: number | undefined;
+
+  @Field(() => Float, { description: "Mex pair deployed at details.", nullable: true })
+  @ApiProperty({ type: Number, example: 1695041576 })
+  deployedAt: number | undefined;
 }

--- a/src/endpoints/mex/entities/mex.token.ts
+++ b/src/endpoints/mex/entities/mex.token.ts
@@ -25,4 +25,8 @@ export class MexToken {
   @Field(() => Float, { description: "Mex token previous24hPrice." })
   @ApiProperty({ type: Number, example: 0.000206738758250580 })
   previous24hPrice: number = 0;
+
+  @Field(() => Float, { description: "Mex token previous24hVolume." })
+  @ApiProperty({ type: Number, example: "333.92640815109234316268" })
+  previous24hVolume: number = 0;
 }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -100,6 +100,7 @@ export class MexPairService {
               identifier
               decimals
               previous24hPrice
+              previous24hVolume
               __typename
             }
             secondToken {
@@ -107,6 +108,7 @@ export class MexPairService {
               identifier
               decimals
               previous24hPrice
+              previous24hVolume
               __typename
             }
             firstTokenPrice
@@ -123,6 +125,10 @@ export class MexPairService {
             type
             lockedValueUSD
             volumeUSD24h
+            hasFarms
+            hasDualFarms
+            tradesCount
+            deployedAt
             __typename
           }
         }
@@ -174,7 +180,9 @@ export class MexPairService {
         name: pair.liquidityPoolToken.name,
         price: Number(pair.liquidityPoolTokenPriceUSD),
         basePrevious24hPrice: Number(pair.firstToken.previous24hPrice),
+        basePrevious24hVolume: Number(pair.firstToken.previous24hVolume),
         quotePrevious24hPrice: Number(pair.secondToken.previous24hPrice),
+        quotePrevious24hVolume: Number(pair.secondToken.previous24hVolume),
         baseId: pair.firstToken.identifier,
         basePrice: Number(pair.firstTokenPriceUSD),
         baseSymbol: firstTokenSymbol,
@@ -188,6 +196,10 @@ export class MexPairService {
         state,
         type,
         exchange,
+        hasFarms: pair.hasFarms,
+        hasDualFarms: pair.hasDualFarms,
+        tradesCount: pair.tradesCount,
+        deployedAt: pair.deployedAt,
       };
     }
 
@@ -198,7 +210,9 @@ export class MexPairService {
       name: pair.liquidityPoolToken.name,
       price: Number(pair.liquidityPoolTokenPriceUSD),
       basePrevious24hPrice: Number(pair.secondToken.previous24hPrice),
+      basePrevious24hVolume: Number(pair.firstToken.previous24hVolume),
       quotePrevious24hPrice: Number(pair.firstToken.previous24hPrice),
+      quotePrevious24hVolume: Number(pair.secondToken.previous24hVolume),
       baseId: pair.secondToken.identifier,
       basePrice: Number(pair.secondTokenPriceUSD),
       baseSymbol: secondTokenSymbol,
@@ -212,6 +226,10 @@ export class MexPairService {
       state,
       type,
       exchange,
+      hasFarms: pair.hasFarms,
+      hasDualFarms: pair.hasDualFarms,
+      tradesCount: pair.tradesCount,
+      deployedAt: pair.deployedAt,
     };
   }
 

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -175,6 +175,7 @@ export class MexTokenService {
         wegldToken.name = pair.baseName;
         wegldToken.price = pair.basePrice;
         wegldToken.previous24hPrice = pair.basePrevious24hPrice;
+        wegldToken.previous24hVolume = pair.basePrevious24hVolume;
         mexTokens.push(wegldToken);
       }
 
@@ -197,6 +198,7 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
+        previous24hVolume: pair.quotePrevious24hVolume,
       };
     }
 
@@ -207,6 +209,7 @@ export class MexTokenService {
         name: pair.baseName,
         price: pair.basePrice,
         previous24hPrice: pair.basePrevious24hPrice,
+        previous24hVolume: pair.basePrevious24hVolume,
       };
     }
 
@@ -217,6 +220,7 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
+        previous24hVolume: pair.quotePrevious24hVolume,
       };
     }
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -2052,14 +2052,26 @@ type MexPair {
   """Mex token basePrevious24hPrice equivalent"""
   basePrevious24hPrice: Float!
 
+  """Mex token basePrevious24hVolume equivalent"""
+  basePrevious24hVolume: Float!
+
   """Base price details."""
   basePrice: String!
 
   """Base symbol details."""
   baseSymbol: String!
 
+  """Mex pair deployed at details."""
+  deployedAt: Float
+
   """Mex pair exchange details."""
   exchange: String
+
+  """Mex pair has dual farm details."""
+  hasDualFarms: Boolean
+
+  """Mex pair has farm details."""
+  hasFarms: Boolean
 
   """Id details."""
   id: String!
@@ -2079,6 +2091,9 @@ type MexPair {
   """Mex token quotePrevious24hPrice equivalent"""
   quotePrevious24hPrice: Float!
 
+  """Mex token quotePrevious24hVolume equivalent"""
+  quotePrevious24hVolume: Float!
+
   """Quote price details."""
   quotePrice: String!
 
@@ -2093,6 +2108,9 @@ type MexPair {
 
   """Total value details."""
   totalValue: String!
+
+  """Mex pair total trades count."""
+  tradesCount: Float
 
   """Mex pair type details."""
   type: MexPairType!
@@ -2144,6 +2162,9 @@ type MexToken {
 
   """Mex token previous24hPrice."""
   previous24hPrice: Float!
+
+  """Mex token previous24hVolume."""
+  previous24hVolume: Float!
 
   """Mex token current price."""
   price: Float!


### PR DESCRIPTION
## Reasoning
- new fields are available on xexchange service
  
## Proposed Changes
- added `hasFarms` `hasDualFarms` `tradesCount` `deployedAt` `basePrevious24hVolume` `quotePrevious24hVolume` pair fields
- added `previous24hVolume` mex token field

## How to test
- `mex/tokens` -> should return `previous24hVolume`
- `mex/pairs` -> `hasFarms` `hasDualFarms` `tradesCount` `deployedAt` `basePrevious24hVolume` `quotePrevious24hVolume` should be defined
