### PR TITLE
include transaction results if has operation

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -577,7 +577,10 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResultsForTransactions(elasticTransactions: any[]): Promise<any[]> {
-    const hashes = elasticTransactions.filter(x => x.hasScResults === true).map(x => x.txHash);
+    const hashes = elasticTransactions
+      .filter(x => x.hasOperations === true || x.hasScResults === true)
+      .map(x => x.txHash);
+
     if (hashes.length === 0) {
       return [];
     }

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -81,7 +81,8 @@ export class TransactionGetService {
       hashes.push(txHash);
       const previousHashes: Record<string, string> = {};
 
-      if (transaction.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
+      if (transaction.hasScResults === true || transaction.hasOperations === true &&
+        (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
         transactionDetailed.results = await this.getTransactionScResultsFromElastic(transactionDetailed.txHash);
 
         for (const scResult of transactionDetailed.results) {


### PR DESCRIPTION
## Reasoning
- if in elastic `hasResults` flag is undefined, even if for transaction exist sc results, `results` field in API is not defined
  
## Proposed Changes
- include also condition for `hasOperations` flag to retrieve the results 


## How to test
- `transactions/10634f5ad92f54d944a42a65dfe10a2b1d59dfb8f72a713668e299ad24ec3f79` -> `results` field should be defined
- `transactions?hashes=10634f5ad92f54d944a42a65dfe10a2b1d59dfb8f72a713668e299ad24ec3f79&withScResults=true` -> `results` field should be defined
