### PR TITLE
include additional data field for operations

### DIFF
--- a/src/common/gateway/entities/transaction.ts
+++ b/src/common/gateway/entities/transaction.ts
@@ -24,6 +24,7 @@ export class Transaction {
   gasUsed: number = 0;
   fee: number = 0;
   data: string = '';
+  additionalData: string[] = [];
   status: string = '';
   signature: string = '';
   sourceShard: number = 0;

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -152,6 +152,9 @@ export class TokenTransferService {
         }
 
         if (operation) {
+          if (event.additionalData) {
+            operation.additionalData = event.additionalData;
+          }
           operations.push(operation);
         }
       }

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -152,9 +152,7 @@ export class TokenTransferService {
         }
 
         if (operation) {
-          if (event.additionalData) {
-            operation.additionalData = event.additionalData;
-          }
+          operation.additionalData = event.additionalData;
           operations.push(operation);
         }
       }

--- a/src/endpoints/transactions/entities/transaction.log.event.ts
+++ b/src/endpoints/transactions/entities/transaction.log.event.ts
@@ -30,5 +30,5 @@ export class TransactionLogEvent {
 
   @Field(() => String, { description: 'Additional data for the given transaction log event.', nullable: true })
   @ApiProperty()
-  additionalData: string[] = [];
+  additionalData: string[] | undefined = undefined;
 }

--- a/src/endpoints/transactions/entities/transaction.log.event.ts
+++ b/src/endpoints/transactions/entities/transaction.log.event.ts
@@ -27,4 +27,8 @@ export class TransactionLogEvent {
   @Field(() => String, { description: 'Data for the given transaction log event.', nullable: true })
   @ApiProperty()
   data: string = '';
+
+  @Field(() => String, { description: 'Additional data for the given transaction log event.', nullable: true })
+  @ApiProperty()
+  additionalData: string[] = [];
 }

--- a/src/endpoints/transactions/entities/transaction.operation.ts
+++ b/src/endpoints/transactions/entities/transaction.operation.ts
@@ -75,6 +75,10 @@ export class TransactionOperation {
   @ApiProperty({ type: String, nullable: true })
   data?: string;
 
+  @Field(() => String, { description: 'Additional data for the given transaction operation.', nullable: true })
+  @ApiProperty()
+  additionalData?: string[] = [];
+
   @Field(() => String, { description: 'Message for the transaction operation.', nullable: true })
   @ApiProperty({ type: String, nullable: true })
   message?: string;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -4201,6 +4201,9 @@ type TransactionLog {
 
 """Transaction log event object type."""
 type TransactionLogEvent {
+  """Additional data for the given transaction log event."""
+  additionalData: String
+
   """Address for the given transaction log event."""
   address: String!
 
@@ -4221,6 +4224,9 @@ type TransactionLogEvent {
 type TransactionOperation {
   """Transaction operation action for the transaction operation."""
   action: TransactionOperationAction!
+
+  """Additional data for the given transaction log event."""
+  additionalData: String
 
   """Collection for the transaction operation."""
   collection: String

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -4225,7 +4225,7 @@ type TransactionOperation {
   """Transaction operation action for the transaction operation."""
   action: TransactionOperationAction!
 
-  """Additional data for the given transaction log event."""
+  """Additional data for the given transaction operation."""
   additionalData: String
 
   """Collection for the transaction operation."""

--- a/src/test/unit/utils/transaction.utils.spec.ts
+++ b/src/test/unit/utils/transaction.utils.spec.ts
@@ -224,6 +224,7 @@ describe('Transaction Utils', () => {
       receiverAssets: undefined,
       senderAssets: undefined,
       ticker: "",
+      additionalData: [],
     });
   });
 });


### PR DESCRIPTION
## Reasoning
- gateway introduced a new field called `additionalData` for transactions
  
## Proposed Changes
- for every transactions include also the `additionalData` field which is and array of base64 strings 

## How to test
- `transactions/ef9bbb5e7f49c799108c5c49c1298c873f667e0f8bb2d93828c65d74877e3276` -> check if in operations `additionalData` is defined
- `transactions?hashes=ef9bbb5e7f49c799108c5c49c1298c873f667e0f8bb2d93828c65d74877e3276&withOperations=true` -> check as above