### PR TITLE
add support for identitites stake sort query pagination

### DIFF
--- a/src/endpoints/identities/entities/identity.sort.criteria.ts
+++ b/src/endpoints/identities/entities/identity.sort.criteria.ts
@@ -1,3 +1,4 @@
 export enum IdentitySortCriteria {
     validators = 'validators',
+    stake = 'stake'
 }

--- a/src/graphql/entities/identities/identities.query.ts
+++ b/src/graphql/entities/identities/identities.query.ts
@@ -2,6 +2,7 @@ import { Args, Query, Resolver } from "@nestjs/graphql";
 import { Identity } from "src/endpoints/identities/entities/identity";
 import { IdentitiesService } from "src/endpoints/identities/identities.service";
 import { GetIndentityInput } from "./identities.input";
+import { QueryPagination } from "src/common/entities/query.pagination";
 
 @Resolver()
 export class IdentityQuery {
@@ -9,7 +10,7 @@ export class IdentityQuery {
 
   @Query(() => [Identity], { name: "identity", description: `Retrieve list of all node identities, used to group nodes by the same entity. "Free-floating" nodes that do not belong to any identity will also be returned` })
   public async getIdentity(@Args("input", { description: "." }) input: GetIndentityInput): Promise<Identity[]> {
-    return await this.identitiesService.getIdentities(GetIndentityInput.resolve(input));
+    return await this.identitiesService.getIdentities(new QueryPagination(), GetIndentityInput.resolve(input));
   }
 
   @Query(() => [Identity], { name: "identities", description: `Retrieve list of all node identities, used to group nodes by the same entity. "Free-floating" nodes that do not belong to any identity will also be returned`, nullable: true })


### PR DESCRIPTION
 
## Proposed Changes
- added support for identities query pagination ( from , size )
- added support for stake sorting criteria
- sort identities by validators instead of locked value

## How to test
- `/identities?size=2` -> should return 2 identities
- `/identities` -> should return all available identities
- `/identities?sort=stake&order=desc` -> should sort all identities by stake ordered desc
