### PR TITLE
Optimize elastic calls when fetching NFT name in transaction operations

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -14,10 +14,6 @@ import { TransactionDetailed } from "../transactions/entities/transaction.detail
 import { BinaryUtils } from "@multiversx/sdk-nestjs-common";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
-import { QueryPagination } from "src/common/entities/query.pagination";
-import { NftFilter } from "../nfts/entities/nft.filter";
-import { IndexerService } from "src/common/indexer/indexer.service";
-import { TokenAccount } from "src/common/indexer/entities";
 
 @Injectable()
 export class TokenTransferService {
@@ -28,7 +24,6 @@ export class TokenTransferService {
     @Inject(forwardRef(() => EsdtService))
     private readonly esdtService: EsdtService,
     private readonly assetsService: AssetsService,
-    private readonly indexerService: IndexerService,
   ) { }
 
   getTokenTransfer(elasticTransaction: any): { tokenIdentifier: string, tokenAmount: string } | undefined {
@@ -153,18 +148,6 @@ export class TokenTransferService {
 
         if (operation) {
           operations.push(operation);
-        }
-      }
-    }
-
-    const distinctNftIdentifiers = operations.filter(x => x.type === TransactionOperationType.nft).map(x => x.identifier).distinct();
-    if (distinctNftIdentifiers.length > 0) {
-      const elasticNfts = await this.indexerService.getNfts(new QueryPagination({ from: 0, size: distinctNftIdentifiers.length }), new NftFilter({ identifiers: distinctNftIdentifiers }));
-      const elasticNftsDict = elasticNfts.toRecord<TokenAccount>(x => x.identifier);
-
-      for (const operation of operations) {
-        if (elasticNftsDict[operation.identifier]) {
-          operation.name = elasticNftsDict[operation.identifier].data?.name ?? operation.name;
         }
       }
     }

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -16,6 +16,10 @@ import { MiniBlockType } from "../miniblocks/entities/mini.block.type";
 import { TransactionStatus } from "./entities/transaction.status";
 import { UsernameUtils } from "../usernames/username.utils";
 import { TransactionLogEvent } from "./entities/transaction.log.event";
+import { TransactionOperationType } from "./entities/transaction.operation.type";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { NftFilter } from "../nfts/entities/nft.filter";
+import { TokenAccount } from "src/common/indexer/entities";
 
 @Injectable()
 export class TransactionGetService {
@@ -123,6 +127,7 @@ export class TransactionGetService {
       }
 
       this.applyUsernamesToDetailedTransaction(transaction, transactionDetailed);
+      await this.applyNftNameOnTransactionOperations([transactionDetailed]);
 
       return ApiUtils.mergeObjects(new TransactionDetailed(), transactionDetailed);
     } catch (error) {
@@ -246,6 +251,22 @@ export class TransactionGetService {
     } catch (error) {
       this.logger.error(error);
       return null;
+    }
+  }
+
+  async applyNftNameOnTransactionOperations(transactions: TransactionDetailed[]): Promise<void> {
+    const operations = transactions.selectMany(x => x.operations ?? []);
+
+    const distinctNftIdentifiers = operations.filter(x => x.type === TransactionOperationType.nft).map(x => x.identifier).distinct();
+    if (distinctNftIdentifiers.length > 0) {
+      const elasticNfts = await this.indexerService.getNfts(new QueryPagination({ from: 0, size: distinctNftIdentifiers.length }), new NftFilter({ identifiers: distinctNftIdentifiers }));
+      const elasticNftsDict = elasticNfts.toRecord<TokenAccount>(x => x.identifier);
+
+      for (const operation of operations) {
+        if (elasticNftsDict[operation.identifier]) {
+          operation.name = elasticNftsDict[operation.identifier].data?.name ?? operation.name;
+        }
+      }
     }
   }
 }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -424,6 +424,8 @@ export class TransactionService {
       detailedTransactions.push(transactionDetailed);
     }
 
+    await this.transactionGetService.applyNftNameOnTransactionOperations(detailedTransactions);
+
     return detailedTransactions;
   }
 
@@ -488,6 +490,8 @@ export class TransactionService {
         operations.push(undefined);
       }
     }
+
+    await this.transactionGetService.applyNftNameOnTransactionOperations(transactions);
 
     return operations;
   }


### PR DESCRIPTION
## Reasoning
- Too many requests were performed on the ES for fetching NFT names, namely for every transaction that transferred NFTs, a separate ES query was made, thus potentially overloading the ES with a lot of queries on each api call that had the `withOperations=true` parameter activated
  
## Proposed Changes
- perform the fetching of NFT names as a batch for all transactions, not each individual one, thus optimizing the number of round-trips with ES

## How to test
- `/accounts/erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8/transactions?function=bulkBuy&withOperations=true&withLogs=true&withScResults=true&size=50` should perform only one round-trip to ES to fetch NFT names
