### PR TITLE
Add mex pairs endpoint

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -62,6 +62,21 @@ export class MexController {
     return await this.mexPairsService.getMexPairs(from, size, filter);
   }
 
+  @Get("/mex-pairs")
+  @ApiOperation({ summary: 'xExchange pairs', description: 'Returns active liquidity pools available on xExchange' })
+  @ApiOkResponse({ type: [MexPair] })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'exchange', description: 'Filter by exchange', required: false, enum: MexPairExchange })
+  async getMexPairsTemp(
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('exchange', new ParseEnumPipe(MexPairExchange)) exchange?: MexPairExchange,
+  ): Promise<MexPair[]> {
+    const filter = new MexPairsFilter({ exchange });
+    return await this.mexPairsService.getMexPairs(from, size, filter);
+  }
+
   @Get("/mex/pairs/count")
   @ApiOperation({ summary: 'Maiar Exchange pairs count', description: 'Returns active liquidity pools count available on Maiar Exchange' })
   @ApiQuery({ name: 'exchange', description: 'Filter by exchange', required: false, enum: MexPairExchange })


### PR DESCRIPTION
## Proposed Changes
- In order to still accomodate coinmarketcap requirements, we added back the `/mex-pairs` endpoint, which was deprecated earlier and removed

## How to test
- the `/mex-pairs` endpoint should return the same data as `/mex/pairs`
