### PR TITLE
fetch ownerBelowRequiredBalanceThreshold from delegation providers

### DIFF
--- a/src/endpoints/providers/entities/delegation.data.ts
+++ b/src/endpoints/providers/entities/delegation.data.ts
@@ -12,4 +12,5 @@ export class DelegationData {
   checkCapOnRedelegate: boolean = false;
   totalUnStaked: string = "";
   createdNonce: number = 0;
+  ownerBelowRequiredBalanceThreshold: boolean = false;
 }

--- a/src/endpoints/providers/entities/provider.ts
+++ b/src/endpoints/providers/entities/provider.ts
@@ -57,6 +57,9 @@ export class Provider extends NodesInfos {
   @ApiProperty({ type: Boolean, default: false })
   checkCapOnRedelegate: boolean | undefined = undefined;
 
+  @ApiProperty({ type: Boolean, default: false })
+  ownerBelowRequiredBalanceThreshold: boolean | undefined = undefined;
+
   @ApiProperty({ type: String })
   totalUnStaked: string | undefined = undefined;
 

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -51,6 +51,7 @@ export class ProviderService {
       modifiedProvider.checkCapOnRedelegate = delegationData.checkCapOnRedelegate;
       modifiedProvider.totalUnStaked = delegationData.totalUnStaked;
       modifiedProvider.createdNonce = delegationData.createdNonce;
+      modifiedProvider.ownerBelowRequiredBalanceThreshold = delegationData.ownerBelowRequiredBalanceThreshold;
 
       return modifiedProvider;
     }
@@ -131,6 +132,10 @@ export class ProviderService {
 
         if (delegationData.checkCapOnRedelegate) {
           element.checkCapOnRedelegate = delegationData.checkCapOnRedelegate;
+        }
+
+        if (delegationData.ownerBelowRequiredBalanceThreshold) {
+          element.ownerBelowRequiredBalanceThreshold = delegationData.ownerBelowRequiredBalanceThreshold;
         }
       }
 


### PR DESCRIPTION
## Reasoning
-`ownerBelowRequiredBalanceThreshold` field is available in delegation-api
  
## Proposed Changes
- fetch and apply `ownerBelowRequiredBalanceThreshold` for all providers if exist

## How to test ( devnet )
- `/providers` -> some providers should have `ownerBelowRequiredBalanceThreshold` defined
- `/providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqr8llllse9cj2t` -> should have `ownerBelowRequiredBalanceThreshold` defined
