### PR TITLE
Deep history block info caching

### DIFF
--- a/src/interceptors/deep-history.interceptor.ts
+++ b/src/interceptors/deep-history.interceptor.ts
@@ -64,8 +64,6 @@ export class DeepHistoryInterceptor implements NestInterceptor {
             response.setHeader('X-Deep-History-Block-Hash', blockInfo.hash);
             response.setHeader('X-Deep-History-Block-Nonce', blockInfo.nonce);
             response.setHeader('X-Deep-History-Block-RootHash', blockInfo.rootHash);
-
-            console.log(`Deep history timestamp: ${timestamp}, block nonce: ${blockNonce}, block hash: ${blockInfo.hash}, root hash: ${blockInfo.rootHash}`);
           }
         }),
         catchError((err) => {

--- a/src/interceptors/deep-history.interceptor.ts
+++ b/src/interceptors/deep-history.interceptor.ts
@@ -57,6 +57,8 @@ export class DeepHistoryInterceptor implements NestInterceptor {
             response.setHeader('X-Deep-History-Block-Hash', blockInfo.hash);
             response.setHeader('X-Deep-History-Block-Nonce', blockInfo.nonce);
             response.setHeader('X-Deep-History-Block-RootHash', blockInfo.rootHash);
+
+            console.log(`Deep history timestamp: ${timestamp}, block nonce: ${blockNonce}, block hash: ${blockInfo.hash}, root hash: ${blockInfo.rootHash}`);
           }
         }),
         catchError((err) => {

--- a/src/interceptors/deep-history.interceptor.ts
+++ b/src/interceptors/deep-history.interceptor.ts
@@ -1,4 +1,4 @@
-import { Constants, ContextTracker } from "@multiversx/sdk-nestjs-common";
+import { ContextTracker } from "@multiversx/sdk-nestjs-common";
 import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
 import { Observable, catchError, tap, throwError } from "rxjs";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
@@ -6,6 +6,7 @@ import { IndexerService } from "src/common/indexer/indexer.service";
 import { ProtocolService } from "src/common/protocol/protocol.service";
 import { Response } from 'express';
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
+import { CacheInfo } from "src/utils/cache.info";
 
 @Injectable()
 export class DeepHistoryInterceptor implements NestInterceptor {
@@ -41,9 +42,9 @@ export class DeepHistoryInterceptor implements NestInterceptor {
     }
 
     const block = await this.cacheService.getOrSet(
-      `deep-history-block-${timestamp}-${shardId}`,
+      CacheInfo.DeepHistoryBlock(timestamp, shardId).key,
       async () => await this.indexerService.getBlockByTimestampAndShardId(timestamp, shardId),
-      Constants.oneMinute() * 10,
+      CacheInfo.DeepHistoryBlock(timestamp, shardId).ttl,
     );
 
     if (!block) {

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -681,4 +681,11 @@ export class CacheInfo {
       ttl: Constants.oneHour(),
     };
   }
+
+  static DeepHistoryBlock(timestamp: number, shardId: number): CacheInfo {
+    return {
+      key: `deepHistoryBlock:${timestamp}:${shardId}`,
+      ttl: Constants.oneMinute() * 10,
+    };
+  }
 }


### PR DESCRIPTION
## Reasoning
- Because requests with block information might be performed with the same information, pressure on the ES could be alleviated by introducing an intermediate caching layer
  
## Proposed Changes
- use `getOrSetCache` when fetching block info based on timestamp and shard id in deep history interceptor

## How to test
- Perform multiple requests with deep history information but for the same shardId and timestamp, and verify that the number of requests to ES stays linear
