### PR TITLE
Update token.transfer.service.ts

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -339,9 +339,9 @@ export class TokenTransferService {
 
     const result: TokenTransferProperties = {
       type: properties.type,
-      name: assets ? assets.name : properties.name,
+      name: assets?.name ?? properties.name,
       ticker: assets ? identifier.split('-')[0] : identifier,
-      svgUrl: assets ? assets.svgUrl : '',
+      svgUrl: assets?.svgUrl ?? '',
     };
 
     if (properties.type === 'FungibleESDT') {

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -339,7 +339,7 @@ export class TokenTransferService {
 
     const result: TokenTransferProperties = {
       type: properties.type,
-      name: properties.name,
+      name: assets ? assets.name : properties.name,
       ticker: assets ? identifier.split('-')[0] : identifier,
       svgUrl: assets ? assets.svgUrl : '',
     };


### PR DESCRIPTION
## Proposed Changes
- try to fetch token name from token transfer action from assets ( if exist )


## How to test
- `accounts/erd1awuuva7dhnlun9huwx7uefwpkhzjx9d3phenujgkv3zvx9tvsatsw420qt/transfers?withUsername=true&size=50&from=0&withActionTransferValue=true&fields=gasLimit,gasPrice,gasUsed,sender,action,receiver,receiverAssets,receiverShard,senderShard,senderAssets,timestamp,txHash,data,value,function,status,fee&withLogs=true&withOperations=true` -> instead of UTrust name it should be xMoney UTK
