### PR TITLE
Optimize refresh time for delegation actions

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -156,6 +156,7 @@ export class CacheWarmerService {
     await this.invalidateKey(CacheInfo.AllEsdtTokens.key, tokens, CacheInfo.AllEsdtTokens.ttl);
   }
 
+  @Cron(CronExpression.EVERY_MINUTE)
   @Lock({ name: 'Identities invalidations', verbose: true })
   async handleIdentityInvalidations() {
     const identities = await this.identitiesService.getAllIdentitiesRaw();

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -45,11 +45,13 @@ export class TransactionProcessorService {
           const invalidatedTokenProperties = await this.tryInvalidateTokenProperties(transaction);
           const invalidatedOwnerKeys = await this.tryInvalidateOwner(transaction);
           const invalidatedCollectionPropertiesKeys = await this.tryInvalidateCollectionProperties(transaction);
+          const invalidatedStakeTopUpKey = this.tryInvalidateStakeTopup(transaction);
 
           allInvalidatedKeys.push(
             ...invalidatedTokenProperties,
             ...invalidatedOwnerKeys,
-            ...invalidatedCollectionPropertiesKeys
+            ...invalidatedCollectionPropertiesKeys,
+            ...invalidatedStakeTopUpKey,
           );
         }
 
@@ -130,5 +132,22 @@ export class TransactionProcessorService {
     }
 
     return [];
+  }
+
+  tryInvalidateStakeTopup(transaction: ShardTransaction): string[] {
+    if (!transaction.data) {
+      return [];
+    }
+
+    const transactionFuncName = transaction.getDataFunctionName();
+    if (!transactionFuncName) {
+      return [];
+    }
+
+    if (!['delegate', 'unDelegate', 'reDelegateRewards'].includes(transactionFuncName)) {
+      return [];
+    }
+
+    return [transaction.receiver];
   }
 }

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -148,6 +148,8 @@ export class TransactionProcessorService {
       return [];
     }
 
+    this.logger.log(`Detected stake topup transaction for address ${transaction.sender} with function '${transactionFuncName}'`);
+
     return [transaction.receiver];
   }
 }

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -150,6 +150,6 @@ export class TransactionProcessorService {
 
     this.logger.log(`Detected stake topup transaction for address ${transaction.sender} with function '${transactionFuncName}'`);
 
-    return [transaction.receiver];
+    return [CacheInfo.StakeTopup(transaction.receiver).key];
   }
 }

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -45,7 +45,7 @@ export class TransactionProcessorService {
           const invalidatedTokenProperties = await this.tryInvalidateTokenProperties(transaction);
           const invalidatedOwnerKeys = await this.tryInvalidateOwner(transaction);
           const invalidatedCollectionPropertiesKeys = await this.tryInvalidateCollectionProperties(transaction);
-          const invalidatedStakeTopUpKey = this.tryInvalidateStakeTopup(transaction);
+          const invalidatedStakeTopUpKey = await this.tryInvalidateStakeTopup(transaction);
 
           allInvalidatedKeys.push(
             ...invalidatedTokenProperties,
@@ -134,7 +134,7 @@ export class TransactionProcessorService {
     return [];
   }
 
-  tryInvalidateStakeTopup(transaction: ShardTransaction): string[] {
+  async tryInvalidateStakeTopup(transaction: ShardTransaction): Promise<string[]> {
     if (!transaction.data) {
       return [];
     }
@@ -148,7 +148,9 @@ export class TransactionProcessorService {
       return [];
     }
 
-    this.logger.log(`Detected stake topup transaction for address ${transaction.sender} with function '${transactionFuncName}'`);
+    this.logger.log(`Detected stake topup transaction for address ${transaction.receiver} with function '${transactionFuncName}'`);
+
+    await this.cachingService.deleteInCache(CacheInfo.StakeTopup(transaction.receiver).key);
 
     return [CacheInfo.StakeTopup(transaction.receiver).key];
   }

--- a/src/endpoints/stake/stake.service.ts
+++ b/src/endpoints/stake/stake.service.ts
@@ -287,6 +287,8 @@ export class StakeService {
       const stake = String(totalStaked / numNodes);
       const locked = String(totalLocked / numNodes);
 
+      this.logger.log(`Computed stake for address ${address}: stake ${stake}, topUp ${topUp}, locked ${locked}, numNodes ${numNodes}`);
+
       return {
         topUp,
         stake,


### PR DESCRIPTION
## Reasoning
- Time to refresh staking information takes a long time, up to 25 minutes
  
## Proposed Changes
- Proactively refresh node owner stake info upon delegation actions (delegate, re-delegate, un-delegate)
- Refresh identities every minute (instead of being refreshed indirectly every 10 minutes as it is right now)

## How to test
- Should take up to 2 minutes for stake information to be refreshed for a identity
