### PR TITLE
add account esdt history endpoint

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -555,6 +555,13 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withDateRangeFilter('timestamp', filter.before, filter.after);
     }
 
+    if (filter && filter.identifiers) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
+        ...filter.identifiers.map(identifier => QueryType.Match('token', identifier, QueryOperator.AND)),
+        ...filter.identifiers.map(identifier => QueryType.Match('identifier', identifier, QueryOperator.AND)),
+      ]));
+    }
+
     return elasticQuery;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -556,9 +556,8 @@ export class ElasticIndexerHelper {
     }
 
     if (filter && filter.identifiers) {
-      elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
-        ...filter.identifiers.map(identifier => QueryType.Match('identifier', identifier, QueryOperator.AND)),
-      ]));
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(
+        filter.identifiers.map(identifier => QueryType.Match('identifier', identifier, QueryOperator.AND))));
     }
 
     if (filter && filter.token) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -557,9 +557,12 @@ export class ElasticIndexerHelper {
 
     if (filter && filter.identifiers) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Should([
-        ...filter.identifiers.map(identifier => QueryType.Match('token', identifier, QueryOperator.AND)),
         ...filter.identifiers.map(identifier => QueryType.Match('identifier', identifier, QueryOperator.AND)),
       ]));
+    }
+
+    if (filter && filter.token) {
+      elasticQuery = elasticQuery.withMustMatchCondition('token', filter.token);
     }
 
     return elasticQuery;

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -497,6 +497,12 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('accountsesdthistory', 'address', elasticQuery);
   }
 
+  async getAccountEsdtHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter);
+
+    return await this.elasticService.getCount('accountsesdthistory', elasticQuery);
+  }
+
   async getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<any[]> {
     const sortOrder: ElasticSortOrder = !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -489,7 +489,7 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getCount('accountsesdthistory', elasticQuery);
   }
 
-  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<any[]> {
+  async getAccountEsdtHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<any[]> {
     const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter)
       .withPagination(pagination)
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -489,6 +489,14 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getCount('accountsesdthistory', elasticQuery);
   }
 
+  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<any[]> {
+    const elasticQuery: ElasticQuery = this.indexerHelper.buildAccountHistoryFilterQuery(address, undefined, filter)
+      .withPagination(pagination)
+      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+
+    return await this.elasticService.getList('accountsesdthistory', 'address', elasticQuery);
+  }
+
   async getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<any[]> {
     const sortOrder: ElasticSortOrder = !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
 

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -118,7 +118,7 @@ export interface IndexerInterface {
 
   getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
-  getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
+  getAccountEsdtHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
   getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]>
 

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -118,6 +118,8 @@ export interface IndexerInterface {
 
   getAccountTokenHistory(address: string, tokenIdentifier: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
+  getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
+
   getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]>
 
   getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<Token[]>

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -120,6 +120,8 @@ export interface IndexerInterface {
 
   getAccountEsdtHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]>
 
+  getAccountEsdtHistoryCount(address: string, filter?: AccountHistoryFilter): Promise<number>
+
   getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]>
 
   getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<Token[]>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -265,8 +265,8 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]> {
-    return await this.indexerInterface.getAccountTokensHistory(address, pagination, filter);
+  async getAccountEsdtHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]> {
+    return await this.indexerInterface.getAccountEsdtHistory(address, pagination, filter);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -265,6 +265,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountTokenHistory[]> {
+    return await this.indexerInterface.getAccountTokensHistory(address, pagination, filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]> {
     return await this.indexerInterface.getTransactions(filter, pagination, address);
   }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -270,6 +270,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAccountEsdtHistoryCount(address: string, filter: AccountHistoryFilter): Promise<number> {
+    return await this.indexerInterface.getAccountEsdtHistoryCount(address, filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getTransactions(filter: TransactionFilter, pagination: QueryPagination, address?: string): Promise<Transaction[]> {
     return await this.indexerInterface.getTransactions(filter, pagination, address);
   }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -90,7 +90,7 @@ export class PostgresIndexerService implements IndexerInterface {
     throw new Error("Method not implemented.");
   }
 
-  getAccountTokensHistory(_address: string, _pagination: QueryPagination, _filter: AccountHistoryFilter): Promise<any[]> {
+  getAccountEsdtHistory(_address: string, _pagination: QueryPagination, _filter: AccountHistoryFilter): Promise<any[]> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -94,6 +94,10 @@ export class PostgresIndexerService implements IndexerInterface {
     throw new Error("Method not implemented.");
   }
 
+  getAccountEsdtHistoryCount(_address: string, _filter: AccountHistoryFilter): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
   getNftCollectionsByIds(_identifiers: string[]): Promise<Collection[]> {
     throw new Error("Method not implemented.");
   }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -90,6 +90,10 @@ export class PostgresIndexerService implements IndexerInterface {
     throw new Error("Method not implemented.");
   }
 
+  getAccountTokensHistory(_address: string, _pagination: QueryPagination, _filter: AccountHistoryFilter): Promise<any[]> {
+    throw new Error("Method not implemented.");
+  }
+
   getNftCollectionsByIds(_identifiers: string[]): Promise<Collection[]> {
     throw new Error("Method not implemented.");
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1223,25 +1223,27 @@ export class AccountController {
       new AccountHistoryFilter({ before, after }));
   }
 
-  @Get("/accounts/:address/tokenhistory")
-  @ApiOperation({ summary: 'Account tokens history', description: 'Returns account tokens balance history' })
+  @Get("/accounts/:address/esdthistory")
+  @ApiOperation({ summary: 'Account esdts history', description: 'Returns account esdts balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
-  @ApiQuery({ name: 'identifiers', description: 'Filter by multiple token identifiers, comma-separated', required: false })
-  async getAccountTokensHistory(
+  @ApiQuery({ name: 'identifier', description: 'Filter by multiple token identifiers, comma-separated', required: false })
+  @ApiQuery({ name: 'token', description: 'Token identifier', required: false })
+  async getAccountEsdtHistory(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
-    @Query('identifiers', ParseArrayPipe) identifiers?: string[],
+    @Query('identifier', ParseArrayPipe) identifier?: string[],
+    @Query('token', ParseTokenPipe) token?: string,
   ): Promise<AccountEsdtHistory[]> {
-    return await this.accountService.getAccountTokensHistory(
+    return await this.accountService.getAccountEsdtHistory(
       address,
       new QueryPagination({ from, size }),
-      new AccountHistoryFilter({ before, after, identifiers }));
+      new AccountHistoryFilter({ before, after, identifiers: identifier, token }));
   }
 
   @Get("/accounts/:address/history/:tokenIdentifier")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1223,7 +1223,7 @@ export class AccountController {
       new AccountHistoryFilter({ before, after }));
   }
 
-  @Get("/accounts/:address/history/tokens")
+  @Get("/accounts/:address/tokenhistory")
   @ApiOperation({ summary: 'Account tokens history', description: 'Returns account tokens balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1229,7 +1229,7 @@ export class AccountController {
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
-  @ApiQuery({ name: 'identifier', description: 'Filter by multiple token identifiers, comma-separated', required: false })
+  @ApiQuery({ name: 'identifier', description: 'Filter by multiple esdt identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'token', description: 'Token identifier', required: false })
   async getAccountEsdtHistory(
     @Param('address', ParseAddressPipe) address: string,
@@ -1243,6 +1243,24 @@ export class AccountController {
     return await this.accountService.getAccountEsdtHistory(
       address,
       new QueryPagination({ from, size }),
+      new AccountHistoryFilter({ before, after, identifiers: identifier, token }));
+  }
+
+  @Get("/accounts/:address/esdthistory/count")
+  @ApiOperation({ summary: 'Account esdts history count', description: 'Returns account esdts balance history count' })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'identifier', description: 'Filter by multiple esdt identifiers, comma-separated', required: false })
+  @ApiQuery({ name: 'token', description: 'Token identifier', required: false })
+  async getAccountEsdtHistoryCount(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+    @Query('identifier', ParseArrayPipe) identifier?: string[],
+    @Query('token', ParseTokenPipe) token?: string,
+  ): Promise<number> {
+    return await this.accountService.getAccountEsdtHistoryCount(
+      address,
       new AccountHistoryFilter({ before, after, identifiers: identifier, token }));
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1223,6 +1223,27 @@ export class AccountController {
       new AccountHistoryFilter({ before, after }));
   }
 
+  @Get("/accounts/:address/history/tokens")
+  @ApiOperation({ summary: 'Account tokens history', description: 'Returns account tokens balance history' })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'identifiers', description: 'Filter by multiple token identifiers, comma-separated', required: false })
+  async getAccountTokensHistory(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+    @Query('identifiers', ParseArrayPipe) identifiers?: string[],
+  ): Promise<AccountEsdtHistory[]> {
+    return await this.accountService.getAccountTokensHistory(
+      address,
+      new QueryPagination({ from, size }),
+      new AccountHistoryFilter({ before, after, identifiers }));
+  }
+
   @Get("/accounts/:address/history/:tokenIdentifier")
   @ApiOperation({ summary: 'Account token history', description: 'Returns account token balance history' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -680,6 +680,11 @@ export class AccountService {
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
   }
 
+  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountEsdtHistory[]> {
+    const elasticResult = await this.indexerService.getAccountTokensHistory(address, pagination, filter);
+    return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
+  }
+
   private async applyNodeUnbondingPeriods(nodes: AccountKey[]): Promise<void> {
     const leavingNodes = nodes.filter(node => node.status === 'unStaked');
     await Promise.all(leavingNodes.map(async node => {

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -685,6 +685,10 @@ export class AccountService {
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
   }
 
+  async getAccountEsdtHistoryCount(address: string, filter: AccountHistoryFilter): Promise<number> {
+    return await this.indexerService.getAccountEsdtHistoryCount(address, filter);
+  }
+
   private async applyNodeUnbondingPeriods(nodes: AccountKey[]): Promise<void> {
     const leavingNodes = nodes.filter(node => node.status === 'unStaked');
     await Promise.all(leavingNodes.map(async node => {

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -680,8 +680,8 @@ export class AccountService {
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
   }
 
-  async getAccountTokensHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountEsdtHistory[]> {
-    const elasticResult = await this.indexerService.getAccountTokensHistory(address, pagination, filter);
+  async getAccountEsdtHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountEsdtHistory[]> {
+    const elasticResult = await this.indexerService.getAccountEsdtHistory(address, pagination, filter);
     return elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
   }
 

--- a/src/endpoints/accounts/entities/account.history.filter.ts
+++ b/src/endpoints/accounts/entities/account.history.filter.ts
@@ -5,4 +5,5 @@ export class AccountHistoryFilter {
   }
   before?: number;
   after?: number;
+  identifiers?: string[];
 }

--- a/src/endpoints/accounts/entities/account.history.filter.ts
+++ b/src/endpoints/accounts/entities/account.history.filter.ts
@@ -6,4 +6,5 @@ export class AccountHistoryFilter {
   before?: number;
   after?: number;
   identifiers?: string[];
+  token?: string;
 }

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -60,6 +60,7 @@ describe('Account Service', () => {
             getAccountTokenHistoryCount: jest.fn(),
             getScDeploy: jest.fn(),
             getTransaction: jest.fn(),
+            getAccountTokensHistory: jest.fn(),
           },
         },
         {
@@ -694,6 +695,57 @@ describe('Account Service', () => {
 
       const expectedResult = elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('getAccountTokensHistory', () => {
+    const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
+    const pagination = { from: 0, size: 10 };
+    const filter = new AccountHistoryFilter({});
+
+    const elasticResult = [
+      {
+        address: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+        timestamp: 1640603532,
+        balance: '0',
+        token: 'WEGLD-bd4d79',
+        identifier: 'WEGLD-bd4d79',
+        tokenNonce: 10,
+        isSender: true,
+        shardID: 0,
+        isSmartContract: false,
+      },
+      {
+        address: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+        timestamp: 1640603532,
+        balance: '0',
+        token: 'WEGLD-bd4d79',
+        identifier: 'WEGLD-bd4d79',
+        tokenNonce: 10,
+        isSender: true,
+        shardID: 0,
+        isSmartContract: false,
+      },
+    ];
+
+    it('should return the account tokens history', async () => {
+      jest.spyOn(indexerService, 'getAccountTokensHistory').mockResolvedValue(elasticResult);
+
+      const result = await service.getAccountTokensHistory(address, pagination, filter);
+
+      expect(indexerService.getAccountTokensHistory).toHaveBeenCalledWith(address, pagination, filter);
+
+      const expectedResult = elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should return an empty array if no token history is found', async () => {
+      jest.spyOn(indexerService, 'getAccountTokensHistory').mockResolvedValue([]);
+
+      const result = await service.getAccountTokensHistory(address, pagination, filter);
+
+      expect(indexerService.getAccountTokensHistory).toHaveBeenCalledWith(address, pagination, filter);
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -61,6 +61,7 @@ describe('Account Service', () => {
             getScDeploy: jest.fn(),
             getTransaction: jest.fn(),
             getAccountEsdtHistory: jest.fn(),
+            getAccountEsdtHistoryCount: jest.fn(),
           },
         },
         {
@@ -746,6 +747,21 @@ describe('Account Service', () => {
 
       expect(indexerService.getAccountEsdtHistory).toHaveBeenCalledWith(address, pagination, filter);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAccountEsdtHistoryCount', () => {
+    const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
+    const filter = new AccountHistoryFilter({});
+    const esdtHistoryCount = 5;
+
+    it('should return the account esdt history count', async () => {
+      jest.spyOn(indexerService, 'getAccountEsdtHistoryCount').mockResolvedValue(esdtHistoryCount);
+
+      const result = await service.getAccountEsdtHistoryCount(address, filter);
+
+      expect(indexerService.getAccountEsdtHistoryCount).toHaveBeenCalledWith(address, filter);
+      expect(result).toEqual(esdtHistoryCount);
     });
   });
 

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -698,7 +698,7 @@ describe('Account Service', () => {
     });
   });
 
-  describe('getAccountTokensHistory', () => {
+  describe('getAccountEsdtHistory', () => {
     const address = 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz';
     const pagination = { from: 0, size: 10 };
     const filter = new AccountHistoryFilter({});
@@ -729,22 +729,22 @@ describe('Account Service', () => {
     ];
 
     it('should return the account tokens history', async () => {
-      jest.spyOn(indexerService, 'getAccountTokensHistory').mockResolvedValue(elasticResult);
+      jest.spyOn(indexerService, 'getAccountEsdtHistory').mockResolvedValue(elasticResult);
 
-      const result = await service.getAccountTokensHistory(address, pagination, filter);
+      const result = await service.getAccountEsdtHistory(address, pagination, filter);
 
-      expect(indexerService.getAccountTokensHistory).toHaveBeenCalledWith(address, pagination, filter);
+      expect(indexerService.getAccountEsdtHistory).toHaveBeenCalledWith(address, pagination, filter);
 
       const expectedResult = elasticResult.map(item => ApiUtils.mergeObjects(new AccountEsdtHistory(), item));
       expect(result).toEqual(expectedResult);
     });
 
     it('should return an empty array if no token history is found', async () => {
-      jest.spyOn(indexerService, 'getAccountTokensHistory').mockResolvedValue([]);
+      jest.spyOn(indexerService, 'getAccountEsdtHistory').mockResolvedValue([]);
 
-      const result = await service.getAccountTokensHistory(address, pagination, filter);
+      const result = await service.getAccountEsdtHistory(address, pagination, filter);
 
-      expect(indexerService.getAccountTokensHistory).toHaveBeenCalledWith(address, pagination, filter);
+      expect(indexerService.getAccountEsdtHistory).toHaveBeenCalledWith(address, pagination, filter);
       expect(result).toEqual([]);
     });
   });

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -60,7 +60,7 @@ describe('Account Service', () => {
             getAccountTokenHistoryCount: jest.fn(),
             getScDeploy: jest.fn(),
             getTransaction: jest.fn(),
-            getAccountTokensHistory: jest.fn(),
+            getAccountEsdtHistory: jest.fn(),
           },
         },
         {


### PR DESCRIPTION
## Proposed Changes
- Added a new method to extract all the account tokens
- Added a new endpoint: `/accounts/:address/esdthistory`
- Added new specs for `getAccountEsdtHistory`

## How to test
`<api>/accounts/:address/esdthistory` -> should return account esdt history list
`<api>/accounts/:address/esdthistory?token=:token` -> should return for a specific token a list of esdt history
`<api>/accounts/:address/esdthistory?identifier=[:identifier_1, :identifier_2]` -> should return for a specific list of identifiers, a list of esdt history
