### PR TITLE
Configurable public api port

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -4,6 +4,7 @@ api:
   public: true
   publicPort: 3001
   private: true
+  privatePort: 4001
 cron:
   cacheWarmer: true
   fastWarm: true

--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -2,6 +2,7 @@ network: 'devnet'
 metaChainShardId: 4294967295
 api:
   public: true
+  publicPort: 3001
   private: true
 cron:
   cacheWarmer: true

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -2,6 +2,7 @@ network: 'mainnet'
 metaChainShardId: 4294967295
 api:
   public: true
+  publicPort: 3001
   private: true
 cron:
   cacheWarmer: true

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -4,6 +4,7 @@ api:
   public: true
   publicPort: 3001
   private: true
+  privatePort: 4001
 cron:
   cacheWarmer: true
   fastWarm: false

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -4,6 +4,7 @@ api:
   public: true
   publicPort: 3001
   private: true
+  privatePort: 4001
 cron:
   cacheWarmer: true
   fastWarm: true

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -2,6 +2,7 @@ network: 'testnet'
 metaChainShardId: 4294967295
 api:
   public: true
+  publicPort: 3001
   private: true
 cron:
   cacheWarmer: true

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -397,6 +397,10 @@ export class ApiConfigService {
     return isApiActive;
   }
 
+  getPrivateApiPort(): number {
+    return this.configService.get<number>('api.privatePort') ?? 4001;
+  }
+
   getIsAuthActive(): boolean {
     return this.configService.get<boolean>('features.auth.enabled') ?? this.configService.get<boolean>('api.auth') ?? false;
   }

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -384,6 +384,10 @@ export class ApiConfigService {
     return isApiActive;
   }
 
+  getPublicApiPort(): number {
+    return this.configService.get<number>('api.publicPort') ?? 3001;
+  }
+
   getIsPrivateApiActive(): boolean {
     const isApiActive = this.configService.get<boolean>('api.private');
     if (isApiActive === undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,7 @@ async function bootstrap() {
 
   if (apiConfigService.getIsPrivateApiActive()) {
     const privateApp = await NestFactory.create(PrivateAppModule);
-    await privateApp.listen(4001);
+    await privateApp.listen(apiConfigService.getPrivateApiPort());
   }
 
   if (apiConfigService.getIsTransactionProcessorCronActive()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ async function bootstrap() {
 
     await configurePublicApp(publicApp, apiConfigService);
 
-    await publicApp.listen(3001);
+    await publicApp.listen(apiConfigService.getPublicApiPort());
 
     const websocketPublisherApp = await NestFactory.createMicroservice<MicroserviceOptions>(
       WebSocketPublisherModule,


### PR DESCRIPTION
# Proposed Changes
- Make public api port configurable

## How to test
- in config, set `api.publicPort` to a value different than 3001 and the public api should start on that port
