### PR TITLE
Configurable websocket API

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -5,6 +5,7 @@ api:
   publicPort: 3001
   private: true
   privatePort: 4001
+  websocket: true
 cron:
   cacheWarmer: true
   fastWarm: true

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -5,6 +5,7 @@ api:
   publicPort: 3001
   private: true
   privatePort: 4001
+  websocket: true
 cron:
   cacheWarmer: true
   fastWarm: false

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -5,6 +5,7 @@ api:
   publicPort: 3001
   private: true
   privatePort: 4001
+  websocket: true
 cron:
   cacheWarmer: true
   fastWarm: true

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -397,6 +397,10 @@ export class ApiConfigService {
     return isApiActive;
   }
 
+  getIsWebsocketApiActive(): boolean {
+    return this.configService.get<boolean>('api.websocket') ?? true;
+  }
+
   getPrivateApiPort(): number {
     return this.configService.get<number>('api.privatePort') ?? 4001;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,22 +59,24 @@ async function bootstrap() {
 
     await publicApp.listen(apiConfigService.getPublicApiPort());
 
-    const websocketPublisherApp = await NestFactory.createMicroservice<MicroserviceOptions>(
-      WebSocketPublisherModule,
-      {
-        transport: Transport.REDIS,
-        options: {
-          host: apiConfigService.getRedisUrl(),
-          port: 6379,
-          retryAttempts: 100,
-          retryDelay: 1000,
-          retryStrategy: () => 1000,
+    if (apiConfigService.getIsWebsocketApiActive()) {
+      const websocketPublisherApp = await NestFactory.createMicroservice<MicroserviceOptions>(
+        WebSocketPublisherModule,
+        {
+          transport: Transport.REDIS,
+          options: {
+            host: apiConfigService.getRedisUrl(),
+            port: 6379,
+            retryAttempts: 100,
+            retryDelay: 1000,
+            retryStrategy: () => 1000,
+          },
         },
-      },
-    );
-    websocketPublisherApp.useWebSocketAdapter(new SocketAdapter(websocketPublisherApp));
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    websocketPublisherApp.listen();
+      );
+      websocketPublisherApp.useWebSocketAdapter(new SocketAdapter(websocketPublisherApp));
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      websocketPublisherApp.listen();
+    }
   }
 
   if (apiConfigService.getIsPrivateApiActive()) {


### PR DESCRIPTION
## Proposed Changes
- make websocket api configurable

## How to test
- `api.websocket: false` should not start the websocket microservice and not use port 3099
