### PR TITLE
Added additional info for /tokens , /mex/tokens and /mex/pairs routes

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -90,19 +90,19 @@ export class MexPair {
   @ApiProperty({ type: String, example: 'jungledex' })
   exchange: MexPairExchange | undefined;
 
-  @Field(() => Boolean, { description: '.', nullable: true })
+  @Field(() => Boolean, { description: 'Mex pair farms details.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   hasFarms: boolean | undefined = undefined;
 
-  @Field(() => Boolean, { description: '.', nullable: true })
+  @Field(() => Boolean, { description: 'Mex pair dual farms details.', nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })
   hasDualFarms: boolean | undefined = undefined;
 
-  @Field(() => Number, { description: '.', nullable: true })
+  @Field(() => Number, { description: 'Mex pair trades count.', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   tradesCount: number | undefined = undefined;
 
-  @Field(() => Number, { description: '.', nullable: true })
+  @Field(() => Number, { description: 'Mex pair deploy date in unix time.', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   deployedAt: number | undefined = undefined;
 }

--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -89,4 +89,20 @@ export class MexPair {
   @Field(() => String, { description: "Mex pair exchange details.", nullable: true })
   @ApiProperty({ type: String, example: 'jungledex' })
   exchange: MexPairExchange | undefined;
+
+  @Field(() => Boolean, { description: '.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  hasFarms: boolean | undefined = undefined;
+
+  @Field(() => Boolean, { description: '.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  hasDualFarms: boolean | undefined = undefined;
+
+  @Field(() => Number, { description: '.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  tradesCount: number | undefined = undefined;
+
+  @Field(() => Number, { description: '.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  deployedAt: number | undefined = undefined;
 }

--- a/src/endpoints/mex/entities/mex.token.ts
+++ b/src/endpoints/mex/entities/mex.token.ts
@@ -25,4 +25,8 @@ export class MexToken {
   @Field(() => Float, { description: "Mex token previous24hPrice." })
   @ApiProperty({ type: Number, example: 0.000206738758250580 })
   previous24hPrice: number = 0;
+
+  @Field(() => Float, { description: "Mex token previous24hVolume." })
+  @ApiProperty({ type: Number, example: 0.000206738758250580 })
+  previous24hVolume: number | undefined = 0;
 }

--- a/src/endpoints/mex/entities/mex.token.ts
+++ b/src/endpoints/mex/entities/mex.token.ts
@@ -29,4 +29,8 @@ export class MexToken {
   @Field(() => Float, { description: "Mex token previous24hVolume." })
   @ApiProperty({ type: Number, example: 0.000206738758250580 })
   previous24hVolume: number | undefined = 0;
+
+  @Field(() => Number, { description: 'Mex token trades count.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  tradesCount: number | undefined = 0;
 }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -123,6 +123,10 @@ export class MexPairService {
             type
             lockedValueUSD
             volumeUSD24h
+            hasFarms
+            hasDualFarms
+            tradesCount
+            deployedAt
             __typename
           }
         }
@@ -185,6 +189,10 @@ export class MexPairService {
         quoteName: pair.secondToken.name,
         totalValue: Number(pair.lockedValueUSD),
         volume24h: Number(pair.volumeUSD24h),
+        hasFarms: pair.hasFarms,
+        hasDualFarms: pair.hasDualFarms,
+        tradesCount: Number(pair.tradesCount),
+        deployedAt: Number(pair.deployedAt),
         state,
         type,
         exchange,
@@ -209,6 +217,10 @@ export class MexPairService {
       quoteName: pair.firstToken.name,
       totalValue: Number(pair.lockedValueUSD),
       volume24h: Number(pair.volumeUSD24h),
+      hasFarms: pair.hasFarms,
+      hasDualFarms: pair.hasDualFarms,
+      tradesCount: Number(pair.tradesCount),
+      deployedAt: Number(pair.deployedAt),
       state,
       type,
       exchange,

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -210,7 +210,7 @@ export class MexTokenService {
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
         previous24hVolume: pair.volume24h,
-        tradesCount: 0
+        tradesCount: 0,
       };
     }
 
@@ -222,7 +222,7 @@ export class MexTokenService {
         price: pair.basePrice,
         previous24hPrice: pair.basePrevious24hPrice,
         previous24hVolume: pair.volume24h,
-        tradesCount: 0
+        tradesCount: 0,
       };
     }
 
@@ -234,7 +234,7 @@ export class MexTokenService {
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
         previous24hVolume: pair.volume24h,
-        tradesCount: 0
+        tradesCount: 0,
       };
     }
 
@@ -288,7 +288,7 @@ export class MexTokenService {
 
   private computeTradesCountForMexToken(mexToken: MexToken, filteredPairs: MexPair[]): number {
     const pairs = filteredPairs.filter(x => x.baseId === mexToken.id || x.quoteId === mexToken.id);
-    let computeResult = pairs.sum(pair => pair.tradesCount ?? 0);
+    const computeResult = pairs.sum(pair => pair.tradesCount ?? 0);
     return computeResult;
   }
 }

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -184,6 +184,7 @@ export class MexTokenService {
         wegldToken.price = pair.basePrice;
         wegldToken.previous24hPrice = pair.basePrevious24hPrice;
         wegldToken.previous24hVolume = pair.volume24h;
+        wegldToken.tradesCount = this.computeTradesCountForMexToken(wegldToken, filteredPairs);
         mexTokens.push(wegldToken);
       }
 
@@ -191,6 +192,8 @@ export class MexTokenService {
       if (!mexToken) {
         continue;
       }
+
+      mexToken.tradesCount = this.computeTradesCountForMexToken(mexToken, filteredPairs);
 
       mexTokens.push(mexToken);
     }
@@ -206,7 +209,8 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
-        previous24hVolume: pair.volume24h
+        previous24hVolume: pair.volume24h,
+        tradesCount: 0
       };
     }
 
@@ -217,7 +221,8 @@ export class MexTokenService {
         name: pair.baseName,
         price: pair.basePrice,
         previous24hPrice: pair.basePrevious24hPrice,
-        previous24hVolume: pair.volume24h
+        previous24hVolume: pair.volume24h,
+        tradesCount: 0
       };
     }
 
@@ -228,7 +233,8 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
-        previous24hVolume: pair.volume24h
+        previous24hVolume: pair.volume24h,
+        tradesCount: 0
       };
     }
 
@@ -278,5 +284,11 @@ export class MexTokenService {
       this.logger.error(error);
       return [];
     }
+  }
+
+  private computeTradesCountForMexToken(mexToken: MexToken, filteredPairs: MexPair[]): number {
+    const pairs = filteredPairs.filter(x => x.baseId === mexToken.id || x.quoteId === mexToken.id);
+    let computeResult = pairs.sum(pair => pair.tradesCount ?? 0);
+    return computeResult;
   }
 }

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -26,7 +26,7 @@ export class MexTokenService {
     @Inject(forwardRef(() => MexFarmService))
     private readonly mexFarmService: MexFarmService,
     private readonly mexSettingsService: MexSettingsService,
-    private readonly graphQlService: GraphQlService
+    private readonly graphQlService: GraphQlService,
   ) { }
 
   async refreshMexTokens(): Promise<void> {
@@ -183,6 +183,7 @@ export class MexTokenService {
         wegldToken.name = pair.baseName;
         wegldToken.price = pair.basePrice;
         wegldToken.previous24hPrice = pair.basePrevious24hPrice;
+        wegldToken.previous24hVolume = pair.volume24h;
         mexTokens.push(wegldToken);
       }
 
@@ -205,6 +206,7 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
+        previous24hVolume: pair.volume24h
       };
     }
 
@@ -215,6 +217,7 @@ export class MexTokenService {
         name: pair.baseName,
         price: pair.basePrice,
         previous24hPrice: pair.basePrevious24hPrice,
+        previous24hVolume: pair.volume24h
       };
     }
 
@@ -225,6 +228,7 @@ export class MexTokenService {
         name: pair.quoteName,
         price: pair.quotePrice,
         previous24hPrice: pair.quotePrevious24hPrice,
+        previous24hVolume: pair.volume24h
       };
     }
 

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -163,19 +163,7 @@ export class Token {
   @ApiProperty({ type: Number, nullable: true })
   lowLiquidityThresholdPercent: number | undefined = undefined;
 
-  @Field(() => Boolean, { description: '.', nullable: true })
-  @ApiProperty({ type: Boolean, nullable: true })
-  hasFarms: boolean | undefined = undefined;
-
-  @Field(() => Boolean, { description: '.', nullable: true })
-  @ApiProperty({ type: Boolean, nullable: true })
-  hasDualFarms: boolean | undefined = undefined;
-
-  @Field(() => Number, { description: '.', nullable: true })
+  @Field(() => Number, { description: 'Mex pair trades count.', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   tradesCount: number | undefined = undefined;
-
-  @Field(() => Number, { description: '.', nullable: true })
-  @ApiProperty({ type: Number, nullable: true })
-  deployedAt: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -162,4 +162,20 @@ export class Token {
   @Field(() => Number, { description: 'If the liquidity to market cap ratio is less than 0.5%, we consider it as low liquidity and display threshold percent .', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   lowLiquidityThresholdPercent: number | undefined = undefined;
+
+  @Field(() => Boolean, { description: '.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  hasFarms: boolean | undefined = undefined;
+
+  @Field(() => Boolean, { description: '.', nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  hasDualFarms: boolean | undefined = undefined;
+
+  @Field(() => Number, { description: '.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  tradesCount: number | undefined = undefined;
+
+  @Field(() => Number, { description: '.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  deployedAt: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -62,6 +62,7 @@ export class TokenController {
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<TokenDetailed[]> {
+
     return await this.tokenService.getTokens(
       new QueryPagination({ from, size }),
       new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, sort, order, mexPairType })

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -765,7 +765,7 @@ export class TokenService {
     await this.applyMexLiquidity(tokens.filter(x => x.type !== TokenType.MetaESDT));
     await this.applyMexPrices(tokens.filter(x => x.type !== TokenType.MetaESDT));
     await this.applyMexPairType(tokens.filter(x => x.type !== TokenType.MetaESDT));
-    await this.applyMexPairInfo(tokens.filter(x => x.type !== TokenType.MetaESDT));
+    await this.applyMexPairTradesCount(tokens.filter(x => x.type !== TokenType.MetaESDT));
 
     await this.cachingService.batchApplyAll(
       tokens,
@@ -957,20 +957,16 @@ export class TokenService {
     }
   }
 
-  private async applyMexPairInfo(tokens: TokenDetailed[]): Promise<void> {
+  private async applyMexPairTradesCount(tokens: TokenDetailed[]): Promise<void> {
     try {
       const pairs = await this.mexPairService.getAllMexPairs();
       const filteredPairs = pairs.filter(x => x.state === MexPairState.active);
 
       for (const token of tokens) {
-        const pair = filteredPairs.filter(x => x.id === token.identifier);
+        const pairs = filteredPairs.filter(x => x.baseId === token.identifier || x.quoteId === token.identifier);
 
-        if (pair.length > 0) {
-          console.log(pair)
-          token.hasFarms = pair[0].hasFarms;
-          token.hasDualFarms = pair[0].hasDualFarms;
-          token.tradesCount = pair[0].tradesCount;
-          token.deployedAt = pair[0].deployedAt;
+        if (pairs.length > 0) {
+          token.tradesCount = pairs.sum(pair => pair.tradesCount ?? 0);
         }
       }
     } catch (error) {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -765,6 +765,7 @@ export class TokenService {
     await this.applyMexLiquidity(tokens.filter(x => x.type !== TokenType.MetaESDT));
     await this.applyMexPrices(tokens.filter(x => x.type !== TokenType.MetaESDT));
     await this.applyMexPairType(tokens.filter(x => x.type !== TokenType.MetaESDT));
+    await this.applyMexPairInfo(tokens.filter(x => x.type !== TokenType.MetaESDT));
 
     await this.cachingService.batchApplyAll(
       tokens,
@@ -952,6 +953,28 @@ export class TokenService {
       }
     } catch (error) {
       this.logger.error('Could not apply mex tokens prices');
+      this.logger.error(error);
+    }
+  }
+
+  private async applyMexPairInfo(tokens: TokenDetailed[]): Promise<void> {
+    try {
+      const pairs = await this.mexPairService.getAllMexPairs();
+      const filteredPairs = pairs.filter(x => x.state === MexPairState.active);
+
+      for (const token of tokens) {
+        const pair = filteredPairs.filter(x => x.id === token.identifier);
+
+        if (pair.length > 0) {
+          console.log(pair)
+          token.hasFarms = pair[0].hasFarms;
+          token.hasDualFarms = pair[0].hasDualFarms;
+          token.tradesCount = pair[0].tradesCount;
+          token.deployedAt = pair[0].deployedAt;
+        }
+      }
+    } catch (error) {
+      this.logger.error('Could not apply mex pair info');
       this.logger.error(error);
     }
   }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -42,7 +42,6 @@ import { TransferService } from "../transfers/transfer.service";
 import { MexPairService } from "../mex/mex.pair.service";
 import { MexPairState } from "../mex/entities/mex.pair.state";
 import { MexTokenType } from "../mex/entities/mex.token.type";
-import assert from "assert";
 
 @Injectable()
 export class TokenService {


### PR DESCRIPTION
## Reasoning
- expose extra information about pairs and tokens in /mex/pairs, /mex/tokens and /tokens routes
  
## Proposed Changes
- add extra fields to MexPair:  hasFarms, hasDualFarms, tradesCount, deployedAt
- add extra fields to Token: tradesCount
- add extra fields to MexToken: tradesCount, previous24hVolume

## How to test
<api>/tokens-> tokens should contain  tradesCount  fields
<api>/mex/pairs  -> should contain hasFarms, hasDualFarms, tradesCount, deployedAt fields
<api>/mex/tokens -> should contain tradesCount and previous24hVolume fields
