### PR TITLE
Nodes and tokens fetch from external api

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -94,6 +94,12 @@ features:
   tps:
     enabled: true
     maxLookBehindNonces: 100
+  nodesFetch:
+    enabled: true
+    serviceUrl: 'https://devnet-api.multiversx.com'
+  tokensFetch:
+    enabled: true
+    serviceUrl: 'https://devnet-api.multiversx.com'
 image:
   width: 600
   height: 600

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -97,7 +97,13 @@ features:
     deadLetterQueueName: 'api-process-nfts-dlq'
   tps:
     enabled: true
-    maxLookBehindNonces: 100  
+    maxLookBehindNonces: 100
+  nodesFetch:
+    enabled: true
+    serviceUrl: 'https://mainnet-api.multiversx.com'
+  tokensFetch:
+    enabled: true
+    serviceUrl: 'https://mainnet-api.multiversx.com'
 image:
   width: 600
   height: 600

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -100,10 +100,10 @@ features:
     maxLookBehindNonces: 100
   nodesFetch:
     enabled: true
-    serviceUrl: 'https://mainnet-api.multiversx.com'
+    serviceUrl: 'https://api.multiversx.com'
   tokensFetch:
     enabled: true
-    serviceUrl: 'https://mainnet-api.multiversx.com'
+    serviceUrl: 'https://api.multiversx.com'
 image:
   width: 600
   height: 600

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -97,6 +97,12 @@ features:
   tps:
     enabled: true
     maxLookBehindNonces: 100
+  nodesFetch:
+    enabled: true
+    serviceUrl: 'https://testnet-api.multiversx.com'
+  tokensFetch:
+    enabled: true
+    serviceUrl: 'https://testnet-api.multiversx.com'
 image:
   width: 600
   height: 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=api
-  
+
   mongodbdatabase:
     image: mongo:latest
     environment:
@@ -49,4 +49,5 @@ services:
       - /var/lib/notifier
     ports:
       - 5673:5672
+
       - 15673:15672

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,5 +49,4 @@ services:
       - /var/lib/notifier
     ports:
       - 5673:5672
-
       - 15673:15672

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,4 +49,5 @@ services:
       - /var/lib/notifier
     ports:
       - 5673:5672
+
       - 15673:15672

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -869,4 +869,30 @@ export class ApiConfigService {
 
     return deepHistoryUrl;
   }
+
+  isTokensFetchFeatureEnabled(): boolean {
+    return this.configService.get<boolean>('features.tokensFetch.enabled') ?? false;
+  }
+
+  getTokensFetchServiceUrl(): string {
+    const serviceUrl = this.configService.get<string>('features.tokensFetch.serviceUrl');
+    if (!serviceUrl) {
+      throw new Error('No tokens fetch service url present');
+    }
+
+    return serviceUrl;
+  }
+
+  isNodesFetchFeatureEnabled(): boolean {
+    return this.configService.get<boolean>('features.nodeFetch.enabled') ?? false;
+  }
+
+  getNodesFetchServiceUrl(): string {
+    const serviceUrl = this.configService.get<string>('features.nodesFetch.serviceUrl');
+    if (!serviceUrl) {
+      throw new Error('No nodes fetch service url present');
+    }
+
+    return serviceUrl;
+  }
 }

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -884,7 +884,7 @@ export class ApiConfigService {
   }
 
   isNodesFetchFeatureEnabled(): boolean {
-    return this.configService.get<boolean>('features.nodeFetch.enabled') ?? false;
+    return this.configService.get<boolean>('features.nodesFetch.enabled') ?? false;
   }
 
   getNodesFetchServiceUrl(): string {

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -407,7 +407,7 @@ export class NodeService {
       let from = 0, size = nodesCount <= 1000 ? nodesCount : 1000;
 
       while (size) {
-        const requestNodes = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/nodes`, { params: { from: from, size: size } });
+        const requestNodes = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes`, { params: { from: from, size: size } });
         nodes.push(...requestNodes.data);
         from += size;
         size = nodesCount <= from + 1000 ? nodesCount - from : 1000;

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -400,23 +400,29 @@ export class NodeService {
 
   private async getAllNodesFromApi(): Promise<Node[]> {
     try {
-      const requestNodesCount = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes/count`);
-      const nodesCount = requestNodesCount.data;
-
+      let from = 0;
+      const size = 10000;
       const nodes = [];
-      let from = 0, size = nodesCount <= 1000 ? nodesCount : 1000;
+      let currentNodes = [];
 
-      while (size) {
-        const requestNodes = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes`, { params: { from: from, size: size } });
-        nodes.push(...requestNodes.data);
+      do {
+        const { data } = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes`, {
+          params: {
+            from,
+            size
+          }
+        });
+
+        nodes.push(...data);
+        currentNodes = data
         from += size;
-        size = nodesCount <= from + 1000 ? nodesCount - from : 1000;
-      }
+      } while (currentNodes.length === size);
 
       return nodes;
     } catch (error) {
       this.logger.error('An unhandled error occurred when getting nodes from API');
       this.logger.error(error);
+
       throw error;
     }
   }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -400,25 +400,9 @@ export class NodeService {
 
   private async getAllNodesFromApi(): Promise<Node[]> {
     try {
-      let from = 0;
-      const size = 10000;
-      const nodes = [];
-      let currentNodes = [];
+      const { data } = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes`, { params: { size: 10000 } });
 
-      do {
-        const { data } = await this.apiService.get(`${this.apiConfigService.getNodesFetchServiceUrl()}/nodes`, {
-          params: {
-            from,
-            size
-          }
-        });
-
-        nodes.push(...data);
-        currentNodes = data
-        from += size;
-      } while (currentNodes.length === size);
-
-      return nodes;
+      return data;
     } catch (error) {
       this.logger.error('An unhandled error occurred when getting nodes from API');
       this.logger.error(error);

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -25,6 +25,7 @@ import { NodeAuction } from "./entities/node.auction";
 import { NodeAuctionFilter } from "./entities/node.auction.filter";
 import { Identity } from "../identities/entities/identity";
 import { NodeSortAuction } from "./entities/node.sort.auction";
+import { ApiService, ApiSettings } from "@multiversx/sdk-nestjs-http";
 
 @Injectable()
 export class NodeService {
@@ -42,7 +43,8 @@ export class NodeService {
     private readonly protocolService: ProtocolService,
     private readonly keysService: KeysService,
     @Inject(forwardRef(() => IdentitiesService))
-    private readonly identitiesService: IdentitiesService
+    private readonly identitiesService: IdentitiesService,
+    private readonly apiService: ApiService,
   ) { }
 
   private getIssues(node: Node, version: string | undefined): string[] {
@@ -372,6 +374,10 @@ export class NodeService {
   }
 
   async getAllNodesRaw(): Promise<Node[]> {
+    if (this.apiConfigService.isNodesFetchFeatureEnabled()) {
+      return await this.getAllNodesFromApi();
+    }
+
     const nodes = await this.getHeartbeatValidatorsAndQueue();
 
     await this.applyNodeIdentities(nodes);
@@ -390,6 +396,27 @@ export class NodeService {
     await this.applyNodeUnbondingPeriods(nodes);
 
     return nodes;
+  }
+
+  private async getAllNodesFromApi(): Promise<Node[]> {
+    try {
+      const requestNodesCount = await this.apiService.get(this.apiConfigService.getNodesFetchServiceUrl() + '/nodes/count');
+      const nodesCount = requestNodesCount.data;
+
+      const requestUrlParams = new ApiSettings();
+      requestUrlParams.params = {
+        size: nodesCount,
+      };
+
+      const requestNodes = await this.apiService.get(this.apiConfigService.getNodesFetchServiceUrl() + '/nodes', requestUrlParams);
+      const nodes = requestNodes.data;
+
+      return nodes;
+    } catch (error) {
+      this.logger.error('An unhandled error occurred when getting nodes from API');
+      this.logger.error(error);
+      return [];
+    }
   }
 
   async processAuctions(nodes: Node[], auctions: Auction[]) {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -862,23 +862,29 @@ export class TokenService {
 
   private async getAllTokensFromApi(): Promise<TokenDetailed[]> {
     try {
-      const requestTokensCount = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens/count`);
-      const tokensCount = requestTokensCount.data;
-
+      let from = 0;
+      const size = 10000;
       const tokens = [];
-      let from = 0, size = tokensCount <= 1000 ? tokensCount : 1000;
+      let currentTokens = [];
 
-      while (size) {
-        const requestTokens = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, { params: { from: from, size: size } });
-        tokens.push(...requestTokens.data);
+      do {
+        const { data } = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, {
+          params: {
+            from,
+            size
+          }
+        });
+
+        tokens.push(...data);
+        currentTokens = data;
         from += size;
-        size = tokensCount <= from + 1000 ? tokensCount - from : 1000;
-      }
+      } while (currentTokens.length === size);
 
       return tokens;
     } catch (error) {
       this.logger.error('An unhandled error occurred when getting tokens from API');
       this.logger.error(error);
+
       throw error;
     }
   }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -862,25 +862,9 @@ export class TokenService {
 
   private async getAllTokensFromApi(): Promise<TokenDetailed[]> {
     try {
-      let from = 0;
-      const size = 10000;
-      const tokens = [];
-      let currentTokens = [];
+      const { data } = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, { params: { size: 10000 } });
 
-      do {
-        const { data } = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, {
-          params: {
-            from,
-            size
-          }
-        });
-
-        tokens.push(...data);
-        currentTokens = data;
-        from += size;
-      } while (currentTokens.length === size);
-
-      return tokens;
+      return data;
     } catch (error) {
       this.logger.error('An unhandled error occurred when getting tokens from API');
       this.logger.error(error);

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -863,12 +863,12 @@ export class TokenService {
 
   private async getAllTokensFromApi(): Promise<TokenDetailed[]> {
     try {
-      const requestTokenCount = await this.apiService.get(this.apiConfigService.getTokensFetchServiceUrl() + '/tokens/count');
-      const tokenCount = requestTokenCount.data;
+      const requestTokensCount = await this.apiService.get(this.apiConfigService.getTokensFetchServiceUrl() + '/tokens/count');
+      const tokensCount = requestTokensCount.data;
 
       const requestUrlParams = new ApiSettings();
       requestUrlParams.params = {
-        size: tokenCount,
+        size: tokensCount,
       };
 
       const requestTokens = await this.apiService.get(this.apiConfigService.getTokensFetchServiceUrl() + '/tokens', requestUrlParams);
@@ -880,7 +880,6 @@ export class TokenService {
       this.logger.error(error);
       return [];
     }
-
   }
 
   private async getTotalTransactions(token: TokenDetailed): Promise<{ count: number, lastUpdatedAt: number } | undefined> {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -20,7 +20,7 @@ import { TokenSort } from "./entities/token.sort";
 import { TokenWithRoles } from "./entities/token.with.roles";
 import { TokenWithRolesFilter } from "./entities/token.with.roles.filter";
 import { AddressUtils, BinaryUtils, NumberUtils, TokenUtils } from "@multiversx/sdk-nestjs-common";
-import { ApiService, ApiSettings, ApiUtils } from "@multiversx/sdk-nestjs-http";
+import { ApiService, ApiUtils } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
@@ -720,12 +720,11 @@ export class TokenService {
   }
 
   async getAllTokensRaw(): Promise<TokenDetailed[]> {
-    this.logger.log(`Starting to fetch all tokens`);
-
     if (this.apiConfigService.isTokensFetchFeatureEnabled()) {
       return await this.getAllTokensFromApi();
     }
 
+    this.logger.log(`Starting to fetch all tokens`);
     const tokensProperties = await this.esdtService.getAllFungibleTokenProperties();
     let tokens = tokensProperties.map(properties => ApiUtils.mergeObjects(new TokenDetailed(), properties));
 
@@ -863,22 +862,24 @@ export class TokenService {
 
   private async getAllTokensFromApi(): Promise<TokenDetailed[]> {
     try {
-      const requestTokensCount = await this.apiService.get(this.apiConfigService.getTokensFetchServiceUrl() + '/tokens/count');
+      const requestTokensCount = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens/count`);
       const tokensCount = requestTokensCount.data;
 
-      const requestUrlParams = new ApiSettings();
-      requestUrlParams.params = {
-        size: tokensCount,
-      };
+      const tokens = [];
+      let from = 0, size = tokensCount <= 1000 ? tokensCount : 1000;
 
-      const requestTokens = await this.apiService.get(this.apiConfigService.getTokensFetchServiceUrl() + '/tokens', requestUrlParams);
-      const tokens = requestTokens.data;
+      while (size) {
+        const requestTokens = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, { params: { from: from, size: size } });
+        tokens.push(...requestTokens.data);
+        from += size;
+        size = tokensCount <= from + 1000 ? tokensCount - from : 1000;
+      }
 
       return tokens;
     } catch (error) {
       this.logger.error('An unhandled error occurred when getting tokens from API');
       this.logger.error(error);
-      return [];
+      throw error;
     }
   }
 

--- a/src/test/unit/services/nodes.spec.ts
+++ b/src/test/unit/services/nodes.spec.ts
@@ -19,6 +19,7 @@ import { IdentitiesService } from "src/endpoints/identities/identities.service";
 import { NodeAuctionFilter } from "src/endpoints/nodes/entities/node.auction.filter";
 import * as fs from 'fs';
 import * as path from 'path';
+import { ApiService } from "@multiversx/sdk-nestjs-http";
 
 describe('NodeService', () => {
   let nodeService: NodeService;
@@ -106,6 +107,12 @@ describe('NodeService', () => {
           useValue: {
             getIdentity: jest.fn(),
             getAllIdentities: jest.fn(),
+          },
+        },
+        {
+          provide: ApiService,
+          useValue: {
+            get: jest.fn(),
           },
         },
       ],

--- a/src/test/unit/services/nodes.spec.ts
+++ b/src/test/unit/services/nodes.spec.ts
@@ -444,12 +444,12 @@ describe('NodeService', () => {
         nodeService['cacheService'].getOrSet = jest.fn().mockImplementation((_, callback) => callback());
         jest.spyOn(apiConfigService, 'isNodesFetchFeatureEnabled').mockReturnValue(true);
         jest.spyOn(apiConfigService, 'getNodesFetchServiceUrl').mockReturnValue('https://testnet-api.multiversx.com');
-        jest.spyOn(apiService, 'get').mockResolvedValueOnce({data: mockNodes.length}).mockResolvedValueOnce({data: mockNodes});
+        jest.spyOn(apiService, 'get').mockResolvedValueOnce({data: mockNodes});
         const getHeartbeatValidatorsAndQueueSpy = jest.spyOn(nodeService, 'getHeartbeatValidatorsAndQueue');
 
         const result = await nodeService.getAllNodes();
         expect(result).toEqual(mockNodes);
-        expect(apiService.get).toHaveBeenCalledTimes(2);
+        expect(apiService.get).toHaveBeenCalledTimes(1);
         expect(getHeartbeatValidatorsAndQueueSpy).not.toHaveBeenCalled();
       });
     });

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -25,6 +25,7 @@ import { TransferService } from "src/endpoints/transfers/transfer.service";
 import { MexPairService } from "src/endpoints/mex/mex.pair.service";
 import * as fs from 'fs';
 import * as path from 'path';
+import { ApiService } from "@multiversx/sdk-nestjs-http";
 
 describe('Token Service', () => {
   let tokenService: TokenService;
@@ -129,6 +130,12 @@ describe('Token Service', () => {
           provide: MexPairService,
           useValue: {
             getAllMexPairs: jest.fn(),
+          },
+        },
+        {
+          provide: ApiService,
+          useValue: {
+            get: jest.fn(),
           },
         },
       ],

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -622,11 +622,11 @@ describe('Token Service', () => {
       tokenService['cachingService'].getOrSet = jest.fn().mockImplementation((_, callback) => callback());
       jest.spyOn(apiConfigService, 'isTokensFetchFeatureEnabled').mockReturnValue(true);
       jest.spyOn(apiConfigService, 'getTokensFetchServiceUrl').mockReturnValue('https://testnet-api.multiversx.com');
-      jest.spyOn(apiService, 'get').mockResolvedValueOnce({data: mockTokens.length}).mockResolvedValueOnce({data: mockTokens});
+      jest.spyOn(apiService, 'get').mockResolvedValueOnce({data: mockTokens});
 
       const result = await tokenService.getAllTokens();
       expect(result).toEqual(mockTokens);
-      expect(apiService.get).toHaveBeenCalledTimes(2);
+      expect(apiService.get).toHaveBeenCalledTimes(1);
       expect(esdtService.getAllFungibleTokenProperties).not.toHaveBeenCalled();
       expect(collectionService.getNftCollections).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Reasoning
- In order to avoid hitting rate limits on ES / gateway, we can specify a set of features to activate fetching of nodes and tokens from an external API, so that we don't perform a lot of requests to the downstream resources and hitting 429 on them
  
## Proposed Changes
- Add external API fetch for the nodes and token routes
- Add 2 features in the config file for nodesFetch and tokenFetch with the fields enabled and serviceURL

## How to test
- when tokenFetch is enabled, calling getAllTokens() should make 2 GET calls through apiService at the serviceURL parameter and not call any other function
- when nodesFetch is enabled, calling getAllNodes() should make 2 GET calls through apiService at the serviceURL parameter and not call any other function
