### PR TITLE
No WEGLD argument for wrapEgld action

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
@@ -45,14 +45,24 @@ export class MexWrapActionRecognizerService {
     result.name = MexFunction.wrapEgld;
     result.description = `Wrap ${valueDenominated} EGLD`;
     result.arguments = {
-      token: {
-        type: EsdtType.FungibleESDT,
-        name: 'WrappedEGLD',
-        token: wegldId,
-        ticker: wegldId.split('-')[0],
-        decimals: 18,
-        value: metadata.value.toString(),
-      },
+      transfers: [
+        {
+          type: EsdtType.FungibleESDT,
+          name: 'EGLD',
+          token: 'EGLD',
+          ticker: 'EGLD',
+          decimals: 18,
+          value: metadata.value.toString(),
+        },
+        {
+          type: EsdtType.FungibleESDT,
+          name: 'WrappedEGLD',
+          token: wegldId,
+          ticker: wegldId.split('-')[0],
+          decimals: 18,
+          value: metadata.value.toString(),
+        },
+      ],
       receiver: metadata.receiver,
     };
 

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@nestjs/common";
-import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import { TransactionAction } from "../../entities/transaction.action";
 import { TransactionActionCategory } from "../../entities/transaction.action.category";
 import { TransactionMetadata } from "../../entities/transaction.metadata";
@@ -44,17 +43,6 @@ export class MexWrapActionRecognizerService {
     result.category = TransactionActionCategory.mex;
     result.name = MexFunction.wrapEgld;
     result.description = `Wrap ${valueDenominated} EGLD`;
-    result.arguments = {
-      token: {
-        type: EsdtType.FungibleESDT,
-        name: 'WrappedEGLD',
-        token: wegldId,
-        ticker: wegldId.split('-')[0],
-        decimals: 18,
-        value: metadata.value.toString(),
-      },
-      receiver: metadata.receiver,
-    };
 
     return result;
   }

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { EsdtType } from "src/endpoints/esdt/entities/esdt.type";
 import { TransactionAction } from "../../entities/transaction.action";
 import { TransactionActionCategory } from "../../entities/transaction.action.category";
 import { TransactionMetadata } from "../../entities/transaction.metadata";
@@ -43,6 +44,17 @@ export class MexWrapActionRecognizerService {
     result.category = TransactionActionCategory.mex;
     result.name = MexFunction.wrapEgld;
     result.description = `Wrap ${valueDenominated} EGLD`;
+    result.arguments = {
+      token: {
+        type: EsdtType.FungibleESDT,
+        name: 'WrappedEGLD',
+        token: wegldId,
+        ticker: wegldId.split('-')[0],
+        decimals: 18,
+        value: metadata.value.toString(),
+      },
+      receiver: metadata.receiver,
+    };
 
     return result;
   }

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.wrap.action.recognizer.service.ts
@@ -47,7 +47,7 @@ export class MexWrapActionRecognizerService {
     result.arguments = {
       transfers: [
         {
-          type: EsdtType.FungibleESDT,
+          type: 'EGLD',
           name: 'EGLD',
           token: 'EGLD',
           ticker: 'EGLD',


### PR DESCRIPTION
## Proposed Changes
- do not set the `WEGLD` ticker for the `wrapEgld` action which is causing incorrect toasts in xPortal app

## How to test (mainnet)
- `/transactions/9b8e7ef23efbc110713e0621ea17f3647585c622dccb9ccddbe29697cbe5e440` should not have the `arguments` attribute for the action at all
