### PR TITLE
Add metrics on transaction processor

### DIFF
--- a/src/common/metrics/api.metrics.service.ts
+++ b/src/common/metrics/api.metrics.service.ts
@@ -17,6 +17,8 @@ export class ApiMetricsService {
   private static graphqlDurationHistogram: Histogram<string>;
   private static currentNonceGauge: Gauge<string>;
   private static lastProcessedNonceGauge: Gauge<string>;
+  private static lastProcessedBatchProcessorNonce: Gauge<string>;
+  private static lastProcessedTransactionCompletedProcessorNonce: Gauge<string>;
 
   constructor(
     private readonly apiConfigService: ApiConfigService,
@@ -87,6 +89,22 @@ export class ApiMetricsService {
         labelNames: ['shardId'],
       });
     }
+
+    if (!ApiMetricsService.lastProcessedBatchProcessorNonce) {
+      ApiMetricsService.lastProcessedBatchProcessorNonce = new Gauge({
+        name: 'last_processed_batch_processor_nonce',
+        help: 'Last processed nonce of the given shard',
+        labelNames: ['shardId'],
+      });
+    }
+
+    if (!ApiMetricsService.lastProcessedTransactionCompletedProcessorNonce) {
+      ApiMetricsService.lastProcessedTransactionCompletedProcessorNonce = new Gauge({
+        name: 'last_processed_transaction_completed_processor_nonce',
+        help: 'Last processed nonce of the given shard',
+        labelNames: ['shardId'],
+      });
+    }
   }
 
   @OnEvent(MetricsEvents.SetVmQuery)
@@ -126,6 +144,18 @@ export class ApiMetricsService {
   setLastProcessedNonce(payload: LogMetricsEvent) {
     const [shardId, nonce] = payload.args;
     ApiMetricsService.lastProcessedNonceGauge.set({ shardId }, nonce);
+  }
+
+  @OnEvent(MetricsEvents.SetLastProcessedBatchProcessorNonce)
+  setLastProcessedBatchProcessorNonce(payload: LogMetricsEvent) {
+    const [shardId, nonce] = payload.args;
+    ApiMetricsService.lastProcessedBatchProcessorNonce.set({ shardId }, nonce);
+  }
+
+  @OnEvent(MetricsEvents.SetLastProcessedTransactionCompletedProcessorNonce)
+  setLastProcessedTransactionCompletedProcessorNonce(payload: LogMetricsEvent) {
+    const [shardId, nonce] = payload.args;
+    ApiMetricsService.lastProcessedTransactionCompletedProcessorNonce.set({ shardId }, nonce);
   }
 
   async getMetrics(): Promise<string> {

--- a/src/crons/transaction.processor/transaction.completed.module.ts
+++ b/src/crons/transaction.processor/transaction.completed.module.ts
@@ -3,11 +3,17 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ApiConfigModule } from 'src/common/api-config/api.config.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionCompletedService } from './transaction.completed.service';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { GatewayModule } from 'src/common/gateway/gateway.module';
+import { ProtocolModule } from 'src/common/protocol/protocol.module';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
     ApiConfigModule,
+    ApiMetricsModule,
+    GatewayModule,
+    ProtocolModule,
     DynamicModuleUtils.getCacheModule(),
   ],
   providers: [

--- a/src/utils/metrics-events.constants.ts
+++ b/src/utils/metrics-events.constants.ts
@@ -4,5 +4,7 @@ export enum MetricsEvents {
   SetPersistenceDuration = "setPersistenceDuration",
   SetIndexerDuration = "setIndexerDuration",
   SetGraphqlDuration = "setGraphqlDuration",
-  SetLastProcessedNonce = "setLastProcessedNonce"
+  SetLastProcessedNonce = "setLastProcessedNonce",
+  SetLastProcessedBatchProcessorNonce = "setLastProcessedBatchProcessorNonce",
+  SetLastProcessedTransactionCompletedProcessorNonce = "setLastProcessedTransactionCompletedProcessorNonce",
 }


### PR DESCRIPTION
## Reasoning
- we need a method of monitoring transaction processor instances that remain stuck
  
## Proposed Changes
- added prometheus metrics for each TransactionProcessor instance. These metrics keep the last block nonce on each shard, and if it is left behind, an alert can be triggered

## How to test
- the `/metrics` endpoint on the private api should contain the `last_processed_batch_processor_nonce` and `last_processed_transaction_completed_processor_nonce` metrics for each shard when the api starts
