### PR TITLE
herotag resolution fixes

### DIFF
--- a/src/test/unit/services/username.spec.ts
+++ b/src/test/unit/services/username.spec.ts
@@ -220,7 +220,7 @@ describe('UsernameService', () => {
       expect(service['cachingService'].get).toHaveBeenCalledWith(normalizedUsername);
       expect(service['cachingService'].set).toHaveBeenCalledWith(normalizedUsername, address, Constants.oneWeek());
     });
-  })
+  });
 
   describe('getUsernameRedirectRoute', () => {
     it('should return route with address only when withGuardianInfo is undefined', () => {


### PR DESCRIPTION
## Reasoning
- if the vm query fails, we cache for 7 days that the herotag has no address
- if querying for herotag before registering, we cache for 7 days that herotag has no address
  
## Proposed Changes
- do not cache at all the fact that a herotag is unregistered and return null in this case
