### PR TITLE
Change rabbitmq docker image version from 3.5 to 3.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: jrottenberg/ffmpeg
 
   rabbitmq:
-    image: rabbitmq:3.5
+    image: rabbitmq:3.9
     container_name: rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: guest


### PR DESCRIPTION
## Reasoning
-  rabbitmq:3.5 docker image is deprecated
  
## Proposed Changes
- change rabbitmq docker image version from 3.5 -> 3.9