### PR TITLE
Filter NFTs by full tag

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -208,7 +208,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.tags) {
-      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(filter.tags.map(tag => QueryType.Nested("data", [new MatchQuery("data.tags", tag)]))));
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(filter.tags.map(tag => QueryType.Nested("data", [new MatchQuery("data.tags", tag, QueryOperator.AND)]))));
     }
 
     if (filter.creator !== undefined) {


### PR DESCRIPTION
## Reasoning
- In some api calls, filtering NFTs by a tag containing separators would return nfts that contain either part of the separated string, such as `nft-ticket` will return the NFTs containing the tags `nft-ticket`, `nft` and `ticket`
  
## Proposed Changes
- apply the `AND` query operator when filtering NFTs by tags

## How to test
- `/accounts/erd129e7mywmqke3ggf9ga922mw8jm49qu9zn3ryupm9602ruksxluvstvsnmq/nfts?tags=nft-ticket&withSupply=true&from=0&size=10&hasUris=true&type=NonFungibleESDT,SemiFungibleESDT&includeFlagged=true&source=elastic` should only return NFTs containing tag `nft-ticket`
