### PR TITLE
update deprecated pairs query

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.status.ts
+++ b/src/endpoints/mex/entities/mex.pair.status.ts
@@ -1,0 +1,27 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum MexPairStatus {
+  active = 'Active',
+  inactive = 'Inactive',
+  paused = 'Paused',
+  partial = 'Partial',
+}
+
+registerEnumType(MexPairStatus, {
+  name: 'MexPairStatus',
+  description: 'MexPairStatus object type.',
+  valuesMap: {
+    active: {
+      description: 'Active state.',
+    },
+    inactive: {
+      description: 'Inactive state.',
+    },
+    paused: {
+      description: 'Pause state.',
+    },
+    partial: {
+      description: 'Partial state.',
+    },
+  },
+});

--- a/src/endpoints/mex/entities/mex.pair.ts
+++ b/src/endpoints/mex/entities/mex.pair.ts
@@ -102,6 +102,10 @@ export class MexPair {
   @ApiProperty({ type: Number, nullable: true })
   tradesCount: number | undefined = undefined;
 
+  @Field(() => Number, { description: 'Mex pair trades count 24h.', nullable: true })
+  @ApiProperty({ type: Number, nullable: true })
+  tradesCount24h: number | undefined = undefined;
+
   @Field(() => Number, { description: 'Mex pair deploy date in unix time.', nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   deployedAt: number | undefined = undefined;

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -1,17 +1,18 @@
-import { Constants } from "@multiversx/sdk-nestjs-common";
-import { CacheService } from "@multiversx/sdk-nestjs-cache";
-import { BadRequestException, Injectable } from "@nestjs/common";
-import { gql } from "graphql-request";
-import { CacheInfo } from "src/utils/cache.info";
-import { GraphQlService } from "src/common/graphql/graphql.service";
-import { MexPair } from "./entities/mex.pair";
-import { MexPairState } from "./entities/mex.pair.state";
-import { MexPairType } from "./entities/mex.pair.type";
-import { MexSettingsService } from "./mex.settings.service";
-import { OriginLogger } from "@multiversx/sdk-nestjs-common";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
-import { MexPairExchange } from "./entities/mex.pair.exchange";
-import { MexPairsFilter } from "./entities/mex.pairs..filter";
+import { Constants } from '@multiversx/sdk-nestjs-common';
+import { CacheService } from '@multiversx/sdk-nestjs-cache';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { gql } from 'graphql-request';
+import { CacheInfo } from 'src/utils/cache.info';
+import { GraphQlService } from 'src/common/graphql/graphql.service';
+import { MexPair } from './entities/mex.pair';
+import { MexPairState } from './entities/mex.pair.state';
+import { MexPairType } from './entities/mex.pair.type';
+import { MexSettingsService } from './mex.settings.service';
+import { OriginLogger } from '@multiversx/sdk-nestjs-common';
+import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { MexPairExchange } from './entities/mex.pair.exchange';
+import { MexPairsFilter } from './entities/mex.pairs..filter';
+import { MexPairStatus } from './entities/mex.pair.status';
 
 @Injectable()
 export class MexPairService {
@@ -52,7 +53,7 @@ export class MexPairService {
       CacheInfo.MexPairs.key,
       async () => await this.getAllMexPairsRaw(),
       CacheInfo.MexPairs.ttl,
-      Constants.oneSecond() * 30
+      Constants.oneSecond() * 30,
     );
   }
 
@@ -82,7 +83,7 @@ export class MexPairService {
 
       const variables = {
         pagination: { first: totalPairs },
-        filters: {},
+        filters: { state: MexPairStatus.active },
       };
 
       const query = gql`
@@ -144,8 +145,7 @@ export class MexPairService {
       }
 
       return result.filteredPairs.edges
-        .map((edge: any) => this.getPairInfo(edge.node))
-        .filter((x: MexPair | undefined) => x && x.state === MexPairState.active);
+        .map((edge: any) => this.getPairInfo(edge.node));
     } catch (error) {
       this.logger.error('An error occurred while getting all mex pairs');
       this.logger.error(error);

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -129,6 +129,7 @@ export class MexPairService {
                 hasFarms
                 hasDualFarms
                 tradesCount
+                tradesCount24h
                 deployedAt
                 __typename
               }
@@ -199,6 +200,7 @@ export class MexPairService {
         hasFarms: pair.hasFarms,
         hasDualFarms: pair.hasDualFarms,
         tradesCount: Number(pair.tradesCount),
+        tradesCount24h: Number(pair.tradesCount24h),
         deployedAt: Number(pair.deployedAt),
         state,
         type,
@@ -227,6 +229,7 @@ export class MexPairService {
       hasFarms: pair.hasFarms,
       hasDualFarms: pair.hasDualFarms,
       tradesCount: Number(pair.tradesCount),
+      tradesCount24h: Number(pair.tradesCount24h),
       deployedAt: Number(pair.deployedAt),
       state,
       type,


### PR DESCRIPTION
## Reasoning
- `pairs` query from exchange graphql is deprecated
  
## Proposed Changes
- remove deprecated `pairs` query and add `filteredPairs` query
- add pagination instead of `offset` and `pairsLimit`

## How to test
- `<api>/mex/pairs` -> should return mex pairs ( 25 size by default )