### PR TITLE
Handle activation epoch where staking v4 flag is checked

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -135,6 +135,11 @@ export class CacheWarmerService {
 
   @Lock({ name: 'Node auction invalidations', verbose: true })
   async handleNodeAuctionInvalidations() {
+    const currentEpoch = await this.blockService.getCurrentEpoch();
+    if (currentEpoch < this.apiConfigService.getStakingV4ActivationEpoch()) {
+      return;
+    }
+
     // wait randomly between 1 and 2 seconds to avoid all nodes refreshing at the same time
     await new Promise(resolve => setTimeout(resolve, 1000 + 1000 * Math.random()));
 

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -113,8 +113,10 @@ export class NetworkService {
     const egldPrice = await this.dataApiService.getEgldPrice();
     const tokenMarketCap = await this.tokenService.getTokenMarketCapRaw();
 
+    const currentEpoch = await this.blockService.getCurrentEpoch();
+
     let totalWaitingStake: BigInt = BigInt(0);
-    if (!this.apiConfigService.isStakingV4Enabled()) {
+    if (!this.apiConfigService.isStakingV4Enabled() || currentEpoch < this.apiConfigService.getStakingV4ActivationEpoch()) {
       totalWaitingStake = await this.getTotalWaitingStake();
     }
 

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -388,7 +388,8 @@ export class NodeService {
 
     await this.applyNodeStakeInfo(nodes);
 
-    if (this.apiConfigService.isStakingV4Enabled()) {
+    const currentEpoch = await this.blockService.getCurrentEpoch();
+    if (this.apiConfigService.isStakingV4Enabled() && currentEpoch >= this.apiConfigService.getStakingV4ActivationEpoch()) {
       const auctions = await this.gatewayService.getValidatorAuctions();
       await this.processAuctions(nodes, auctions);
     }

--- a/src/test/unit/services/nodes.spec.ts
+++ b/src/test/unit/services/nodes.spec.ts
@@ -493,7 +493,7 @@ describe('NodeService', () => {
         const result = await nodeService.deleteOwnersForAddressInCache(address);
 
         expect(result).toEqual([]);
-        expect(currentEpochSpy).toHaveBeenCalledTimes(1);
+        expect(currentEpochSpy).toHaveBeenCalledTimes(2);
         expect(allNodesSpy).toHaveBeenCalledTimes(1);
       });
     });
@@ -539,7 +539,7 @@ describe('NodeService', () => {
             undefined,
           ]
         );
-        expect(currentEpochSpy).toHaveBeenCalledTimes(1);
+        expect(currentEpochSpy).toHaveBeenCalledTimes(2);
       });
     });
 


### PR DESCRIPTION
## Reasoning
- In some places in the code, only the `stakingv4` flag was checked, not taking into account the activation epoch, and causing errors in cases where the staking v4 is enabled but not activated yet
  
## Proposed Changes
- add the necessary support in the code

## How to test
- before activation epoch is started, loading of nodes should not crash
