### PR TITLE
 applications assets

### DIFF
--- a/src/endpoints/applications/application.module.ts
+++ b/src/endpoints/applications/application.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { ElasticIndexerModule } from "src/common/indexer/elastic/elastic.indexer.module";
 import { ApplicationService } from "./application.service";
+import { AssetsService } from '../../common/assets/assets.service';
 
 @Module({
   imports: [
@@ -8,6 +9,7 @@ import { ApplicationService } from "./application.service";
   ],
   providers: [
     ApplicationService,
+    AssetsService,
   ],
   exports: [
     ApplicationService,

--- a/src/endpoints/applications/application.service.ts
+++ b/src/endpoints/applications/application.service.ts
@@ -9,7 +9,7 @@ import { AssetsService } from '../../common/assets/assets.service';
 export class ApplicationService {
   constructor(
     private readonly elasticIndexerService: ElasticIndexerService,
-    private readonly  assetsService: AssetsService,
+    private readonly assetsService: AssetsService,
   ) { }
 
   async getApplications(pagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {

--- a/src/endpoints/applications/application.service.ts
+++ b/src/endpoints/applications/application.service.ts
@@ -1,30 +1,33 @@
-import { Injectable } from "@nestjs/common";
-import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
-import { Application } from "./entities/application";
-import { QueryPagination } from "src/common/entities/query.pagination";
-import { ApplicationFilter } from "./entities/application.filter";
+import { Injectable } from '@nestjs/common';
+import { ElasticIndexerService } from 'src/common/indexer/elastic/elastic.indexer.service';
+import { Application } from './entities/application';
+import { QueryPagination } from 'src/common/entities/query.pagination';
+import { ApplicationFilter } from './entities/application.filter';
+import { AssetsService } from '../../common/assets/assets.service';
 
 @Injectable()
 export class ApplicationService {
   constructor(
     private readonly elasticIndexerService: ElasticIndexerService,
+    private readonly  assetsService: AssetsService,
   ) { }
 
   async getApplications(pagination: QueryPagination, filter: ApplicationFilter): Promise<Application[]> {
     const elasticResults = await this.elasticIndexerService.getApplications(filter, pagination);
+    const assets = await this.assetsService.getAllAccountAssets();
+
     if (!elasticResults) {
       return [];
     }
 
-    const applications: Application[] = elasticResults.map(item => ({
+    return elasticResults.map(item => ({
       contract: item.address,
       deployer: item.deployer,
       owner: item.currentOwner,
       codeHash: item.initialCodeHash,
       timestamp: item.timestamp,
+      assets: assets[item.address],
     }));
-
-    return applications;
   }
 
   async getApplicationsCount(filter: ApplicationFilter): Promise<number> {

--- a/src/endpoints/applications/entities/application.ts
+++ b/src/endpoints/applications/entities/application.ts
@@ -1,29 +1,34 @@
-import { Field, Float, ObjectType } from "@nestjs/graphql";
-import { ApiProperty } from "@nestjs/swagger";
+import { Field, Float, ObjectType } from '@nestjs/graphql';
+import { ApiProperty } from '@nestjs/swagger';
+import { AccountAssets } from '../../../common/assets/entities/account.assets';
 
-@ObjectType("Application", { description: "Application object type." })
+@ObjectType('Application', { description: 'Application object type.' })
 export class Application {
   constructor(init?: Partial<Application>) {
     Object.assign(this, init);
   }
 
-  @Field(() => String, { description: "Contract address details." })
+  @Field(() => String, { description: 'Contract address details.' })
   @ApiProperty({ type: String })
   contract: string = '';
 
-  @Field(() => String, { description: "Deployer address details." })
+  @Field(() => String, { description: 'Deployer address details.' })
   @ApiProperty({ type: String })
   deployer: string = '';
 
-  @Field(() => String, { description: "Owner address details." })
+  @Field(() => String, { description: 'Owner address details.' })
   @ApiProperty({ type: String })
   owner: string = '';
 
-  @Field(() => String, { description: "Code hash details." })
+  @Field(() => String, { description: 'Code hash details.' })
   @ApiProperty({ type: String })
   codeHash: string = '';
 
-  @Field(() => Float, { description: "Timestamp details." })
+  @Field(() => Float, { description: 'Timestamp details.' })
   @ApiProperty({ type: Number })
   timestamp: number = 0;
+
+  @Field(() => AccountAssets, { description: 'Assets for the given account.', nullable: true })
+  @ApiProperty({ type: AccountAssets, nullable: true, description: 'Contract assets' })
+  assets: AccountAssets | undefined = undefined;
 }

--- a/src/test/unit/services/applications.spec.ts
+++ b/src/test/unit/services/applications.spec.ts
@@ -1,112 +1,135 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import { QueryPagination } from "src/common/entities/query.pagination";
-import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexer.service";
-import { ApplicationService } from "src/endpoints/applications/application.service";
-import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
+import { Test, TestingModule } from '@nestjs/testing';
+import { QueryPagination } from 'src/common/entities/query.pagination';
+import { ElasticIndexerService } from 'src/common/indexer/elastic/elastic.indexer.service';
+import { ApplicationService } from 'src/endpoints/applications/application.service';
+import { ApplicationFilter } from 'src/endpoints/applications/entities/application.filter';
+import { AssetsService } from '../../../common/assets/assets.service';
+import { AccountAssetsSocial } from '../../../common/assets/entities/account.assets.social';
+import { AccountAssets } from '../../../common/assets/entities/account.assets';
 
 describe('ApplicationService', () => {
-    let service: ApplicationService;
-    let indexerService: ElasticIndexerService;
+  let service: ApplicationService;
+  let indexerService: ElasticIndexerService;
+  let assetsService: AssetsService;
 
-    beforeEach(async () => {
-        const module: TestingModule = await Test.createTestingModule({
-            providers: [
-                ApplicationService,
-                {
-                    provide: ElasticIndexerService,
-                    useValue: {
-                        getApplications: jest.fn(),
-                        getApplicationCount: jest.fn(),
-                    },
-                },
-            ],
-        }).compile();
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApplicationService,
+        {
+          provide: ElasticIndexerService,
+          useValue: {
+            getApplications: jest.fn(),
+            getApplicationCount: jest.fn(),
+          },
+        },
+        {
+          provide: AssetsService,
+          useValue: {
+            getAllAccountAssets: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
 
-        service = module.get<ApplicationService>(ApplicationService);
-        indexerService = module.get<ElasticIndexerService>(ElasticIndexerService);
+    service = module.get<ApplicationService>(ApplicationService);
+    indexerService = module.get<ElasticIndexerService>(ElasticIndexerService);
+    assetsService = module.get<AssetsService>(AssetsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getApplications', () => {
+    it('should return an array of applications', async () => {
+      const indexResult = [
+        {
+          address: 'erd1qqqqqqqqqqqqqpgq8372f63glekg7zl22tmx7wzp4drql25r6avs70dmp0',
+          deployer: 'erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams',
+          currentOwner: 'erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams',
+          initialCodeHash: 'kDh8hR9vyceELMUuy6JdAg0X90+ZaLeyVQS6tPbY82s=',
+          timestamp: 1724955216,
+        },
+        {
+          address: 'erd1qqqqqqqqqqqqqpgquc4v0pujmewzr26tm2gtawmsq4vsrm4mwmfs459g65',
+          deployer: 'erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v',
+          currentOwner: 'erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v',
+          initialCodeHash: 'kDiPwFRJhcB7TmeBbQvw1uWQ8vuhRSU6XF71Z4OybeQ=',
+          timestamp: 1725017514,
+        },
+      ];
+
+      const assets: { [key: string]: AccountAssets } = {
+        erd1qqqqqqqqqqqqqpgq8372f63glekg7zl22tmx7wzp4drql25r6avs70dmp0: {
+          name: 'Multiversx DNS: Contract 239',
+          description: '',
+          social: new AccountAssetsSocial({
+            website: 'https://xexchange.com',
+            twitter: 'https://twitter.com/xExchangeApp',
+            telegram: 'https://t.me/xExchangeApp',
+            blog: 'https://multiversx.com/blog/maiar-exchange-mex-tokenomics',
+          }),
+          tags: ['dns'],
+          icon: 'multiversx',
+          iconPng: '',
+          iconSvg: '',
+          proof: '',
+        },
+      };
+
+      jest.spyOn(indexerService, 'getApplications').mockResolvedValue(indexResult);
+      jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValue(assets);
+
+      const queryPagination = new QueryPagination();
+      const filter = new ApplicationFilter();
+      const result = await service.getApplications(queryPagination, filter);
+
+      expect(indexerService.getApplications).toHaveBeenCalledWith(filter, queryPagination);
+      expect(indexerService.getApplications).toHaveBeenCalledTimes(1);
+      expect(assetsService.getAllAccountAssets).toHaveBeenCalled();
+
+      const expectedApplications = indexResult.map(item => ({
+        contract: item.address,
+        deployer: item.deployer,
+        owner: item.currentOwner,
+        codeHash: item.initialCodeHash,
+        timestamp: item.timestamp,
+        assets: assets[item.address],
+      }));
+
+      expect(result).toEqual(expectedApplications);
     });
 
-    it('should be defined', () => {
-        expect(service).toBeDefined();
+    it('should return an empty array if no applications are found', async () => {
+      jest.spyOn(indexerService, 'getApplications').mockResolvedValue([]);
+
+      const queryPagination = new QueryPagination;
+      const filter = new ApplicationFilter;
+      const result = await service.getApplications(queryPagination, filter);
+
+      expect(indexerService.getApplications)
+        .toHaveBeenCalledWith(filter, queryPagination);
+      expect(indexerService.getApplications)
+        .toHaveBeenCalledTimes(1);
+
+      expect(result).toEqual([]);
     });
+  });
 
-    describe('getApplications', () => {
-        it('should return an array of applications', async () => {
-            const indexResult = [
-                {
-                    address: 'erd1qqqqqqqqqqqqqpgq8372f63glekg7zl22tmx7wzp4drql25r6avs70dmp0',
-                    deployer: 'erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams',
-                    currentOwner: 'erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams',
-                    initialCodeHash: 'kDh8hR9vyceELMUuy6JdAg0X90+ZaLeyVQS6tPbY82s=',
-                    timestamp: 1724955216,
-                },
-                {
-                    address: 'erd1qqqqqqqqqqqqqpgquc4v0pujmewzr26tm2gtawmsq4vsrm4mwmfs459g65',
-                    deployer: 'erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v',
-                    currentOwner: 'erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v',
-                    initialCodeHash: 'kDiPwFRJhcB7TmeBbQvw1uWQ8vuhRSU6XF71Z4OybeQ=',
-                    timestamp: 1725017514,
-                },
-            ];
+  describe('getApplicationsCount', () => {
+    it('should return total applications count', async () => {
+      jest.spyOn(indexerService, 'getApplicationCount').mockResolvedValue(2);
 
-            jest.spyOn(indexerService, 'getApplications').mockResolvedValue(indexResult);
+      const filter = new ApplicationFilter;
+      const result = await service.getApplicationsCount(filter);
 
-            const queryPagination = new QueryPagination;
-            const filter = new ApplicationFilter;
-            const result = await service.getApplications(queryPagination, filter);
+      expect(indexerService.getApplicationCount)
+        .toHaveBeenCalledWith(filter);
+      expect(indexerService.getApplicationCount)
+        .toHaveBeenCalledTimes(1);
 
-            expect(indexerService.getApplications)
-                .toHaveBeenCalledWith(filter, queryPagination);
-            expect(indexerService.getApplications)
-                .toHaveBeenCalledTimes(1);
-
-            expect(result).toEqual([
-                {
-                    contract: "erd1qqqqqqqqqqqqqpgq8372f63glekg7zl22tmx7wzp4drql25r6avs70dmp0",
-                    deployer: "erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams",
-                    owner: "erd1j770k2n46wzfn5g63gjthhqemu9r23n9tp7seu95vpz5gk5s6avsk5aams",
-                    codeHash: "kDh8hR9vyceELMUuy6JdAg0X90+ZaLeyVQS6tPbY82s=",
-                    timestamp: 1724955216,
-                },
-                {
-                    contract: "erd1qqqqqqqqqqqqqpgquc4v0pujmewzr26tm2gtawmsq4vsrm4mwmfs459g65",
-                    deployer: "erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v",
-                    owner: "erd1szcgm7vq3tmyxfgd4wd2k2emh59az8jq5jjpj9799a0k59u0wmfss4vw3v",
-                    codeHash: "kDiPwFRJhcB7TmeBbQvw1uWQ8vuhRSU6XF71Z4OybeQ=",
-                    timestamp: 1725017514,
-                },
-            ]);
-        });
-
-        it('should return an empty array if no applications are found', async () => {
-            jest.spyOn(indexerService, 'getApplications').mockResolvedValue([]);
-
-            const queryPagination = new QueryPagination;
-            const filter = new ApplicationFilter;
-            const result = await service.getApplications(queryPagination, filter);
-
-            expect(indexerService.getApplications)
-                .toHaveBeenCalledWith(filter, queryPagination);
-            expect(indexerService.getApplications)
-                .toHaveBeenCalledTimes(1);
-
-            expect(result).toEqual([]);
-        });
+      expect(result).toEqual(2);
     });
-
-    describe('getApplicationsCount', () => {
-        it('should return total applications count', async () => {
-            jest.spyOn(indexerService, 'getApplicationCount').mockResolvedValue(2);
-
-            const filter = new ApplicationFilter;
-            const result = await service.getApplicationsCount(filter);
-
-            expect(indexerService.getApplicationCount)
-                .toHaveBeenCalledWith(filter);
-            expect(indexerService.getApplicationCount)
-                .toHaveBeenCalledTimes(1);
-
-            expect(result).toEqual(2);
-        });
-    });
+  });
 });


### PR DESCRIPTION
## Reasoning
- for every applications, `assets` details are missing
  
## Proposed Changes
- add for each application ( if branded ) `assets` field
- update `applications.spec.ts` to reflect the new field

## How to test
- `<api>/applications` -> some of the applications, should contain `assets`

