### PR TITLE
add support for token priceSource filter

### DIFF
--- a/src/endpoints/tokens/entities/token.filter.ts
+++ b/src/endpoints/tokens/entities/token.filter.ts
@@ -2,6 +2,7 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { TokenType } from "src/common/indexer/entities";
 import { TokenSort } from "./token.sort";
 import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
+import { TokenAssetsPriceSourceType } from "src/common/assets/entities/token.assets.price.source.type";
 
 export class TokenFilter {
   constructor(init?: Partial<TokenFilter>) {
@@ -25,4 +26,6 @@ export class TokenFilter {
   order?: SortOrder;
 
   mexPairType?: MexPairType[];
+
+  priceSource?: TokenAssetsPriceSourceType;
 }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -23,6 +23,7 @@ import { Response } from "express";
 import { TokenType } from "src/common/indexer/entities";
 import { ParseArrayPipeOptions } from "@multiversx/sdk-nestjs-common/lib/pipes/entities/parse.array.options";
 import { MexPairType } from "../mex/entities/mex.pair.type";
+import { TokenAssetsPriceSourceType } from "src/common/assets/entities/token.assets.price.source.type";
 
 @Controller()
 @ApiTags('tokens')
@@ -47,6 +48,7 @@ export class TokenController {
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
   @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
+  @ApiQuery({ name: 'priceSource', description: 'Token Price Source', required: false, enum: TokenAssetsPriceSourceType })
   async getTokens(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -59,11 +61,12 @@ export class TokenController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
+    @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<TokenDetailed[]> {
 
     return await this.tokenService.getTokens(
       new QueryPagination({ from, size }),
-      new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, sort, order, mexPairType })
+      new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, sort, order, mexPairType, priceSource })
     );
   }
 
@@ -77,6 +80,7 @@ export class TokenController {
   @ApiQuery({ name: 'identifiers', description: 'Search by multiple token identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'includeMetaESDT', description: 'Include MetaESDTs in response', required: false, type: Boolean })
   @ApiQuery({ name: 'mexPairType', description: 'Token Mex Pair', required: false, enum: MexPairType })
+  @ApiQuery({ name: 'priceSource', description: 'Token Price Source', required: false, enum: TokenAssetsPriceSourceType })
   async getTokenCount(
     @Query('search') search?: string,
     @Query('name') name?: string,
@@ -85,8 +89,9 @@ export class TokenController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
+    @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<number> {
-    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
+    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType, priceSource }));
   }
 
   @Get("/tokens/c")
@@ -99,8 +104,9 @@ export class TokenController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
+    @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<number> {
-    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
+    return await this.tokenService.getTokenCount(new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType, priceSource }));
   }
 
   @Get('/tokens/:identifier')

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -167,6 +167,10 @@ export class TokenService {
       tokens = tokens.filter(token => mexPairTypes.includes(token.mexPairType));
     }
 
+    if (filter.priceSource) {
+      tokens = tokens.filter(token => token.assets?.priceSource?.type === filter.priceSource);
+    }
+
     return tokens;
   }
 


### PR DESCRIPTION
## Proposed Changes
-  added token filter to be able to return all the tokens where priceSource is `dataApi` or `customUrl`

## How to test
- `<api>/tokens?priceSource=customUrl`
- `<api>/tokens?priceSource=dataApi`

