### PR TITLE
 add support for relayer v3

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -299,6 +299,10 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMatchCondition('relayerAddr', filter.relayer);
     }
 
+    if (filter.isRelayed) {
+      elasticQuery = elasticQuery.withMustMatchCondition('isRelayed', filter.isRelayed);
+    }
+
     if (filter.type) {
       elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('type', filter.type === TransactionType.Transaction ? 'normal' : 'unsigned'));
     }

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -64,6 +64,7 @@ export class TransactionGetService {
     let transaction: any;
     try {
       transaction = await this.indexerService.getTransaction(txHash);
+
       if (!transaction) {
         return null;
       }
@@ -77,6 +78,10 @@ export class TransactionGetService {
     try {
       if (transaction.scResults) {
         transaction.results = transaction.scResults;
+      }
+
+      if (transaction.relayerAddr) {
+        transaction.relayer = transaction.relayerAddr;
       }
 
       const transactionDetailed: TransactionDetailed = ApiUtils.mergeObjects(new TransactionDetailed(), transaction);
@@ -124,7 +129,6 @@ export class TransactionGetService {
             }
           }
         }
-
       }
 
       this.applyUsernamesToDetailedTransaction(transaction, transactionDetailed);

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -552,16 +552,16 @@ export class TransactionService {
   }
 
   private extractRelayedVersion(transaction: TransactionDetailed): string | undefined {
-      if (transaction.isRelayed == true && transaction.data) {
-        const decodedData = BinaryUtils.base64Decode(transaction.data);
+    if (transaction.isRelayed == true && transaction.data) {
+      const decodedData = BinaryUtils.base64Decode(transaction.data);
 
-        if (decodedData.startsWith('relayedTx@')) {
-          return 'v1';
-        } else if (decodedData.startsWith('relayedTxV2@')) {
-          return 'v2';
-        }
+      if (decodedData.startsWith('relayedTx@')) {
+        return 'v1';
+      } else if (decodedData.startsWith('relayedTxV2@')) {
+        return 'v2';
       }
-
-      return undefined;
     }
+
+    return undefined;
+  }
 }

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -38,6 +38,7 @@ export class TransferController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'relayer', description: 'Filter by relayer address', required: false })
+  @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -61,6 +62,7 @@ export class TransferController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('relayer', ParseAddressPipe) relayer?: string,
+    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
@@ -86,6 +88,7 @@ export class TransferController {
       after,
       order,
       relayer,
+      isRelayed,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -107,6 +110,7 @@ export class TransferController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   async getAccountTransfersCount(
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
@@ -119,6 +123,7 @@ export class TransferController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       senders: sender,
@@ -132,6 +137,7 @@ export class TransferController {
       status,
       before,
       after,
+      isRelayed,
     }));
   }
 


### PR DESCRIPTION
 
## Proposed Changes
- add support for `isRelayed` filter in `transfers`
- add `relayer` field

## How to test
- `<api>/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u/transfers?relayer=erd17ndrqg38lqf2zjgeqvle90rsn9ejrd9upx8evkyvh8e0m5xlph5scv9l6n` -> should return all accounts transfers based on relayer address
- `<api>/transactions/107324e85cc770dc10b6134ad75d2eef3f48b76e4b2757ce962c1bef8fb3073f` -> should return `relayer` address
- `<api>/transfers?isRelayed=true` -> should return all relayed transfers
- `<api>/transfers/count?isRelayed=true` -> should return relayed count
