### PR TITLE
add support for wildSearchcard accounts

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -619,6 +619,10 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.addresses, address => QueryType.Match('address', address));
     }
 
+    if (filter.search) {
+      elasticQuery = elasticQuery.withSearchWildcardCondition(filter.search, ['address', 'api_assets.name']);
+    }
+
     return elasticQuery;
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -94,6 +94,7 @@ export class AccountController {
   @ApiQuery({ name: 'tags', description: 'Filter accounts by assets tags', required: false })
   @ApiQuery({ name: 'excludeTags', description: 'Exclude specific tags from result', required: false })
   @ApiQuery({ name: 'hasAssets', description: 'Returns a list of accounts that have assets', required: false })
+  @ApiQuery({ name: 'search', description: 'Search by account address', required: false })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -109,6 +110,7 @@ export class AccountController {
     @Query("withScrCount", new ParseBoolPipe) withScrCount?: boolean,
     @Query("excludeTags", new ParseArrayPipe) excludeTags?: string[],
     @Query("hasAssets", new ParseBoolPipe) hasAssets?: boolean,
+    @Query("search") search?: string,
   ): Promise<Account[]> {
     const queryOptions = new AccountQueryOptions(
       {
@@ -124,6 +126,7 @@ export class AccountController {
         tags,
         excludeTags,
         hasAssets,
+        search,
       });
     queryOptions.validate(size);
     return this.accountService.getAccounts(

--- a/src/endpoints/accounts/entities/account.query.options.ts
+++ b/src/endpoints/accounts/entities/account.query.options.ts
@@ -21,6 +21,7 @@ export class AccountQueryOptions {
   tags?: string[];
   excludeTags?: string[];
   hasAssets?: boolean;
+  search?: string;
 
   validate(size: number) {
     if (this.withDeployInfo && size > 25) {
@@ -46,6 +47,7 @@ export class AccountQueryOptions {
       this.name !== undefined ||
       this.tags !== undefined ||
       this.excludeTags !== undefined ||
-      this.hasAssets !== undefined;
+      this.hasAssets !== undefined ||
+      this.search !== undefined;
   }
 }


### PR DESCRIPTION
 
## Proposed Changes
- added support for wildcard account search
- added `search` filter on accounts endpoint

## How to test
- `<api>/accounts?search=mex`
