### PR TITLE
Basic support for innerTx in transfers endpoint

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -286,7 +286,10 @@ export class ElasticIndexerHelper {
         QueryType.Exists('canBeIgnored'),
       ]))
         .withCondition(QueryConditionOptions.should, QueryType.Must([
-          QueryType.Match('type', 'normal'),
+          QueryType.Should([
+            QueryType.Match('type', 'normal'),
+            QueryType.Match('type', 'innerTx'),
+          ]),
           QueryType.Should([
             QueryType.Match('sender', filter.address),
             QueryType.Match('receiver', filter.address),

--- a/src/endpoints/transactions/entities/transaction.type.ts
+++ b/src/endpoints/transactions/entities/transaction.type.ts
@@ -3,7 +3,8 @@ import { registerEnumType } from "@nestjs/graphql";
 export enum TransactionType {
   Transaction = 'Transaction',
   SmartContractResult = 'SmartContractResult',
-  Reward = 'Reward'
+  InnerTransaction = 'InnerTransaction',
+  Reward = 'Reward',
 }
 
 registerEnumType(TransactionType, {
@@ -15,6 +16,9 @@ registerEnumType(TransactionType, {
     },
     SmartContractResult: {
       description: 'SmartContractResult type.',
+    },
+    InnerTransaction: {
+      description: 'InnerTransaction type.',
     },
     Reward: {
       description: 'Reward type.',

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -50,8 +50,19 @@ export class TransferService {
 
     for (const elasticOperation of elasticOperations) {
       const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
-      transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
       transaction.relayer = elasticOperation.relayerAddr;
+
+      switch (elasticOperation.type) {
+        case 'normal':
+          transaction.type = TransactionType.Transaction;
+          break;
+        case 'unsigned':
+          transaction.type = TransactionType.SmartContractResult;
+          break;
+        case 'innerTx':
+          transaction.type = TransactionType.InnerTransaction;
+          break;
+      }
 
       if (transaction.type === TransactionType.SmartContractResult) {
         delete transaction.gasLimit;


### PR DESCRIPTION
## Proposed Changes
- Add support for inner transactions in ElasticSearch

## How to test
- `/transactions/:txHash` should return innerTransaction value transfers (EGLD, ESDT) as operations
- `/transfers`, `/accounts/:address/transfers` should return innerTransactions from relayed transactions as well, with type `InnerTransaction`
