### PR TITLE
Reset transferLast24h to 0 for accounts that have no transactions in the last 24h

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -402,7 +402,7 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getList('operations', 'hash', elasticQuery);
   }
 
-  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<any[]> {
+  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions, fields?: string[]): Promise<any[]> {
     let elasticQuery = this.indexerHelper.buildAccountFilterQuery(filter);
     const sortOrder: ElasticSortOrder = !filter.order || filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending;
     const sort: AccountSort = filter.sort ?? AccountSort.balance;
@@ -426,6 +426,10 @@ export class ElasticIndexerService implements IndexerInterface {
     }
 
     elasticQuery = elasticQuery.withPagination(queryPagination);
+
+    if (fields && fields.length > 0) {
+      elasticQuery = elasticQuery.withFields(fields);
+    }
 
     return await this.elasticService.getList('accounts', 'address', elasticQuery);
   }
@@ -974,5 +978,15 @@ export class ElasticIndexerService implements IndexerInterface {
     const elasticQuery = this.indexerHelper.buildApplicationFilter(filter);
 
     return await this.elasticService.getCount('scdeploys', elasticQuery);
+  }
+
+  async getAddressesWithTransfersLast24h(): Promise<string[]> {
+    const elasticQuery = ElasticQuery.create()
+      .withFields(['address'])
+      .withPagination({ from: 0, size: 10000 })
+      .withMustExistCondition('api_transfersLast24h');
+
+    const result = await this.elasticService.getList('accounts', 'address', elasticQuery);
+    return result.map(x => x.address);
   }
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -102,13 +102,13 @@ export interface IndexerInterface {
 
   getAccount(address: string): Promise<Account>
 
-  getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<Account[]>
+  getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions, fields?: string[]): Promise<Account[]>
 
   getAccountDeploys(pagination: QueryPagination, address: string): Promise<ScDeploy[]>
 
   getAccountContracts(pagination: QueryPagination, address: string): Promise<any[]>
 
-  getAccountContractsCount( address: string): Promise<number>
+  getAccountContractsCount(address: string): Promise<number>
 
   getAccountHistory(address: string, pagination: QueryPagination, filter: AccountHistoryFilter): Promise<AccountHistory[]>
 
@@ -185,4 +185,6 @@ export interface IndexerInterface {
   getApplications(filter: ApplicationFilter, pagination: QueryPagination): Promise<any[]>
 
   getApplicationCount(filter: ApplicationFilter): Promise<number>
+
+  getAddressesWithTransfersLast24h(): Promise<string[]>
 }

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -225,8 +225,8 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions): Promise<Account[]> {
-    return await this.indexerInterface.getAccounts(queryPagination, filter);
+  async getAccounts(queryPagination: QueryPagination, filter: AccountQueryOptions, fields?: string[]): Promise<Account[]> {
+    return await this.indexerInterface.getAccounts(queryPagination, filter, fields);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
@@ -447,5 +447,10 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getApplicationCount(filter: ApplicationFilter): Promise<number> {
     return await this.indexerInterface.getApplicationCount(filter);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getAddressesWithTransfersLast24h(): Promise<string[]> {
+    return await this.indexerInterface.getAddressesWithTransfersLast24h();
   }
 }

--- a/src/common/indexer/postgres/postgres.indexer.service.ts
+++ b/src/common/indexer/postgres/postgres.indexer.service.ts
@@ -402,12 +402,12 @@ export class PostgresIndexerService implements IndexerInterface {
     return await query.getMany();
   }
 
-   getAccountContracts(): Promise<any[]> {
+  getAccountContracts(): Promise<any[]> {
     throw new Error("Method not implemented.");
   }
 
   getAccountContractsCount(): Promise<number> {
-   throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.");
   }
 
   async getAccountHistory(address: string, { from, size }: QueryPagination): Promise<any[]> {
@@ -688,5 +688,10 @@ export class PostgresIndexerService implements IndexerInterface {
 
   async setAccountTransfersLast24h(_address: string, _transfersLast24h: number): Promise<void> {
     // TODO custom columns cannot be added
+  }
+
+  async getAddressesWithTransfersLast24h(): Promise<string[]> {
+    // TODO not implemented
+    return [];
   }
 }

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -33,6 +33,7 @@ import { PoolService } from "src/endpoints/pool/pool.service";
 import * as JsonDiff from "json-diff";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { StakeService } from "src/endpoints/stake/stake.service";
+import { ApplicationMostUsed } from "src/endpoints/accounts/entities/application.most.used";
 
 @Injectable()
 export class CacheWarmerService {
@@ -378,21 +379,28 @@ export class CacheWarmerService {
   async handleUpdateAccountTransfersLast24h() {
     const batchSize = 100;
     const mostUsed = await this.accountService.getApplicationMostUsedRaw();
+    const mostUsedIndexedAccounts = await this.indexerService.getAddressesWithTransfersLast24h()
 
-    const batches = BatchUtils.splitArrayIntoChunks(mostUsed, batchSize);
+    const allAddressesToUpdate = [...mostUsed.map(item => item.address), ...mostUsedIndexedAccounts].distinct();
+    const mostUsedDictionary = mostUsed.toRecord<ApplicationMostUsed>(item => item.address);
+
+    const batches = BatchUtils.splitArrayIntoChunks(allAddressesToUpdate, batchSize);
     for (const batch of batches) {
       const accounts = await this.indexerService.getAccounts(
         new QueryPagination({ from: 0, size: batchSize }),
-        new AccountQueryOptions({ addresses: batch.map(item => item.address) }),
+        new AccountQueryOptions({ addresses: batch }),
+        ['address', 'api_transfersLast24h']
       );
 
-      const accountsDictionary = accounts.toRecord<Account>(account => account.address);
+      const accountsDictionary = accounts.toRecord<Pick<Account, 'address' | 'api_transfersLast24h'>>(account => account.address);
 
-      for (const item of batch) {
-        const account = accountsDictionary[item.address];
-        if (account && account.api_transfersLast24h !== item.transfers24H) {
-          this.logger.log(`Setting transferLast24h to ${item.transfers24H} for account with address '${item.address}'`);
-          await this.indexerService.setAccountTransfersLast24h(item.address, item.transfers24H);
+      for (const address of batch) {
+        const account = accountsDictionary[address];
+        const newTransfersLast24h = mostUsedDictionary[address]?.transfers24H ?? 0;
+
+        if (account && account.api_transfersLast24h !== newTransfersLast24h) {
+          this.logger.log(`Setting transferLast24h to ${newTransfersLast24h} for account with address '${address}'`);
+          await this.indexerService.setAccountTransfersLast24h(address, newTransfersLast24h);
         }
       }
     }


### PR DESCRIPTION
## Reasoning
- We have a cron that sets in the indexer the number of transfers in the last 24 hours for each address. The addresses that no longer had transfers remained set with the old value and were no longer updated
- Added a new option in the indexer on the `getAccounts` method called `fields` that fetches only the required fields from the indexer to reduce traffic
  
## Proposed Changes
- In the `handleUpdateAccountTransfersLast24h` cron, the addresses that have already set a value on the custom key are also taken and set to 0 if they do not appear in the list with the most transfers
