### PR TITLE
add round filter for transactions / transfers

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -400,6 +400,10 @@ export class ElasticIndexerHelper {
         ]));
     }
 
+    if (filter.round) {
+      elasticQuery = elasticQuery.withMustMatchCondition('round', filter.round);
+    }
+
     return elasticQuery;
   }
 
@@ -528,6 +532,10 @@ export class ElasticIndexerHelper {
 
     if (filter.isRelayed) {
       elasticQuery = elasticQuery.withMustMatchCondition('isRelayed', filter.isRelayed);
+    }
+
+    if (filter.round) {
+      elasticQuery = elasticQuery.withMustMatchCondition('round', filter.round);
     }
 
     if (filter.condition === QueryConditionOptions.should) {

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -852,6 +852,7 @@ export class AccountController {
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'withScResults', description: 'Return scResults for transactions. When "withScresults" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transactions. When "withOperations" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions. When "withLogs" parameter is applied, complexity estimation is 200', required: false })
@@ -877,6 +878,7 @@ export class AccountController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
@@ -906,6 +908,7 @@ export class AccountController {
       order,
       senderOrReceiver,
       isRelayed,
+      round,
     }), new QueryPagination({ from, size }), options, address, fields);
   }
 
@@ -923,6 +926,7 @@ export class AccountController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns isRelayed transactions details', required: false, type: Boolean })
   async getAccountTransactionsCount(
@@ -938,6 +942,7 @@ export class AccountController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
@@ -956,6 +961,7 @@ export class AccountController {
       after,
       senderOrReceiver,
       isRelayed,
+      round,
     }), address);
   }
 
@@ -977,6 +983,7 @@ export class AccountController {
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'relayer', description: 'Address of the relayer', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
@@ -1001,6 +1008,7 @@ export class AccountController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('relayer', ParseAddressPipe) relayer?: string,
@@ -1031,6 +1039,7 @@ export class AccountController {
       order,
       senderOrReceiver,
       relayer,
+      round,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -1052,6 +1061,7 @@ export class AccountController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   async getAccountTransfersCount(
     @Param('address', ParseAddressPipe) address: string,
@@ -1066,6 +1076,7 @@ export class AccountController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -1082,6 +1093,7 @@ export class AccountController {
       before,
       after,
       senderOrReceiver,
+      round,
     }));
   }
 
@@ -1100,6 +1112,7 @@ export class AccountController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -1116,6 +1129,7 @@ export class AccountController {
       before,
       after,
       senderOrReceiver,
+      round,
     }));
   }
 

--- a/src/endpoints/accounts/entities/account.ts
+++ b/src/endpoints/accounts/entities/account.ts
@@ -50,7 +50,7 @@ export class Account {
   ownerAssets: AccountAssets | undefined = undefined;
 
   @Field(() => Boolean, { description: 'If the given detailed account is verified.', nullable: true })
-  @ApiProperty({ description: 'Specific property flag for smart contract', type: Boolean })
+  @ApiProperty({ description: 'Specific property flag for smart contract', type: Boolean, required: false })
   isVerified?: boolean;
 
   @Field(() => Float, { description: 'Transactions count for the given detailed account.' })

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -327,6 +327,7 @@ export class CollectionController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -349,6 +350,7 @@ export class CollectionController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
@@ -376,6 +378,7 @@ export class CollectionController {
       before,
       after,
       order,
+      round,
     }), new QueryPagination({ from, size }), options);
   }
 
@@ -392,6 +395,7 @@ export class CollectionController {
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   async getCollectionTransactionsCount(
     @Param('collection', ParseCollectionPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -403,6 +407,7 @@ export class CollectionController {
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ) {
     const isCollection = await this.collectionService.isCollection(identifier);
     if (!isCollection) {
@@ -420,6 +425,7 @@ export class CollectionController {
       status,
       before,
       after,
+      round,
     }));
   }
 
@@ -438,6 +444,7 @@ export class CollectionController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -460,6 +467,7 @@ export class CollectionController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
@@ -487,6 +495,7 @@ export class CollectionController {
       before,
       after,
       order,
+      round,
     }), new QueryPagination({ from, size }), options);
   }
 
@@ -504,6 +513,7 @@ export class CollectionController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   async getCollectionTransfersCount(
     @Param('collection', ParseCollectionPipe) identifier: string,
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
@@ -516,6 +526,7 @@ export class CollectionController {
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ) {
     const isCollection = await this.collectionService.isCollection(identifier);
     if (!isCollection) {
@@ -534,6 +545,7 @@ export class CollectionController {
       before,
       after,
       functions,
+      round,
     }));
   }
 

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -208,6 +208,7 @@ export class TokenController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -232,6 +233,7 @@ export class TokenController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
@@ -262,6 +264,7 @@ export class TokenController {
       before,
       after,
       order,
+      round,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -283,6 +286,7 @@ export class TokenController {
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   async getTokenTransactionsCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -294,6 +298,7 @@ export class TokenController {
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ) {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -311,6 +316,7 @@ export class TokenController {
       status,
       before,
       after,
+      round,
     }));
   }
 
@@ -372,6 +378,7 @@ export class TokenController {
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
@@ -391,6 +398,7 @@ export class TokenController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
@@ -418,6 +426,7 @@ export class TokenController {
       before,
       after,
       order,
+      round,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -438,6 +447,7 @@ export class TokenController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   async getTokenTransfersCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -450,6 +460,7 @@ export class TokenController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ): Promise<number> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -468,6 +479,7 @@ export class TokenController {
       status,
       before,
       after,
+      round,
     }));
   }
 
@@ -485,6 +497,7 @@ export class TokenController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ): Promise<number> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -503,6 +516,7 @@ export class TokenController {
       status,
       before,
       after,
+      round,
     }));
   }
 

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -28,4 +28,5 @@ export class TransactionFilter {
   senderOrReceiver?: string;
   isRelayed?: boolean;
   relayer?: string;
+  round?: number;
 }

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -35,6 +35,7 @@ export class TransactionController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
@@ -63,6 +64,7 @@ export class TransactionController {
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
@@ -91,6 +93,7 @@ export class TransactionController {
       condition,
       order,
       isRelayed,
+      round,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -114,6 +117,7 @@ export class TransactionController {
   @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   getTransactionCount(
     @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
@@ -128,6 +132,7 @@ export class TransactionController {
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
@@ -144,6 +149,7 @@ export class TransactionController {
       after,
       condition,
       isRelayed,
+      round,
     }));
   }
 
@@ -162,6 +168,7 @@ export class TransactionController {
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', new ParseIntPipe) round?: number,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
@@ -178,6 +185,7 @@ export class TransactionController {
       after,
       condition,
       isRelayed,
+      round,
     }));
   }
 

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -36,6 +36,7 @@ export class TransferController {
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'relayer', description: 'Filter by relayer address', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
@@ -59,6 +60,7 @@ export class TransferController {
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('relayer', ParseAddressPipe) relayer?: string,
@@ -89,6 +91,7 @@ export class TransferController {
       order,
       relayer,
       isRelayed,
+      round,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -110,6 +113,7 @@ export class TransferController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   async getAccountTransfersCount(
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -123,6 +127,7 @@ export class TransferController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -138,6 +143,7 @@ export class TransferController {
       before,
       after,
       isRelayed,
+      round,
     }));
   }
 
@@ -155,6 +161,7 @@ export class TransferController {
     @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
+    @Query('round', ParseIntPipe) round?: number,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       senders: sender,
@@ -168,6 +175,7 @@ export class TransferController {
       status,
       before,
       after,
+      round,
     }));
   }
 }


### PR DESCRIPTION
 
## Proposed Changes
- added `round` filter for the following endpoints
- `transfers` -> `transactions` -> `accounts/:address/transactions` -> `accounts/:address/transfers` -> `accounts/:address/transactions/count` -> `accounts/:address/transfers/count` -> `collections/:identifier/transfers` -> `collections/:identifier/transfers/count` -> `collections/:identifier/transactions` -> `collections/:identifier/transactions/count` -> `tokens/:identifier/transactions` -> `tokens/:identifier/transactions/count` -> `tokens/:identifier/transfers` -> `tokens/:identifier/transfers/count`

## How to test
- `<api>/transactions?round=270791`
- `<api>/transactions/count?round=270791`
- `<api>/transfers?round=270791`
- `<api>/transfers/count?round=270791`
- `<api>/accounts/erd1essu6c8rv6n35s6whfklxj907e22msu786vzd9m65802qf2y9ukq8uqmtw/transactions?round=270791`
- `<api>/accounts/erd1essu6c8rv6n35s6whfklxj907e22msu786vzd9m65802qf2y9ukq8uqmtw/transactions/count?round=270791`
-  `<api>/accounts/erd1essu6c8rv6n35s6whfklxj907e22msu786vzd9m65802qf2y9ukq8uqmtw/transfers?round=270791`
- `<api>/accounts/erd1essu6c8rv6n35s6whfklxj907e22msu786vzd9m65802qf2y9ukq8uqmtw/transfers/count?round=270791`
- `<api>/tokens/ROSETTA-449e95/transactions?round=154696`
- `<api>/tokens/ROSETTA-449e95/transactions/count?round=154696`
- `<api>/tokens/ROSETTA-449e95/transfers?round=154696`
- `<api>/tokens/ROSETTA-449e95/transfers/count?round=154696`
- `<api>/collections/NFTOOTH-bad29b/transactions?round=54697`
- `<api>/collections/NFTOOTH-bad29b/transactions/count?round=54697`
