### PR TITLE
remove new keyword for query parsers without specific parameter

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -104,13 +104,13 @@ export class AccountController {
     @Query("tags", new ParseArrayPipe()) tags?: string[],
     @Query('sort', new ParseEnumPipe(AccountSort)) sort?: AccountSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
-    @Query("withOwnerAssets", new ParseBoolPipe) withOwnerAssets?: boolean,
-    @Query("withDeployInfo", new ParseBoolPipe) withDeployInfo?: boolean,
-    @Query("withTxCount", new ParseBoolPipe) withTxCount?: boolean,
-    @Query("withScrCount", new ParseBoolPipe) withScrCount?: boolean,
-    @Query("excludeTags", new ParseArrayPipe) excludeTags?: string[],
-    @Query("hasAssets", new ParseBoolPipe) hasAssets?: boolean,
+    @Query("isSmartContract", ParseBoolPipe) isSmartContract?: boolean,
+    @Query("withOwnerAssets", ParseBoolPipe) withOwnerAssets?: boolean,
+    @Query("withDeployInfo", ParseBoolPipe) withDeployInfo?: boolean,
+    @Query("withTxCount", ParseBoolPipe) withTxCount?: boolean,
+    @Query("withScrCount", ParseBoolPipe) withScrCount?: boolean,
+    @Query("excludeTags", ParseArrayPipe) excludeTags?: string[],
+    @Query("hasAssets", ParseBoolPipe) hasAssets?: boolean,
     @Query("search") search?: string,
   ): Promise<Account[]> {
     const queryOptions = new AccountQueryOptions(
@@ -147,11 +147,11 @@ export class AccountController {
   @ApiQuery({ name: 'hasAssets', description: 'Returns a list of accounts that have assets', required: false })
   async getAccountsCount(
     @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
-    @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
+    @Query("isSmartContract", ParseBoolPipe) isSmartContract?: boolean,
     @Query("name") name?: string,
     @Query("tags", new ParseArrayPipe()) tags?: string[],
-    @Query("excludeTags", new ParseArrayPipe) excludeTags?: string[],
-    @Query("hasAssets", new ParseBoolPipe) hasAssets?: boolean,
+    @Query("excludeTags", ParseArrayPipe) excludeTags?: string[],
+    @Query("hasAssets", ParseBoolPipe) hasAssets?: boolean,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(
       new AccountQueryOptions(
@@ -169,11 +169,11 @@ export class AccountController {
   @ApiExcludeEndpoint()
   async getAccountsCountAlternative(
     @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
-    @Query("isSmartContract", new ParseBoolPipe) isSmartContract?: boolean,
+    @Query("isSmartContract", ParseBoolPipe) isSmartContract?: boolean,
     @Query("name") name?: string,
     @Query("tags", new ParseArrayPipe()) tags?: string[],
-    @Query("excludeTags", new ParseArrayPipe) excludeTags?: string[],
-    @Query("hasAssets", new ParseBoolPipe) hasAssets?: boolean,
+    @Query("excludeTags", ParseArrayPipe) excludeTags?: string[],
+    @Query("hasAssets", ParseBoolPipe) hasAssets?: boolean,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(
       new AccountQueryOptions(
@@ -196,7 +196,7 @@ export class AccountController {
   @ApiOkResponse({ type: AccountDetailed })
   async getAccountDetails(
     @Param('address', ParseAddressPipe) address: string,
-    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo?: boolean,
+    @Query('withGuardianInfo', ParseBoolPipe) withGuardianInfo?: boolean,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<AccountDetailed> {
@@ -257,7 +257,7 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<TokenWithBalance[]> {
@@ -290,7 +290,7 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
@@ -314,7 +314,7 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('identifier') identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<number> {
@@ -370,13 +370,13 @@ export class AccountController {
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canCreate', new ParseBoolPipe) canCreate?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('canAddQuantity', new ParseBoolPipe) canAddQuantity?: boolean,
-    @Query('canUpdateAttributes', new ParseBoolPipe) canUpdateAttributes?: boolean,
-    @Query('canAddUri', new ParseBoolPipe) canAddUri?: boolean,
-    @Query('canTransferRole', new ParseBoolPipe) canTransferRole?: boolean,
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('canCreate', ParseBoolPipe) canCreate?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('canAddQuantity', ParseBoolPipe) canAddQuantity?: boolean,
+    @Query('canUpdateAttributes', ParseBoolPipe) canUpdateAttributes?: boolean,
+    @Query('canAddUri', ParseBoolPipe) canAddUri?: boolean,
+    @Query('canTransferRole', ParseBoolPipe) canTransferRole?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<NftCollectionWithRoles[]> {
     return await this.collectionService.getCollectionsWithRolesForAddress(
       address,
@@ -412,10 +412,10 @@ export class AccountController {
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canCreate', new ParseBoolPipe) canCreate?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('canAddQuantity', new ParseBoolPipe) canAddQuantity?: boolean,
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('canCreate', ParseBoolPipe) canCreate?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('canAddQuantity', ParseBoolPipe) canAddQuantity?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddressWithRoles(address, new CollectionFilter({ search, type, subType, owner, canCreate, canBurn, canAddQuantity, excludeMetaESDT }));
   }
@@ -428,10 +428,10 @@ export class AccountController {
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canCreate', new ParseBoolPipe) canCreate?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('canAddQuantity', new ParseBoolPipe) canAddQuantity?: boolean,
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('canCreate', ParseBoolPipe) canCreate?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('canAddQuantity', ParseBoolPipe) canAddQuantity?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddressWithRoles(address, new CollectionFilter({
       search, type, subType, owner, canCreate, canBurn, canAddQuantity, excludeMetaESDT,
@@ -469,9 +469,9 @@ export class AccountController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canMint', new ParseBoolPipe) canMint?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('canMint', ParseBoolPipe) canMint?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
   ): Promise<TokenWithRoles[]> {
     return await this.tokenService.getTokensWithRolesForAddress(address, new TokenWithRolesFilter({ search, owner, canMint, canBurn, includeMetaESDT }), new QueryPagination({ from, size }));
   }
@@ -488,9 +488,9 @@ export class AccountController {
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canMint', new ParseBoolPipe) canMint?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('canMint', ParseBoolPipe) canMint?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.tokenService.getTokensWithRolesForAddressCount(address, new TokenWithRolesFilter({ search, owner, canMint, canBurn, includeMetaESDT }));
   }
@@ -501,9 +501,9 @@ export class AccountController {
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
-    @Query('canMint', new ParseBoolPipe) canMint?: boolean,
-    @Query('canBurn', new ParseBoolPipe) canBurn?: boolean,
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('canMint', ParseBoolPipe) canMint?: boolean,
+    @Query('canBurn', ParseBoolPipe) canBurn?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.tokenService.getTokensWithRolesForAddressCount(address, new TokenWithRolesFilter({ search, owner, canMint, canBurn, includeMetaESDT }));
   }
@@ -539,7 +539,7 @@ export class AccountController {
     @Query('search') search?: string,
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<NftCollectionAccount[]> {
     return await this.collectionService.getCollectionsForAddress(
       address,
@@ -559,7 +559,7 @@ export class AccountController {
     @Query('search') search?: string,
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddress(address, new CollectionFilter({ search, type, subType, excludeMetaESDT }));
   }
@@ -571,7 +571,7 @@ export class AccountController {
     @Query('search') search?: string,
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('subType', new ParseEnumArrayPipe(NftSubType)) subType?: NftSubType[],
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddress(address, new CollectionFilter({ search, type, subType, excludeMetaESDT }));
   }
@@ -630,13 +630,13 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
-    @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
-    @Query('includeFlagged', new ParseBoolPipe) includeFlagged?: boolean,
-    @Query('withSupply', new ParseBoolPipe) withSupply?: boolean,
+    @Query('hasUris', ParseBoolPipe) hasUris?: boolean,
+    @Query('includeFlagged', ParseBoolPipe) includeFlagged?: boolean,
+    @Query('withSupply', ParseBoolPipe) withSupply?: boolean,
     @Query('source', new ParseEnumPipe(EsdtDataSource)) source?: EsdtDataSource,
     @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
     @Query('fields', ParseArrayPipe) fields?: string[],
-    @Query('isScam', new ParseBoolPipe) isScam?: boolean,
+    @Query('isScam', ParseBoolPipe) isScam?: boolean,
     @Query('scamType', new ParseEnumPipe(ScamType)) scamType?: ScamType,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<NftAccount[]> {
@@ -695,10 +695,10 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
-    @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
-    @Query('includeFlagged', new ParseBoolPipe) includeFlagged?: boolean,
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
-    @Query('isScam', new ParseBoolPipe) isScam?: boolean,
+    @Query('hasUris', ParseBoolPipe) hasUris?: boolean,
+    @Query('includeFlagged', ParseBoolPipe) includeFlagged?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('isScam', ParseBoolPipe) isScam?: boolean,
     @Query('scamType', new ParseEnumPipe(ScamType)) scamType?: ScamType,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<number> {
@@ -734,10 +734,10 @@ export class AccountController {
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
-    @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
-    @Query('includeFlagged', new ParseBoolPipe) includeFlagged?: boolean,
-    @Query('excludeMetaESDT', new ParseBoolPipe) excludeMetaESDT?: boolean,
-    @Query('isScam', new ParseBoolPipe) isScam?: boolean,
+    @Query('hasUris', ParseBoolPipe) hasUris?: boolean,
+    @Query('includeFlagged', ParseBoolPipe) includeFlagged?: boolean,
+    @Query('excludeMetaESDT', ParseBoolPipe) excludeMetaESDT?: boolean,
+    @Query('isScam', ParseBoolPipe) isScam?: boolean,
     @Query('scamType', new ParseEnumPipe(ScamType)) scamType?: ScamType,
     @Query('timestamp', ParseIntPipe) _timestamp?: number,
   ): Promise<number> {
@@ -881,14 +881,14 @@ export class AccountController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
-    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
@@ -1012,12 +1012,12 @@ export class AccountController {
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('relayer', ParseAddressPipe) relayer?: string,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ): Promise<Transaction[]> {
     const options = TransactionQueryOptions.applyDefaultOptions(

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -178,12 +178,12 @@ export class NftController {
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
     @Query('isWhitelistedStorage', new ParseBoolPipe) isWhitelistedStorage?: boolean,
-    @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
-    @Query('isNsfw', new ParseBoolPipe) isNsfw?: boolean,
-    @Query('traits', new ParseRecordPipe) traits?: Record<string, string>,
-    @Query('before', new ParseIntPipe) before?: number,
-    @Query('after', new ParseIntPipe) after?: number,
-    @Query('isScam', new ParseBoolPipe) isScam?: boolean,
+    @Query('hasUris', ParseBoolPipe) hasUris?: boolean,
+    @Query('isNsfw', ParseBoolPipe) isNsfw?: boolean,
+    @Query('traits', ParseRecordPipe) traits?: Record<string, string>,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+    @Query('isScam', ParseBoolPipe) isScam?: boolean,
     @Query('scamType', new ParseEnumPipe(ScamType)) scamType?: ScamType,
   ): Promise<number> {
     return await this.nftService.getNftCount(new NftFilter({ search, identifiers, type, subType, collection, collections, name, tags, creator, isWhitelistedStorage, hasUris, isNsfw, traits, before, after, isScam, scamType }));
@@ -312,11 +312,11 @@ export class NftController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
 
@@ -414,11 +414,11 @@ export class NftController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
+    @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername });
 

--- a/src/endpoints/nodes/node.controller.ts
+++ b/src/endpoints/nodes/node.controller.ts
@@ -59,7 +59,7 @@ export class NodeController {
     @Query('fullHistory', ParseBoolPipe) fullHistory?: boolean,
     @Query('sort', new ParseEnumPipe(NodeSort)) sort?: NodeSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
+    @Query('withIdentityInfo', ParseBoolPipe) withIdentityInfo?: boolean,
     @Query('isQualified', ParseBoolPipe) isQualified?: boolean,
     @Query('isAuctioned', ParseBoolPipe) isAuctioned?: boolean,
     @Query('isAuctionDangerZone', ParseBoolPipe) isAuctionDangerZone?: boolean,

--- a/src/endpoints/providers/provider.controller.ts
+++ b/src/endpoints/providers/provider.controller.ts
@@ -26,8 +26,8 @@ export class ProviderController {
     @Query('identity') identity?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('providers', ParseAddressArrayPipe) providers?: string[],
-    @Query('withIdentityInfo', new ParseBoolPipe) withIdentityInfo?: boolean,
-    @Query('withLatestInfo', new ParseBoolPipe) withLatestInfo?: boolean,
+    @Query('withIdentityInfo', ParseBoolPipe) withIdentityInfo?: boolean,
+    @Query('withLatestInfo', ParseBoolPipe) withLatestInfo?: boolean,
   ): Promise<Provider[]> {
     const options = ProviderQueryOptions.applyDefaultOptions(owner, { withIdentityInfo, withLatestInfo });
 

--- a/src/endpoints/rounds/round.controller.ts
+++ b/src/endpoints/rounds/round.controller.ts
@@ -26,8 +26,8 @@ export class RoundController {
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query("validator", ParseBlsHashPipe) validator?: string,
     @Query('condition', new ParseEnumPipe(QueryConditionOptions)) condition?: QueryConditionOptions,
-    @Query("shard", new ParseIntPipe) shard?: number,
-    @Query("epoch", new ParseIntPipe) epoch?: number,
+    @Query("shard", ParseIntPipe) shard?: number,
+    @Query("epoch", ParseIntPipe) epoch?: number,
   ): Promise<Round[]> {
     return this.roundService.getRounds(new RoundFilter({ from, size, condition, validator, shard, epoch }));
   }
@@ -42,8 +42,8 @@ export class RoundController {
   getRoundCount(
     @Query("validator", ParseBlsHashPipe) validator?: string,
     @Query('condition', new ParseEnumPipe(QueryConditionOptions)) condition?: QueryConditionOptions,
-    @Query("shard", new ParseIntPipe) shard?: number,
-    @Query("epoch", new ParseIntPipe) epoch?: number,
+    @Query("shard", ParseIntPipe) shard?: number,
+    @Query("epoch", ParseIntPipe) epoch?: number,
   ): Promise<number> {
     return this.roundService.getRoundCount(new RoundFilter({ condition, validator, shard, epoch }));
   }
@@ -53,8 +53,8 @@ export class RoundController {
   getRoundCountAlternative(
     @Query("validator", ParseBlsHashPipe) validator?: string,
     @Query('condition', new ParseEnumPipe(QueryConditionOptions)) condition?: QueryConditionOptions,
-    @Query("shard", new ParseIntPipe) shard?: number,
-    @Query("epoch", new ParseIntPipe) epoch?: number,
+    @Query("shard", ParseIntPipe) shard?: number,
+    @Query("epoch", ParseIntPipe) epoch?: number,
   ): Promise<number> {
     return this.roundService.getRoundCount(new RoundFilter({ condition, validator, shard, epoch }));
   }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -59,7 +59,7 @@ export class TokenController {
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('sort', new ParseEnumPipe(TokenSort)) sort?: TokenSort,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
     @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<TokenDetailed[]> {
@@ -87,7 +87,7 @@ export class TokenController {
     @Query('type', new ParseEnumPipe(TokenType)) type?: TokenType,
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
     @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<number> {
@@ -102,7 +102,7 @@ export class TokenController {
     @Query('type', new ParseEnumPipe(TokenType)) type?: TokenType,
     @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
-    @Query('includeMetaESDT', new ParseBoolPipe) includeMetaESDT?: boolean,
+    @Query('includeMetaESDT', ParseBoolPipe) includeMetaESDT?: boolean,
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
     @Query('priceSource', new ParseEnumPipe(TokenAssetsPriceSourceType)) priceSource?: TokenAssetsPriceSourceType,
   ): Promise<number> {
@@ -116,7 +116,7 @@ export class TokenController {
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getToken(
     @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('denominated', new ParseBoolPipe) denominated?: boolean,
+    @Query('denominated', ParseBoolPipe) denominated?: boolean,
   ): Promise<TokenDetailed> {
     const supplyOptions = { denominated };
     const token = await this.tokenService.getToken(identifier, supplyOptions);
@@ -134,7 +134,7 @@ export class TokenController {
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getTokenSupply(
     @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('denominated', new ParseBoolPipe) denominated?: boolean,
+    @Query('denominated', ParseBoolPipe) denominated?: boolean,
   ): Promise<TokenSupplyResult> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -236,12 +236,12 @@ export class TokenController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
-    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
@@ -401,9 +401,9 @@ export class TokenController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ): Promise<Transaction[]> {
     const isToken = await this.tokenService.isToken(identifier);

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -67,13 +67,13 @@ export class TransactionController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
-    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
@@ -133,7 +133,7 @@ export class TransactionController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
       sender,
@@ -168,8 +168,8 @@ export class TransactionController {
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
-    @Query('round', new ParseIntPipe) round?: number,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('round', ParseIntPipe) round?: number,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
       sender,

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -64,12 +64,12 @@ export class TransferController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('relayer', ParseAddressPipe) relayer?: string,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
-    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
-    @Query('withUsername', new ParseBoolPipe) withUsername?: boolean,
-    @Query('withBlockInfo', new ParseBoolPipe) withBlockInfo?: boolean,
-    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
+    @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
+    @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
+    @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
+    @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
   ): Promise<Transaction[]> {
     const options = TransactionQueryOptions.applyDefaultOptions(
@@ -128,7 +128,7 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
-    @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       senders: sender,

--- a/src/endpoints/usernames/username.controller.ts
+++ b/src/endpoints/usernames/username.controller.ts
@@ -22,7 +22,7 @@ export class UsernameController {
   async getUsernameDetails(
     @Res() res: any,
     @Param('username') username: string,
-    @Query('withGuardianInfo', new ParseBoolPipe) withGuardianInfo: boolean
+    @Query('withGuardianInfo', ParseBoolPipe) withGuardianInfo: boolean
   ): Promise<AccountDetailed | null> {
     const address = await this.usernameService.getAddressForUsername(username);
     if (!address) {


### PR DESCRIPTION
## Reasoning
- we should use NestJs singleton `dependecy injection` for query parsers that `don't` have specific parameters
  
## Proposed Changes
- remove `new` keyword for query parsers `without` specific parameter

## How to test
- it should work the same as before
