### PR TITLE
Add 'addresses' query parameter to filter accounts by a list of addresses

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -5,6 +5,7 @@ export enum GatewayComponentRequest {
   networkEconomics = 'networkEconomics',
   networkTotalStaked = 'networkTotalStaked',
   addressDetails = 'addressDetails',
+  addressesBulk = 'addressesBulk',
   addressEsdt = 'addressEsdt',
   addressEsdtHistorical = 'addressEsdtHistorical',
   addressEsdtBalance = 'addressEsdtBalance',

--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -94,6 +94,11 @@ export class GatewayService {
     return result;
   }
 
+  async getAccountsBulk(addresses: string[]): Promise<Account[]> {
+    const result = await this.create('address/bulk', GatewayComponentRequest.addressDetails, addresses);
+    return result.accounts;
+  }
+
   async getEsdtSupply(identifier: string): Promise<EsdtSupply> {
     const result = await this.get(`network/esdt/supply/${identifier}`, GatewayComponentRequest.esdtSupply);
     return result;

--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -95,7 +95,7 @@ export class GatewayService {
   }
 
   async getAccountsBulk(addresses: string[]): Promise<Account[]> {
-    const result = await this.create('address/bulk', GatewayComponentRequest.addressDetails, addresses);
+    const result = await this.create('address/bulk', GatewayComponentRequest.addressesBulk, addresses);
     return result.accounts;
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -96,6 +96,7 @@ export class AccountController {
   @ApiQuery({ name: 'excludeTags', description: 'Exclude specific tags from result', required: false })
   @ApiQuery({ name: 'hasAssets', description: 'Returns a list of accounts that have assets', required: false })
   @ApiQuery({ name: 'search', description: 'Search by account address', required: false })
+  @ApiQuery({ name: 'addresses', description: 'A comma-separated list of addresses to filter by', required: false, type: String })
   getAccounts(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -112,10 +113,12 @@ export class AccountController {
     @Query("excludeTags", new ParseArrayPipe) excludeTags?: string[],
     @Query("hasAssets", new ParseBoolPipe) hasAssets?: boolean,
     @Query("search") search?: string,
+    @Query("addresses", ParseAddressArrayPipe) addresses?: string[],
   ): Promise<Account[]> {
     const queryOptions = new AccountQueryOptions(
       {
         ownerAddress,
+        addresses,
         sort,
         order,
         isSmartContract,

--- a/src/endpoints/accounts/entities/account.query.options.ts
+++ b/src/endpoints/accounts/entities/account.query.options.ts
@@ -35,6 +35,10 @@ export class AccountQueryOptions {
     if (this.withScrCount && size > 25) {
       throw new BadRequestException('Size must be less than or equal to 25 when withScrCount is set');
     }
+
+    if (this.addresses && this.addresses.length > 25) {
+      throw new BadRequestException('Addresses array must contain 25 or fewer elements');
+    }
   }
 
   isSet(): boolean {
@@ -48,6 +52,7 @@ export class AccountQueryOptions {
       this.tags !== undefined ||
       this.excludeTags !== undefined ||
       this.hasAssets !== undefined ||
-      this.search !== undefined;
+      this.search !== undefined ||
+      this.addresses !== undefined;
   }
 }


### PR DESCRIPTION
## Proposed Changes
- Introduces a new query parameter to filter accounts by a list of addresses and includes validation to ensure the addresses array does not exceed 25 elements.

## How to test
- `<api>/accounts?addresses=erd1an4xpn58j7ymd58m2jznr32t0vmas75egrdfa8mta6fzvqn9tkxq4jvghn,erd1kyle4p6chlvj0u6fyds7wj47jqwq6kh9h083kw8j76254l8u49dqepfz86`
- `<api>/accounts?addresses[... >25 ] -> should throw 400 Bad Request`
