### PR TITLE
uppercase token identifier

### DIFF
--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -239,6 +239,27 @@ describe('Token Service', () => {
       }));
     });
 
+    it('should return token even if the input string is not uppercase', async () => {
+      const data = require('../../mocks/tokens.mock.json');
+
+      tokenService.getAllTokens = jest.fn().mockResolvedValue(data);
+
+      tokenService.applyTickerFromAssets = jest.fn().mockResolvedValue(undefined);
+      tokenService.applySupply = jest.fn().mockResolvedValue(undefined);
+      tokenService.getTokenRoles = jest.fn().mockResolvedValue([]);
+
+      const result = await tokenService.getToken('wEglD-bd4d79');
+      expect(tokenService.getAllTokens).toHaveBeenCalledTimes(1);
+      expect(tokenService.applyTickerFromAssets).toHaveBeenCalledTimes(1);
+      expect(tokenService.applySupply).toHaveBeenCalledTimes(1);
+      expect(tokenService.getTokenRoles).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(expect.objectContaining({
+        identifier: 'WEGLD-bd4d79',
+        type: 'FungibleESDT',
+        price: 41.626458658528016,
+      }));
+    });
+
     it('should return undefined if identifier does not exist in getAllTokens', async () => {
       tokenService.getAllTokens = jest.fn().mockResolvedValue([]);
       tokenService.applyTickerFromAssets = jest.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Reasoning
- API queries regarding tokens were case sensitive. 
- API calls like `<api>/tokens/mex-455c57` did not work 
  
## Proposed Changes
- convert the ticker part of the token identifier to uppercase before searching inside underlying services

## How to test
- `<api>/tokens/mex-455c57` should work
