### PR TITLE
Add ResponseTimeCpuInterceptor to monitor response time and CPU usage per endpoint

### DIFF
--- a/src/interceptors/response-time.cpu.interceptor.ts
+++ b/src/interceptors/response-time.cpu.interceptor.ts
@@ -1,0 +1,36 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { MetricsService, PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
+
+@Injectable()
+export class ResponseTimeCpuInterceptor implements NestInterceptor {
+  constructor(private readonly metricsService: MetricsService) { }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const profiler = new PerformanceProfiler();
+    const startCpuUsage = process.cpuUsage();
+
+    return next.handle().pipe(
+      tap(() => {
+        const duration = profiler.stop();
+        const endCpuUsage = process.cpuUsage(startCpuUsage);
+        const cpuUsage = (endCpuUsage.user + endCpuUsage.system) / 1000;
+
+        const request = context.switchToHttp().getRequest();
+        const endpoint = request.url;
+
+        this.metricsService.setExternalCall('response_time', duration);
+        this.metricsService.setExternalCall('cpu_usage', cpuUsage);
+
+        if (duration > 1000) {
+          console.warn(`Warning: Response time for ${endpoint} is ${duration}ms`);
+        }
+
+        if (cpuUsage > 500) {
+          console.warn(`Warning: CPU usage for ${endpoint} is ${cpuUsage}ms`);
+        }
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import { JwtOrNativeAuthGuard } from '@multiversx/sdk-nestjs-auth';
 import { WebSocketPublisherModule } from './common/websockets/web-socket-publisher-module';
 import { IndexerService } from './common/indexer/indexer.service';
 import { NotWritableError } from './common/indexer/entities/not.writable.error';
+import { ResponseTimeCpuInterceptor } from './interceptors/response-time.cpu.interceptor';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrapper');
@@ -220,6 +221,8 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   globalInterceptors.push(new RequestCpuTimeInterceptor(metricsService));
   // @ts-ignore
   globalInterceptors.push(new LoggingInterceptor(metricsService));
+  //@ts-ignore
+  globalInterceptors.push(new ResponseTimeCpuInterceptor(metricsService));
 
   const getUseRequestCachingFlag = await settingsService.getUseRequestCachingFlag();
   const cacheDuration = apiConfigService.getCacheDuration();


### PR DESCRIPTION
## Reasoning
- To monitor and log the response time and CPU usage for each endpoint in the application.
- To provide warnings when response time or CPU usage exceeds specified thresholds.
- To improve the observability and performance monitoring of the application.
  
## Proposed Changes
- Added a new `ResponseTimeCpuInterceptor` to log response time and CPU usage for each endpoint.
- Configured the interceptor to log warnings if response time exceeds `1000ms` or CPU usage exceeds `500ms`.
- Integrated the interceptor globally in the application.

## How to test
- Fast Endpoint:
Make a request to a fast endpoint and verify that no warnings are logged.
- Slow Endpoint:
Make a request to a slow endpoint and verify that warnings for response time and CPU usage are logged.

