### PR TITLE
added missing filters to tx pool count endpoint

### DIFF
--- a/src/endpoints/pool/pool.controller.ts
+++ b/src/endpoints/pool/pool.controller.ts
@@ -46,14 +46,24 @@ export class PoolController {
   @ApiOperation({ summary: 'Transactions pool count', description: 'Returns the number of transactions that are currently in the memory pool.' })
   @ApiOkResponse({ type: Number })
   @ApiQuery({ name: 'sender', description: 'Returns the number of transactions with a specific sender', required: false })
-  @ApiQuery({ name: 'receiver', description: 'Returns the number of transactions with a specific receiver', required: false })
+  @ApiQuery({ name: 'receiver', description: 'Search in transaction pool by a specific receiver', required: false })
+  @ApiQuery({ name: 'senderShard', description: 'The shard of the sender', required: false })
+  @ApiQuery({ name: 'receiverShard', description: 'The shard of the receiver', required: false })
   @ApiQuery({ name: 'type', description: 'Returns the number of transactions with a specific type', required: false })
   async getTransactionPoolCount(
     @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
+    @Query('senderShard', ParseIntPipe) senderShard?: number,
+    @Query('receiverShard', ParseIntPipe) receiverShard?: number,
     @Query('type', new ParseEnumPipe(TransactionType)) type?: TransactionType,
   ): Promise<number> {
-    return await this.poolService.getPoolCount(new PoolFilter({ sender, receiver, type }));
+    return await this.poolService.getPoolCount(new PoolFilter({
+      sender: sender,
+      receiver: receiver,
+      senderShard: senderShard,
+      receiverShard: receiverShard,
+      type: type,
+    }));
   }
 
   @Get("/pool/c")

--- a/src/endpoints/pool/pool.service.ts
+++ b/src/endpoints/pool/pool.service.ts
@@ -23,9 +23,7 @@ export class PoolService {
 
   async getTransactionFromPool(txHash: string): Promise<TransactionInPool | undefined> {
     const pool = await this.getEntirePool();
-    const transaction = pool.find(tx => tx.txHash === txHash);
-
-    return transaction;
+    return pool.find(tx => tx.txHash === txHash);
   }
 
   async getPoolCount(filter: PoolFilter): Promise<number> {
@@ -41,7 +39,7 @@ export class PoolService {
       return [];
     }
 
-    const {from, size} = queryPagination;
+    const { from, size } = queryPagination;
     const entirePool = await this.getEntirePool();
     const pool = this.applyFilters(entirePool, filter);
     return pool.slice(from, from + size);


### PR DESCRIPTION
## Reasoning
- The filters used for getting the tx pool were not present for the pool count endpoint
  
## Proposed Changes
- Added new filters

## How to test
- <api>/transaction/pool?sender=...&receiver=...&senderShard=1&receiverShard=2&type=Transaction
