### PR TITLE
API-91: type + subType fixes

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -240,6 +240,7 @@ export class AccountController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'type', description: 'Token type', required: false, enum: TokenType })
+  @ApiQuery({ name: 'subType', description: 'Token sub type', required: false, enum: NftSubType })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
   @ApiQuery({ name: 'name', description: 'Search by token name', required: false })
   @ApiQuery({ name: 'identifier', description: 'Search by token identifier', required: false })
@@ -253,6 +254,7 @@ export class AccountController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('type', new ParseEnumPipe(TokenType)) type?: TokenType,
+    @Query('subType', new ParseEnumPipe(NftSubType)) subType?: NftSubType,
     @Query('search') search?: string,
     @Query('name') name?: string,
     @Query('identifier') identifier?: string,
@@ -262,7 +264,7 @@ export class AccountController {
     @Query('mexPairType', new ParseEnumArrayPipe(MexPairType)) mexPairType?: MexPairType[],
   ): Promise<TokenWithBalance[]> {
     try {
-      return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
+      return await this.tokenService.getTokensForAddress(address, new QueryPagination({ from, size }), new TokenFilter({ type, subType, search, name, identifier, identifiers, includeMetaESDT, mexPairType }));
     } catch (error) {
       this.logger.error(`Error in getAccountTokens for address ${address}`);
       this.logger.error(error);

--- a/src/endpoints/nfts/entities/nft.sub.type.ts
+++ b/src/endpoints/nfts/entities/nft.sub.type.ts
@@ -8,6 +8,7 @@ export enum NftSubType {
   DynamicNonFungibleESDT = 'DynamicNonFungibleESDT',
   DynamicSemiFungibleESDT = 'DynamicSemiFungibleESDT',
   DynamicMetaESDT = 'DynamicMetaESDT',
+  None = '',
 }
 
 registerEnumType(NftSubType, {
@@ -34,6 +35,9 @@ registerEnumType(NftSubType, {
     },
     DynamicMetaESDT: {
       description: 'Dynamic meta ESDT NFT type.',
+    },
+    None: {
+      description: '',
     },
   },
 });

--- a/src/endpoints/tokens/entities/token.filter.ts
+++ b/src/endpoints/tokens/entities/token.filter.ts
@@ -3,6 +3,7 @@ import { TokenType } from "src/common/indexer/entities";
 import { TokenSort } from "./token.sort";
 import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 import { TokenAssetsPriceSourceType } from "src/common/assets/entities/token.assets.price.source.type";
+import { NftSubType } from "../../nfts/entities/nft.sub.type";
 
 export class TokenFilter {
   constructor(init?: Partial<TokenFilter>) {
@@ -10,6 +11,8 @@ export class TokenFilter {
   }
 
   type?: TokenType;
+
+  subType?: NftSubType;
 
   search?: string;
 

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -4,6 +4,7 @@ import { TokenType } from "src/common/indexer/entities";
 import { TokenAssets } from "../../../common/assets/entities/token.assets";
 import { MexPairType } from "src/endpoints/mex/entities/mex.pair.type";
 import { TokenOwnersHistory } from "./token.owner.history";
+import { NftSubType } from "../../nfts/entities/nft.sub.type";
 
 export class Token {
   constructor(init?: Partial<Token>) {
@@ -12,6 +13,9 @@ export class Token {
 
   @ApiProperty({ enum: TokenType })
   type: TokenType = TokenType.FungibleESDT;
+
+  @ApiProperty({ enum: NftSubType })
+  subType: NftSubType = NftSubType.None;
 
   @ApiProperty({ type: String })
   identifier: string = '';

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -717,6 +717,7 @@ describe('Token Service', () => {
         mockNftCollections.forEach(collection => {
           mockTokens.push(new TokenDetailed({
             type: TokenType.MetaESDT,
+            subType: collection.subType,
             identifier: collection.collection,
             name: collection.name,
             timestamp: collection.timestamp,


### PR DESCRIPTION
## Reasoning
- there were some inconsistencies with endpoints that return new NFTs
  
## Proposed Changes
- added subType to missling places

## How to test
- `<api>/accounts/<address>/tokens` for an address that has a dynamic MetaESDT should have `type` set to `MetaESDT` and `subType` set to `DynamicMetaESDT`
