### PR TITLE
API-98: relayed v3 transactions support

### DIFF
--- a/src/common/gateway/entities/transaction.ts
+++ b/src/common/gateway/entities/transaction.ts
@@ -43,4 +43,6 @@ export class Transaction {
   logs: TransactionLog | undefined = undefined;
   receipt: TransactionReceipt | undefined = undefined;
   smartContractResults: GatewaySmartContractResults[] | undefined = undefined;
+  relayerAddress: string = '';
+  relayerSignature: string = '';
 }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -535,6 +535,10 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMatchCondition('isRelayed', filter.isRelayed);
     }
 
+    if (filter.relayer) {
+      elasticQuery = elasticQuery.withShouldCondition(QueryType.Match('relayer', filter.relayer));
+    }
+
     if (filter.round) {
       elasticQuery = elasticQuery.withMustMatchCondition('round', filter.round);
     }

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -107,6 +107,9 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true, required: false })
   relayer: string | undefined = undefined;
 
+  @ApiProperty({ type: String, nullable: true, required: false })
+  relayerSignature: string | undefined = undefined;
+
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -1,5 +1,16 @@
 import { QueryConditionOptions } from '@multiversx/sdk-nestjs-elastic';
-import { ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe, ParseAddressAndMetachainPipe, ApplyComplexity, ParseAddressArrayPipe, ParseArrayPipe } from '@multiversx/sdk-nestjs-common';
+import {
+  ParseBlockHashPipe,
+  ParseBoolPipe,
+  ParseEnumPipe,
+  ParseIntPipe,
+  ParseTransactionHashPipe,
+  ParseAddressAndMetachainPipe,
+  ApplyComplexity,
+  ParseAddressArrayPipe,
+  ParseArrayPipe,
+  ParseAddressPipe,
+} from '@multiversx/sdk-nestjs-common';
 import { BadRequestException, Body, Controller, DefaultValuePipe, Get, NotFoundException, Param, Post, Query } from '@nestjs/common';
 import { ApiCreatedResponse, ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { QueryPagination } from 'src/common/entities/query.pagination';
@@ -54,6 +65,7 @@ export class TransactionController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
+    @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -81,6 +93,7 @@ export class TransactionController {
     return this.transactionService.getTransactions(new TransactionFilter({
       sender,
       receivers: receiver,
+      relayer,
       token,
       functions,
       senderShard,

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -250,6 +250,8 @@ export class TransactionGetService {
         guardianAddress: transaction.guardian,
         guardianSignature: transaction.guardianSignature,
         inTransit: transaction.miniblockHash !== undefined && transaction.status === TransactionStatus.pending,
+        relayer: transaction.relayerAddress,
+        relayerSignature: transaction.relayerSignature,
       };
 
       return ApiUtils.mergeObjects(new TransactionDetailed(), result);


### PR DESCRIPTION
## Reasoning
- new relayed v3 transaction comming from new protocol versions lack support for filtering and both fields (`relayer` and `relayerSignature`) inside the API
  
## Proposed Changes
- adjust queries/filter/responses to include the new transactions

## How to test
- `<api>/transactions/<hash of a tx with relayed v3>` should contain `relayer` and `relayerSignature`
- `<api>/transaction?relayer=erd1...` should work
