### PR TITLE
fix fields query in transactions

### DIFF
--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -37,7 +37,7 @@ export class TransactionController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
-  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false })
+  @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false, isArray: true, style: 'form', explode: false })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'condition', description: 'Condition for elastic search queries', required: false, deprecated: true })


### PR DESCRIPTION
## Reasoning
- related with bug report : https://github.com/multiversx/mx-api-service/issues/1396
- the values from fields query were not serialized so when the query was added, the URL was build as follow: `fields=txHash&fields=code` 
  
## Proposed Changes
-  add `explode:false ` ApiQuery property  to make sure that the values are serialized  

## How to test
- go to local swagger
- on `transactions` controller, add multiple values in fields and the result should not return 500 InternalServer Error
