### PR TITLE
Hotfix empty token type from gateway

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -431,6 +431,10 @@ export class TokenService {
         ...esdt,
       };
 
+      if (esdt.type === '') { // empty type can come from gateway
+        tokenWithBalance.type = token.type;
+      }
+
       tokensWithBalance.push(tokenWithBalance);
     }
 


### PR DESCRIPTION
## Reasoning
- `<api>/accounts/erd1.../tokens` would have returned empty `type` because an empty `type` field can come from gateway
  
## Proposed Changes
- if empty `type` comes from gateway, then use the type fetched from indexer 

## How to test
- `<api>/accounts/erd1tgqkv2yqdq2eytqhsut3rkcdyvmt7ngt4lq5pvhass3u79dl98tsc07cjq/tokens?size=400&includeMetaESDT=true` should have the `type` field for MetaESDT as well
