### PR TITLE
Update load test workflow triggers

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -1,8 +1,6 @@
 name: Load Tests
 
 on:
-  push:
-    branches: [main, development]
   pull_request:
     branches: [main, development]
 


### PR DESCRIPTION
## Reasoning
- the load testing workflow should only run on PRs
  
## Proposed Changes
- remove the `push` trigger

## How to test
- 
