### PR TITLE
API-339: include transactions marked as canBeIgnored

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -309,12 +309,16 @@ export class ElasticIndexerHelper {
         smartContractResultConditions.push(QueryType.Match('sender', filter.address));
       }
 
+      let mustNotQueries: AbstractQuery[] = [
+        QueryType.Exists('canBeIgnored'),
+      ];
+      if (filter.withRefunds) {
+        mustNotQueries = [];
+      }
       elasticQuery = elasticQuery.withCondition(QueryConditionOptions.should, QueryType.Must([
         QueryType.Match('type', 'unsigned'),
         QueryType.Should(smartContractResultConditions),
-      ], [
-        QueryType.Exists('canBeIgnored'),
-      ]))
+      ], mustNotQueries))
         .withCondition(QueryConditionOptions.should, QueryType.Must([
           QueryType.Should([QueryType.Match('type', 'normal')]),
           QueryType.Should([

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -995,6 +995,7 @@ export class AccountController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transfers. When "withLogs" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transfers. When "withOperations" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
+  @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfers(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -1021,6 +1022,7 @@ export class AccountController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<Transaction[]> {
     const options = TransactionQueryOptions.applyDefaultOptions(
       size, { withScamInfo, withUsername, withBlockInfo, withOperations, withLogs, withActionTransferValue });
@@ -1042,6 +1044,7 @@ export class AccountController {
       senderOrReceiver,
       relayer,
       round,
+      withRefunds,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -1065,6 +1068,7 @@ export class AccountController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
+  @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfersCount(
     @Param('address', ParseAddressPipe) address: string,
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -1080,6 +1084,7 @@ export class AccountController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       address,
@@ -1096,6 +1101,7 @@ export class AccountController {
       after,
       senderOrReceiver,
       round,
+      withRefunds,
     }));
   }
 
@@ -1116,6 +1122,7 @@ export class AccountController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       address,
@@ -1132,6 +1139,7 @@ export class AccountController {
       after,
       senderOrReceiver,
       round,
+      withRefunds,
     }));
   }
 

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -29,4 +29,5 @@ export class TransactionFilter {
   isRelayed?: boolean;
   relayer?: string;
   round?: number;
+  withRefunds?: boolean;
 }

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -46,6 +46,7 @@ export class TransferController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transfers. When "withLogs" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transfers. When "withOperations" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
+  @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfers(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -71,6 +72,7 @@ export class TransferController {
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<Transaction[]> {
     const options = TransactionQueryOptions.applyDefaultOptions(
       size, new TransactionQueryOptions({ withScamInfo, withUsername, withBlockInfo, withLogs, withOperations, withActionTransferValue }),
@@ -92,6 +94,7 @@ export class TransferController {
       relayer,
       isRelayed,
       round,
+      withRefunds,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -115,6 +118,7 @@ export class TransferController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfersCount(
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
@@ -129,6 +133,7 @@ export class TransferController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('isRelayed', new ParseBoolPipe) isRelayed?: boolean,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       senders: sender,
@@ -144,6 +149,7 @@ export class TransferController {
       after,
       isRelayed,
       round,
+      withRefunds,
     }));
   }
 
@@ -162,6 +168,7 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
+    @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       senders: sender,
@@ -176,6 +183,7 @@ export class TransferController {
       before,
       after,
       round,
+      withRefunds,
     }));
   }
 }


### PR DESCRIPTION
## Reasoning
- by default, transactions marked as `canBeIgnored` in ES (usually receipt transactions) are not returned by the API
  
## Proposed Changes
- add a new API flag `withRefunds` so such transactions are included as well

## How to test
- check if refunds transactions are included 
