### PR TITLE
fix bls cache

### DIFF
--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -84,10 +84,11 @@ export class BlockService {
     let { proposer, validators } = item;
 
     let blses: any = await this.cachingService.getLocal(CacheInfo.ShardAndEpochBlses(shardId, epoch).key);
-    if (!blses) {
+    if (!blses || blses.length === 0) {
       blses = await this.blsService.getPublicKeys(shardId, epoch);
-
-      await this.cachingService.setLocal(CacheInfo.ShardAndEpochBlses(shardId, epoch).key, blses, CacheInfo.ShardAndEpochBlses(shardId, epoch).ttl);
+      if (blses.length > 0) {
+        await this.cachingService.setLocal(CacheInfo.ShardAndEpochBlses(shardId, epoch).key, blses, CacheInfo.ShardAndEpochBlses(shardId, epoch).ttl);
+      }
     }
 
     proposer = blses[proposer];


### PR DESCRIPTION
## Reasoning
- even though the caching unit will not store empty array anymore, bls service uses a local cache that could have still kept the empty result
  
## Proposed Changes
- don't save empty array in local cache either

## How to test
- 
