### PR TITLE
forward checkSignature param for tx simulation

### DIFF
--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -6,7 +6,7 @@ import { GatewayService } from "src/common/gateway/gateway.service";
 import { Response, Request } from "express";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { PluginService } from "src/common/plugins/plugin.service";
-import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseBlsHashPipe, ParseIntPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
+import { Constants, ParseAddressPipe, ParseBlockHashPipe, ParseBlsHashPipe, ParseIntPipe, ParseTransactionHashPipe, ParseBoolPipe } from "@multiversx/sdk-nestjs-common";
 import { CacheService, NoCache } from "@multiversx/sdk-nestjs-cache";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { DeepHistoryInterceptor } from "src/interceptors/deep-history.interceptor";
@@ -118,8 +118,12 @@ export class GatewayProxyController {
   }
 
   @Post('/transaction/simulate')
-  async transactionSimulate(@Body() body: any) {
-    return await this.gatewayPost('transaction/simulate', GatewayComponentRequest.simulateTransaction, body);
+  async transactionSimulate(@Query('checkSignature', ParseBoolPipe) checkSignature: boolean, @Body() body: any) {
+    let url = 'transaction/simulate';
+    if (checkSignature !== undefined) {
+      url += `?checkSignature=${checkSignature}`;
+    }
+    return await this.gatewayPost(url, GatewayComponentRequest.simulateTransaction, body);
   }
 
   @Post('/transaction/send-multiple')


### PR DESCRIPTION
## Reasoning
- when forwarding the `/transaction/simulate` endoint to gateway, the `checkSignature` query param was not forwarded
  
## Proposed Changes
- pass the query param as well

## How to test
```bash
curl --request POST \
  --url http://localhost:3001/transaction/simulate \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/10.2.0' \
  --data '{
  "nonce":0,
  "value":"0",
  "receiver":"erd1qqqqqqqqqqqqqpgqccmyzj9sade2495w78h42erfrw7qmqxpd8sss6gmgn",
  "sender":"erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
  "senderUsername":"",
  "receiverUsername":"",
  "gasPrice":1000000000,
  "gasLimit":5000000,
  "data":"YWRkQDA3",
  "chainID":"D",
  "version":2,
  "options":0,
  "guardian":"",
  "signature":"5f9f8ede6c993944095ffa9c4356ccbbafc0a2d98df2fff93ad9e000366e42af332a8c907d93fe43f22f5b4763b408152bb3fb6a454c73473c86a509f011ba0f",
  "guardianSignature":"",
  "relayer":"",
  "relayerSignature": ""
}'
```
