### PR TITLE
added function name for pool transactions

### DIFF
--- a/src/endpoints/pool/entities/pool.filter.ts
+++ b/src/endpoints/pool/entities/pool.filter.ts
@@ -10,4 +10,5 @@ export class PoolFilter {
   senderShard?: number;
   receiverShard?: number;
   type?: TransactionType;
+  functions?: string[];
 }

--- a/src/endpoints/pool/entities/transaction.in.pool.dto.ts
+++ b/src/endpoints/pool/entities/transaction.in.pool.dto.ts
@@ -48,6 +48,9 @@ export class TransactionInPool {
   @ApiProperty({ type: String, example: "0228618b6339c5eaf71ed1a8cd71df010ccd0369a29d957c37d53b0409408161726dd97e10ac7836996f666ffd636a797b9b9abecbd276971376fb3479b48203" })
   signature: string = '';
 
+  @ApiProperty({ type: String, nullable: true, example: 'composeTasks', required: false })
+  function: string = '';
+
   @ApiProperty({ type: String, example: "SmartContractResult" })
   type: TransactionType = TransactionType.Transaction;
 }

--- a/src/endpoints/pool/pool.controller.ts
+++ b/src/endpoints/pool/pool.controller.ts
@@ -1,4 +1,4 @@
-import { ParseAddressAndMetachainPipe, ParseAddressPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe } from "@multiversx/sdk-nestjs-common";
+import { ParseAddressAndMetachainPipe, ParseAddressPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe, ParseArrayPipe } from "@multiversx/sdk-nestjs-common";
 import { Controller, DefaultValuePipe, Get, NotFoundException, Param, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { PoolService } from "./pool.service";
@@ -6,6 +6,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { TransactionInPool } from "./entities/transaction.in.pool.dto";
 import { TransactionType } from "../transactions/entities/transaction.type";
 import { PoolFilter } from "./entities/pool.filter";
+import { ParseArrayPipeOptions } from "@multiversx/sdk-nestjs-common/lib/pipes/entities/parse.array.options";
 
 @Controller()
 @ApiTags('pool')
@@ -24,6 +25,8 @@ export class PoolController {
   @ApiQuery({ name: 'senderShard', description: 'The shard of the sender', required: false })
   @ApiQuery({ name: 'receiverShard', description: 'The shard of the receiver', required: false })
   @ApiQuery({ name: 'type', description: 'Search in transaction pool by type', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
+
   async getTransactionPool(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -32,6 +35,7 @@ export class PoolController {
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
     @Query('type', new ParseEnumPipe(TransactionType)) type?: TransactionType,
+    @Query('function', new ParseArrayPipe(new ParseArrayPipeOptions({ allowEmptyString: true }))) functions?: string[],
   ): Promise<TransactionInPool[]> {
     return await this.poolService.getPool(new QueryPagination({ from, size }), new PoolFilter({
       sender: sender,
@@ -39,6 +43,7 @@ export class PoolController {
       senderShard: senderShard,
       receiverShard: receiverShard,
       type: type,
+      functions: functions,
     }));
   }
 

--- a/src/endpoints/pool/pool.module.ts
+++ b/src/endpoints/pool/pool.module.ts
@@ -1,7 +1,11 @@
 import { Module } from "@nestjs/common";
 import { PoolService } from "./pool.service";
+import { TransactionActionModule } from "../transactions/transaction-action/transaction.action.module";
 
 @Module({
+  imports: [
+    TransactionActionModule,
+  ],
   providers: [
     PoolService,
   ],

--- a/src/endpoints/pool/pool.service.ts
+++ b/src/endpoints/pool/pool.service.ts
@@ -124,7 +124,8 @@ export class PoolService {
         (!filters.receiver || transaction.receiver === filters.receiver) &&
         (!filters.type || transaction.type === filters.type) &&
         (filters.senderShard === undefined || transaction.senderShard === filters.senderShard) &&
-        (filters.receiverShard === undefined || transaction.receiverShard === filters.receiverShard)
+        (filters.receiverShard === undefined || transaction.receiverShard === filters.receiverShard) &&
+        (filters.functions === undefined || transaction.function === undefined || filters.functions.indexOf(transaction.function) > -1)
       );
     });
   }

--- a/src/endpoints/pool/pool.service.ts
+++ b/src/endpoints/pool/pool.service.ts
@@ -11,6 +11,9 @@ import { PoolFilter } from "./entities/pool.filter";
 import { TxInPoolFields } from "src/common/gateway/entities/tx.in.pool.fields";
 import { AddressUtils } from "@multiversx/sdk-nestjs-common";
 import { ProtocolService } from "../../common/protocol/protocol.service";
+import { TransactionActionService } from "../transactions/transaction-action/transaction.action.service";
+import { Transaction } from "../transactions/entities/transaction";
+import { ApiUtils } from "@multiversx/sdk-nestjs-http";
 
 @Injectable()
 export class PoolService {
@@ -19,6 +22,7 @@ export class PoolService {
     private readonly apiConfigService: ApiConfigService,
     private readonly cacheService: CacheService,
     private readonly protocolService: ProtocolService,
+    private readonly transactionActionService: TransactionActionService,
   ) { }
 
   async getTransactionFromPool(txHash: string): Promise<TransactionInPool | undefined> {
@@ -105,6 +109,11 @@ export class PoolService {
       transaction.receiverShard = AddressUtils.computeShard(AddressUtils.bech32Decode(transaction.receiver), shardCount);
     }
 
+    const metadata = await this.transactionActionService.getTransactionMetadata(this.poolTransactionToTransaction(transaction), false);
+    if (metadata && metadata.functionName) {
+      transaction.function = metadata.functionName;
+    }
+
     return transaction;
   }
 
@@ -118,5 +127,9 @@ export class PoolService {
         (filters.receiverShard === undefined || transaction.receiverShard === filters.receiverShard)
       );
     });
+  }
+
+  private poolTransactionToTransaction(transaction: TransactionInPool): Transaction {
+    return ApiUtils.mergeObjects(new Transaction(), transaction);
   }
 }

--- a/src/test/unit/services/pool.spec.ts
+++ b/src/test/unit/services/pool.spec.ts
@@ -7,6 +7,7 @@ import { PoolFilter } from "src/endpoints/pool/entities/pool.filter";
 import { PoolService } from "src/endpoints/pool/pool.service";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { ProtocolService } from "../../../common/protocol/protocol.service";
+import { TransactionActionService } from "../../../endpoints/transactions/transaction-action/transaction.action.service";
 
 describe('PoolService', () => {
   let service: PoolService;
@@ -39,6 +40,12 @@ describe('PoolService', () => {
           provide: ApiConfigService,
           useValue: {
             isTransactionPoolEnabled: jest.fn().mockResolvedValue(true),
+          },
+        },
+        {
+          provide: TransactionActionService,
+          useValue: {
+            getTransactionMetadata: jest.fn(),
           },
         },
       ],


### PR DESCRIPTION
## Reasoning
- pool transactions did not have the 'function' field which would make the pool analysis easier
  
## Proposed Changes
- add function name to pool transactions if it exists

## How to test
- `/transaction/pool` should contain the transactions functions
