### PR TITLE
check for remainingUnbonPeriod null response

### DIFF
--- a/src/endpoints/keys/keys.service.ts
+++ b/src/endpoints/keys/keys.service.ts
@@ -27,6 +27,10 @@ export class KeysService {
         [key]
       );
 
+      if (!encoded || !encoded[0]) {
+        return { remainingUnBondPeriod: 0 };
+      }
+
       let remainingUnBondPeriod = parseInt(Buffer.from(encoded[0], 'base64').toString('ascii'));
 
       if (isNaN(remainingUnBondPeriod)) {


### PR DESCRIPTION
## Reasoning
- The error "Cannot read properties of null (reading '0')" when trying o access encoded[0] for keys unbonding period
  
## Proposed Changes
- Added a check for encoded data in KeysService to handle cases where no data is returned, ensuring a default response of `remainingUnBondPeriod` as 0.

