### PR TITLE
Batch API: better treat invalid transactions

### DIFF
--- a/src/endpoints/transactions.batch/transactions.batch.service.ts
+++ b/src/endpoints/transactions.batch/transactions.batch.service.ts
@@ -146,7 +146,11 @@ export class TransactionsBatchService {
       return transactionBatchItem;
     }
 
-    transaction.hash = result.txHash;
+    if (result.txHash) {
+      transaction.hash = result.txHash;
+    } else {
+      transactionBatchItem.status = BatchTransactionStatus.invalid;
+    }
 
     return transactionBatchItem;
   }


### PR DESCRIPTION
## Reasoning
- invalid transactions(code 400 from gateway) do not throw errors, so they are not properly treated
  
## Proposed Changes
- if the result of the gateway call does not contain a txHash, mark the batch transaction as invalid

## How to test
- 
- 
- 
