### PR TITLE
websockets transactions events metrics

### DIFF
--- a/src/common/metrics/api.metrics.service.ts
+++ b/src/common/metrics/api.metrics.service.ts
@@ -113,7 +113,6 @@ export class ApiMetricsService {
       ApiMetricsService.transactionsCompletedCounter = new Counter({
         name: 'websocket_transactions_completed_total',
         help: 'Total number of completed transactions processed via websocket',
-        labelNames: ['shardId'],
       });
     }
 
@@ -121,7 +120,6 @@ export class ApiMetricsService {
       ApiMetricsService.transactionsPendingResultsCounter = new Counter({
         name: 'websocket_transactions_pending_results_total',
         help: 'Total number of transactions with pending results processed via websocket',
-        labelNames: ['shardId'],
       });
     }
 
@@ -129,7 +127,6 @@ export class ApiMetricsService {
       ApiMetricsService.batchUpdatesCounter = new Counter({
         name: 'websocket_batch_updates_total',
         help: 'Total number of batch updates processed via websocket',
-        labelNames: ['address'],
       });
     }
   }
@@ -186,18 +183,18 @@ export class ApiMetricsService {
   }
 
   @OnEvent(MetricsEvents.SetTransactionsCompleted)
-  recordTransactionsCompleted(payload: { transactions: any[], duration: number, shardId: number }) {
-    ApiMetricsService.transactionsCompletedCounter.inc({ shard: payload.shardId.toString() }, payload.transactions.length);
+  recordTransactionsCompleted(payload: { transactions: any[] }) {
+    ApiMetricsService.transactionsCompletedCounter.inc(payload.transactions.length);
   }
 
   @OnEvent(MetricsEvents.SetTransactionsPendingResults)
-  recordTransactionsPendingResults(payload: { transactions: any[], duration: number, shardId: number }) {
-    ApiMetricsService.transactionsPendingResultsCounter.inc({ shard: payload.shardId.toString() }, payload.transactions.length);
+  recordTransactionsPendingResults(payload: { transactions: any[] }) {
+    ApiMetricsService.transactionsPendingResultsCounter.inc(payload.transactions.length);
   }
 
   @OnEvent(MetricsEvents.SetBatchUpdated)
-  recordBatchUpdated(payload: { address: string, duration: number }) {
-    ApiMetricsService.batchUpdatesCounter.inc({ address: payload.address });
+  recordBatchUpdated() {
+    ApiMetricsService.batchUpdatesCounter.inc();
   }
 
   async getMetrics(): Promise<string> {

--- a/src/common/websockets/web-socket-publisher-controller.ts
+++ b/src/common/websockets/web-socket-publisher-controller.ts
@@ -3,6 +3,8 @@ import { ShardTransaction } from "@elrondnetwork/transaction-processor";
 import { Controller } from "@nestjs/common";
 import { EventPattern } from "@nestjs/microservices";
 import { WebSocketPublisherService } from "src/common/websockets/web-socket-publisher-service";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { MetricsEvents } from "src/utils/metrics-events.constants";
 
 @Controller()
 export class WebSocketPublisherController {
@@ -10,6 +12,7 @@ export class WebSocketPublisherController {
 
   constructor(
     private readonly webSocketPublisherService: WebSocketPublisherService,
+    private readonly eventEmitter: EventEmitter2,
   ) { }
 
   @EventPattern('transactionsCompleted')
@@ -17,6 +20,10 @@ export class WebSocketPublisherController {
     for (const transaction of transactions) {
       await this.webSocketPublisherService.onTransactionCompleted(transaction);
     }
+
+    this.eventEmitter.emit(MetricsEvents.SetTransactionsCompleted, {
+      transactions,
+    });
   }
 
   @EventPattern('transactionsPendingResults')
@@ -24,11 +31,17 @@ export class WebSocketPublisherController {
     for (const transaction of transactions) {
       await this.webSocketPublisherService.onTransactionPendingResults(transaction);
     }
+
+    this.eventEmitter.emit(MetricsEvents.SetTransactionsPendingResults, {
+      transactions,
+    });
   }
 
   @EventPattern('onBatchUpdated')
   onBatchUpdated(payload: { address: string, batchId: string, txHashes: string[] }) {
     this.logger.log(`Notifying batch updated for address ${payload.address}, batch id '${payload.batchId}', hashes ${payload.txHashes} `);
     this.webSocketPublisherService.onBatchUpdated(payload.address, payload.batchId, payload.txHashes);
+
+    this.eventEmitter.emit(MetricsEvents.SetBatchUpdated);
   }
 }

--- a/src/test/unit/controllers/web.socket.publiser.controller.spec.ts
+++ b/src/test/unit/controllers/web.socket.publiser.controller.spec.ts
@@ -1,11 +1,14 @@
 import { ShardTransaction } from "@elrondnetwork/transaction-processor";
 import { TestingModule, Test } from "@nestjs/testing";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import { WebSocketPublisherController } from "src/common/websockets/web-socket-publisher-controller";
 import { WebSocketPublisherService } from "src/common/websockets/web-socket-publisher-service";
+import { MetricsEvents } from "src/utils/metrics-events.constants";
 
 describe('WebSocketPublisherController', () => {
   let controller: WebSocketPublisherController;
   let webSocketPublisherService: WebSocketPublisherService;
+  let eventEmitter: EventEmitter2;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,23 +22,32 @@ describe('WebSocketPublisherController', () => {
             onBatchUpdated: jest.fn(),
           },
         },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     controller = module.get<WebSocketPublisherController>(WebSocketPublisherController);
     webSocketPublisherService = module.get<WebSocketPublisherService>(WebSocketPublisherService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
   });
 
   it('should handle transactionsCompleted event', async () => {
     const mockTransactions = [{}, {}] as ShardTransaction[];
     await controller.transactionsCompleted(mockTransactions);
     expect(webSocketPublisherService.onTransactionCompleted).toHaveBeenCalledTimes(mockTransactions.length);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(MetricsEvents.SetTransactionsCompleted, { transactions: mockTransactions });
   });
 
   it('should handle transactionsPendingResults event', async () => {
     const mockTransactions = [{}, {}] as ShardTransaction[];
     await controller.transactionsPendingResults(mockTransactions);
     expect(webSocketPublisherService.onTransactionPendingResults).toHaveBeenCalledTimes(mockTransactions.length);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(MetricsEvents.SetTransactionsPendingResults, { transactions: mockTransactions });
   });
 
   it('should handle onBatchUpdated event', () => {
@@ -43,5 +55,6 @@ describe('WebSocketPublisherController', () => {
     controller.onBatchUpdated(mockPayload);
     expect(webSocketPublisherService.onBatchUpdated).toHaveBeenCalledWith(mockPayload.address, mockPayload.batchId, mockPayload.txHashes);
     expect(webSocketPublisherService.onBatchUpdated).toHaveBeenCalledTimes(1);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(MetricsEvents.SetBatchUpdated);
   });
 });

--- a/src/utils/metrics-events.constants.ts
+++ b/src/utils/metrics-events.constants.ts
@@ -7,4 +7,7 @@ export enum MetricsEvents {
   SetLastProcessedNonce = "setLastProcessedNonce",
   SetLastProcessedBatchProcessorNonce = "setLastProcessedBatchProcessorNonce",
   SetLastProcessedTransactionCompletedProcessorNonce = "setLastProcessedTransactionCompletedProcessorNonce",
+  SetTransactionsCompleted = "setTransactionsCompleted",
+  SetTransactionsPendingResults = "setTransactionsPendingResults",
+  SetBatchUpdated = "setBatchUpdated",
 }


### PR DESCRIPTION
## Reasoning
- Need visibility into total WebSocket events at cluster level
- Missing basic counters for core WebSocket operations. (`transactionsCompleted`, `transactionsPendingResults`, `onBatchUpdated` 
  
## Proposed Changes
- Added three simple counters:
- `websocket_transactions_completed_total`
- `websocket_transactions_pending_results_total`
- `websocket_batch_updates_total`

## How to test
- `<localhost:4001>/metrics`
