### PR TITLE
API-375 add support for MetaESDT assets in ES

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -157,9 +157,24 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.subType, subType => QueryType.Match('type', subType));
     }
 
+    if (filter.name) {
+      elasticQuery = elasticQuery.withMustWildcardCondition('api_assets.name', filter.name);
+    }
+
+    if (filter.hasAssets !== undefined) {
+      if (filter.hasAssets) {
+        elasticQuery = elasticQuery.withMustExistCondition('api_assets');
+      } else {
+        elasticQuery = elasticQuery.withMustNotExistCondition('api_assets');
+      }
+    }
+
+    if (filter.search) {
+      elasticQuery = elasticQuery.withSearchWildcardCondition(filter.search, ['token', 'name', 'api_assets.name']);
+    }
+
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
-      .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
-      .withSearchWildcardCondition(filter.search, ['token', 'name']);
+      .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND));
   }
 
   private getRoleCondition(query: ElasticQuery, name: string, address: string | undefined, value: string | boolean) {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -920,6 +920,19 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.setCustomValues('accounts', address, { assets });
   }
 
+  async setCollectionAssetsFields(identifier: string, assets: any): Promise<void> {
+    const collection = await this.getCollection(identifier);
+    if (!collection) {
+      return;
+    }
+
+    if (this.metaEsdtTypes.includes(collection.type as NftType)) {
+      return await this.elasticService.setCustomValues('tokens', identifier, {
+        api_assets: assets,
+      });
+    }
+  }
+
   async ensureAccountsWritable(): Promise<void> {
     await this.ensureCollectionWritable('accounts');
   }

--- a/src/common/indexer/entities/collection.ts
+++ b/src/common/indexer/entities/collection.ts
@@ -13,4 +13,5 @@ export interface Collection {
   api_holderCount?: number;
   nft_scamInfoType?: string;
   nft_scamInfoDescription?: string;
+  api_assets?: any;
 }

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -174,6 +174,8 @@ export interface IndexerInterface {
 
   setAccountAssetsFields(address: string, assets: AccountAssets): Promise<void>
 
+  setCollectionAssetsFields(identifier: string, assets: any): Promise<void>
+
   ensureAccountsWritable(): Promise<void>
 
   ensureTokensWritable(): Promise<void>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -469,4 +469,9 @@ export class IndexerService implements IndexerInterface {
   async getEventsCount(filter: EventsFilter): Promise<number> {
     return await this.indexerInterface.getEventsCount(filter);
   }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async setCollectionAssetsFields(identifier: string, assets: any): Promise<void> {
+    return await this.indexerInterface.setCollectionAssetsFields(identifier, assets);
+  }
 }

--- a/src/endpoints/collections/entities/collection.filter.ts
+++ b/src/endpoints/collections/entities/collection.filter.ts
@@ -26,4 +26,7 @@ export class CollectionFilter {
 
   sort?: SortCollections;
   order?: SortOrder;
+
+  name?: string;
+  hasAssets?: boolean;
 }


### PR DESCRIPTION
  
## Proposed Changes
- Add setCollectionAssetsFields method to IndexerInterface.
- Introduced setCollectionAssetsFields method in IndexerInterface to handle collection asset updates.
- Implemented the method in IndexerService and ElasticIndexerService for processing collection assets.
- Enhanced ElasticIndexerHelper to support additional filtering options for asset queries.
- Updated Collection entity to include `api_assets` field.
- Modified CollectionFilter to add `name` and `hasAssets` properties for improved filtering capabilities.

## How to test
- 
- 
- 
