### PR TITLE
add support for xoxno data API provider

### DIFF
--- a/src/common/data-api/data-api.service.ts
+++ b/src/common/data-api/data-api.service.ts
@@ -72,17 +72,18 @@ export class DataApiService {
     }
 
     try {
-      const [cexTokensRaw, xExchangeTokensRaw, hatomTokensRaw] = await Promise.all([
+      const [cexTokensRaw, xExchangeTokensRaw, hatomTokensRaw, xoxnoTokensRaw] = await Promise.all([
         this.apiService.get(`${this.apiConfigService.getDataApiServiceUrl()}/v1/tokens/cex?fields=identifier`),
         this.apiService.get(`${this.apiConfigService.getDataApiServiceUrl()}/v1/tokens/xexchange?fields=identifier`),
         this.apiService.get(`${this.apiConfigService.getDataApiServiceUrl()}/v1/tokens/hatom?fields=identifier`),
+        this.apiService.get(`${this.apiConfigService.getDataApiServiceUrl()}/v1/tokens/xoxno?fields=identifier`),
       ]);
 
       const cexTokens: DataApiToken[] = cexTokensRaw.data.map((token: any) => new DataApiToken({ identifier: token.identifier, market: 'cex' }));
       const xExchangeTokens: DataApiToken[] = xExchangeTokensRaw.data.map((token: any) => new DataApiToken({ identifier: token.identifier, market: 'xexchange' }));
       const hatomTokens: DataApiToken[] = hatomTokensRaw.data.map((token: any) => new DataApiToken({ identifier: token.identifier, market: 'hatom' }));
-
-      const tokens = [...cexTokens, ...xExchangeTokens, ...hatomTokens].toRecord<DataApiToken>(x => x.identifier);
+      const xoxnoTokens: DataApiToken[] = xoxnoTokensRaw.data.map((token: any) => new DataApiToken({ identifier: token.identifier, market: 'xoxno' }));
+      const tokens = [...cexTokens, ...xExchangeTokens, ...hatomTokens, ...xoxnoTokens].toRecord<DataApiToken>(x => x.identifier);
       return tokens;
     } catch (error) {
       this.logger.error(`An unexpected error occurred while fetching tokens from Data API.`);

--- a/src/common/data-api/entities/data-api.token.ts
+++ b/src/common/data-api/entities/data-api.token.ts
@@ -4,5 +4,5 @@ export class DataApiToken {
   }
 
   identifier: string = '';
-  market: 'cex' | 'xexchange' | 'hatom' = 'cex';
+  market: 'cex' | 'xexchange' | 'hatom' | 'xoxno' = 'cex';
 }


### PR DESCRIPTION
## Reasoning
- data API support new provider: `xoxno`
  
## Proposed Changes
- include `xoxno` provider to fetch all the xoxno tokens prices

