### PR TITLE
API-417: added withCrossChainTransfers filter

### DIFF
--- a/.github/workflows/unit.tests.yml
+++ b/.github/workflows/unit.tests.yml
@@ -4,10 +4,7 @@
 name: Unit tests
 
 on:
-  push:
-    branches: [main, development]
   pull_request:
-    branches: [main, development]
 
 jobs:
   build:

--- a/config/config.devnet-old.yaml
+++ b/config/config.devnet-old.yaml
@@ -1,5 +1,6 @@
 network: 'devnet-old'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   private: true

--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -1,5 +1,6 @@
 network: 'devnet'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   publicPort: 3001

--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -1,5 +1,6 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   private: true

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -1,5 +1,6 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   private: true

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -1,5 +1,6 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   publicPort: 3001

--- a/config/config.placeholder.yaml
+++ b/config/config.placeholder.yaml
@@ -1,5 +1,6 @@
 network: 'DAPP_CONFIG'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   publicPort: 3001

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -1,5 +1,6 @@
 network: 'testnet'
 metaChainShardId: 4294967295
+crossChainSenderShardId: 4294967293
 api:
   public: true
   publicPort: 3001

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -550,6 +550,15 @@ export class ApiConfigService {
     return metaChainShardId;
   }
 
+  getCrossChainSenderShardId(): number {
+    const crossChainSenderShardId = this.configService.get<number>('crossChainSenderShardId');
+    if (crossChainSenderShardId === undefined) {
+      throw new Error('No crossChainSenderShardId present');
+    }
+
+    return crossChainSenderShardId;
+  }
+
   getRateLimiterSecret(): string | undefined {
     return this.configService.get<string>('rateLimiterSecret');
   }

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -25,7 +25,6 @@ export class ElasticIndexerHelper {
   private nonFungibleEsdtTypes: NftType[] = [NftType.NonFungibleESDT, NftType.NonFungibleESDTv2, NftType.DynamicNonFungibleESDT];
   private semiFungibleEsdtTypes: NftType[] = [NftType.SemiFungibleESDT, NftType.DynamicSemiFungibleESDT];
   private metaEsdtTypes: NftType[] = [NftType.MetaESDT, NftType.DynamicMetaESDT];
-  private crossChainTransferSenderShard = 4294967293;
 
   constructor(
     private readonly apiConfigService: ApiConfigService,
@@ -535,7 +534,7 @@ export class ElasticIndexerHelper {
       } else {
         elasticQuery = elasticQuery.withShouldCondition([
           QueryType.Match('type', 'normal'),
-          QueryType.Match('senderShard', this.crossChainTransferSenderShard),
+          QueryType.Match('senderShard', this.apiConfigService.getCrossChainSenderShardId()),
         ]);
       }
     } else {
@@ -548,7 +547,7 @@ export class ElasticIndexerHelper {
         ]),
       ];
       if (filter.withCrossChainTransfers) {
-        shouldConditions.push(QueryType.Match('senderShard', this.crossChainTransferSenderShard));
+        shouldConditions.push(QueryType.Match('senderShard', this.apiConfigService.getCrossChainSenderShardId()));
       }
       elasticQuery = elasticQuery.withShouldCondition(shouldConditions);
     }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -879,6 +879,7 @@ export class AccountController {
   @ApiQuery({ name: 'isRelayed', description: 'Returns isRelayed transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   async getAccountTransactions(
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -907,6 +908,7 @@ export class AccountController {
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
 
@@ -927,6 +929,7 @@ export class AccountController {
       isRelayed,
       round,
       withRelayedScresults,
+      withCrossChainTransfers,
     });
     TransactionFilter.validate(transactionFilter, size);
     return await this.transactionService.getTransactions(transactionFilter, new QueryPagination({ from, size }), options, address, fields);
@@ -950,6 +953,7 @@ export class AccountController {
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns isRelayed transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   async getAccountTransactionsCount(
     @Param('address', ParseAddressPipe) address: string,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -967,7 +971,7 @@ export class AccountController {
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
-
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ): Promise<number> {
 
     return await this.transactionService.getTransactionCount(new TransactionFilter({
@@ -986,6 +990,7 @@ export class AccountController {
       isRelayed,
       round,
       withRelayedScresults,
+      withCrossChainTransfers,
     }), address);
   }
 

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -205,6 +205,7 @@ export class TokenController {
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   async getTokenTransactions(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -230,6 +231,7 @@ export class TokenController {
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
 
@@ -253,6 +255,7 @@ export class TokenController {
       order,
       round,
       withRelayedScresults,
+      withCrossChainTransfers,
     });
     TransactionFilter.validate(transactionFilter, size);
 
@@ -280,6 +283,7 @@ export class TokenController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   async getTokenTransactionsCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -293,6 +297,7 @@ export class TokenController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ) {
     return await this.transactionService.getTransactionCount(new TransactionFilter({
       sender,
@@ -307,6 +312,7 @@ export class TokenController {
       after,
       round,
       withRelayedScresults,
+      withCrossChainTransfers,
     }));
   }
 

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -29,6 +29,7 @@ export class TransactionFilter {
   withRefunds?: boolean;
   withRelayedScresults?: boolean;
   withTxsRelayedByAddress?: boolean;
+  withCrossChainTransfers?: boolean;
 
   constructor(init?: Partial<TransactionFilter>) {
     Object.assign(this, init);

--- a/src/endpoints/transactions/transaction-action/entities/transaction.metadata.ts
+++ b/src/endpoints/transactions/transaction-action/entities/transaction.metadata.ts
@@ -11,6 +11,7 @@ export class TransactionMetadata {
   receiver: string = '';
   value: BigInt = BigInt(0);
   functionName?: string;
+  senderShard?: number = -1;
   functionArgs: string[] = [];
   timestamp: number = 0;
   transfers?: TransactionMetadataTransfer[];

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -17,7 +17,7 @@ import { TokenTransferProperties } from "../../tokens/entities/token.transfer.pr
 export class TransactionActionService {
   private recognizers: TransactionActionRecognizerInterface[] = [];
   private readonly logger = new OriginLogger(TransactionActionService.name);
-  private readonly esdtSystemAccountAddress = 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u';
+  private crossChainTransferSenderShard = 4294967293;
 
   constructor(
     private readonly mexRecognizer: TransactionActionMexRecognizerService,
@@ -46,6 +46,9 @@ export class TransactionActionService {
   }
 
   async getTransactionAction(transaction: Transaction, applyValue: boolean = false): Promise<TransactionAction | undefined> {
+    if (transaction.txHash === '8537cde573855199b4bd2e01c4c6792c52f6cfaf2416e476b7ef32d4131c3f5a') {
+      console.log('aqui');
+    }
     const metadata = await this.getTransactionMetadata(transaction, applyValue);
 
     const recognizers = await this.getRecognizers();
@@ -87,6 +90,9 @@ export class TransactionActionService {
     metadata.receiver = transaction.receiver;
     metadata.timestamp = transaction.timestamp;
     metadata.value = BigInt(transaction.value);
+    if (transaction.senderShard !== undefined) {
+      metadata.senderShard = transaction.senderShard;
+    }
 
     if (transaction.data) {
       const decodedData = BinaryUtils.base64Decode(transaction.data);
@@ -175,7 +181,7 @@ export class TransactionActionService {
     sovereign cross chain transfer example: MultiESDTNFTTransfer@02@4147452d626532353731@@01314fb37062980000@42474431362d633437663436@@5d894a4a3a220000
     regular chain example:                  MultiESDTNFTTransfer@0000000000000000050000b4c094947e427d79931a8bad81316b797d238cdb3f@02@4c524f4e452d633133303234@@036f5933a0d19ae387@524f4e452d626232653639@@04493d2ce61b650000@6164644c6971756964697479@01@01
      */
-    const isSovereignCrossChainTransfer = metadata.sender === this.esdtSystemAccountAddress;
+    const isSovereignCrossChainTransfer = metadata.senderShard === this.crossChainTransferSenderShard;
     if (metadata.sender !== metadata.receiver) {
       if (!isSovereignCrossChainTransfer) {
         return undefined;

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -10,13 +10,14 @@ import { TransactionActionEsdtNftRecognizerService } from "./recognizers/esdt/tr
 import { TokenTransferService } from "src/endpoints/tokens/token.transfer.service";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { MetabondingActionRecognizerService } from "./recognizers/mex/mex.metabonding.action.recognizer.service";
-import { AddressUtils, BinaryUtils, StringUtils } from "@multiversx/sdk-nestjs-common";
-import { OriginLogger } from "@multiversx/sdk-nestjs-common";
+import { AddressUtils, BinaryUtils, OriginLogger, StringUtils } from "@multiversx/sdk-nestjs-common";
+import { TokenTransferProperties } from "../../tokens/entities/token.transfer.properties";
 
 @Injectable()
 export class TransactionActionService {
   private recognizers: TransactionActionRecognizerInterface[] = [];
   private readonly logger = new OriginLogger(TransactionActionService.name);
+  private readonly esdtSystemAccountAddress = 'erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzllls8a5w6u';
 
   constructor(
     private readonly mexRecognizer: TransactionActionMexRecognizerService,
@@ -170,8 +171,15 @@ export class TransactionActionService {
   }
 
   private async getMultiTransferMetadata(metadata: TransactionMetadata, applyValue: boolean = false): Promise<TransactionMetadata | undefined> {
+    /*
+    sovereign cross chain transfer example: MultiESDTNFTTransfer@02@4147452d626532353731@@01314fb37062980000@42474431362d633437663436@@5d894a4a3a220000
+    regular chain example:                  MultiESDTNFTTransfer@0000000000000000050000b4c094947e427d79931a8bad81316b797d238cdb3f@02@4c524f4e452d633133303234@@036f5933a0d19ae387@524f4e452d626232653639@@04493d2ce61b650000@6164644c6971756964697479@01@01
+     */
+    const isSovereignCrossChainTransfer = metadata.sender === this.esdtSystemAccountAddress;
     if (metadata.sender !== metadata.receiver) {
-      return undefined;
+      if (!isSovereignCrossChainTransfer) {
+        return undefined;
+      }
     }
 
     if (metadata.functionName !== 'MultiESDTNFTTransfer') {
@@ -183,12 +191,22 @@ export class TransactionActionService {
       return undefined;
     }
 
-    if (!AddressUtils.isValidHexAddress(args[0])) {
+    if (!AddressUtils.isValidHexAddress(args[0]) && !isSovereignCrossChainTransfer) {
       return undefined;
     }
 
-    const receiver = AddressUtils.bech32Encode(args[0]);
-    const transferCount = BinaryUtils.hexToNumber(args[1]);
+    let receiver: string;
+    if (!isSovereignCrossChainTransfer) {
+      receiver = AddressUtils.bech32Encode(args[0]);
+    } else {
+      receiver = metadata.receiver;
+    }
+
+    let transferCountIndex = 1;
+    if (isSovereignCrossChainTransfer) {
+      transferCountIndex = 0;
+    }
+    const transferCount = BinaryUtils.hexToNumber(args[transferCountIndex]);
 
     const result = new TransactionMetadata();
     if (!result.transfers) {
@@ -196,14 +214,19 @@ export class TransactionActionService {
     }
 
     let index = 2;
+    if (isSovereignCrossChainTransfer) {
+      index = 1;
+    }
     for (let i = 0; i < transferCount; i++) {
       const identifier = BinaryUtils.hexToString(args[index++]);
       const nonce = args[index++];
       const value = this.parseValueFromMultiTransferValueArg(args[index++]);
 
+      let validProperties = false;
       if (nonce && nonce !== "00") {
         const properties = await this.tokenTransferService.getTokenTransferProperties({ identifier, nonce });
         if (properties) {
+          validProperties = true;
           result.transfers.push({
             value,
             properties,
@@ -212,11 +235,25 @@ export class TransactionActionService {
       } else {
         const properties = await this.tokenTransferService.getTokenTransferProperties({ identifier, timestamp: metadata.timestamp, value: value.toString(), applyValue });
         if (properties) {
+          validProperties = true;
           result.transfers.push({
             value,
             properties,
           });
         }
+      }
+
+      // TODO: might remove this after token details are indexed inside sovereign es
+      if (!validProperties) { // missing token details (decimals for example. extract transfer info - best effort)
+        result.transfers.push({
+          value,
+          properties: new TokenTransferProperties({
+            decimals: 18,
+            identifier,
+            ticker: identifier,
+            token: identifier,
+          }),
+        });
       }
     }
 

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -46,9 +46,6 @@ export class TransactionActionService {
   }
 
   async getTransactionAction(transaction: Transaction, applyValue: boolean = false): Promise<TransactionAction | undefined> {
-    if (transaction.txHash === '8537cde573855199b4bd2e01c4c6792c52f6cfaf2416e476b7ef32d4131c3f5a') {
-      console.log('aqui');
-    }
     const metadata = await this.getTransactionMetadata(transaction, applyValue);
 
     const recognizers = await this.getRecognizers();

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -137,7 +137,8 @@ export class TransactionActionService {
     try {
       if (transaction.type === TransactionType.SmartContractResult) {
         if (metadata.functionName === 'MultiESDTNFTTransfer' &&
-          metadata.functionArgs.length > 0
+          metadata.functionArgs.length > 0 &&
+          metadata.senderShard !== this.crossChainTransferSenderShard
         ) {
           // if the first argument has up to 4 hex chars (meaning it will contain up to 65536 transfers)
           // then we insert the address as the first parameter. otherwise we assume that the address

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -51,6 +51,7 @@ export class TransactionController {
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   getTransactions(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -79,6 +80,7 @@ export class TransactionController {
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ) {
     const options = TransactionQueryOptions.applyDefaultOptions(size, { withScResults, withOperations, withLogs, withScamInfo, withUsername, withBlockInfo, withActionTransferValue });
 
@@ -99,7 +101,8 @@ export class TransactionController {
       relayer,
       isRelayed,
       round,
-      withRelayedScresults: withRelayedScresults,
+      withRelayedScresults,
+      withCrossChainTransfers,
     });
     TransactionFilter.validate(transactionFilter, size);
     return this.transactionService.getTransactions(transactionFilter,
@@ -129,6 +132,7 @@ export class TransactionController {
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'relayer', description: 'Filter by a relayer address', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withCrossChainTransfers', description: 'If set to true, will include cross chain transfer transactions', required: false, type: Boolean })
   getTransactionCount(
     @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
@@ -146,6 +150,7 @@ export class TransactionController {
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
       sender,
@@ -163,7 +168,8 @@ export class TransactionController {
       relayer,
       isRelayed,
       round,
-      withRelayedScresults: withRelayedScresults,
+      withRelayedScresults,
+      withCrossChainTransfers,
     }));
   }
 
@@ -186,6 +192,7 @@ export class TransactionController {
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('withCrossChainTransfers', ParseBoolPipe) withCrossChainTransfers?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
       sender,
@@ -203,7 +210,8 @@ export class TransactionController {
       isRelayed,
       relayer,
       round,
-      withRelayedScresults: withRelayedScresults,
+      withRelayedScresults,
+      withCrossChainTransfers,
     }));
   }
 

--- a/src/test/unit/services/bls.spec.ts
+++ b/src/test/unit/services/bls.spec.ts
@@ -100,6 +100,14 @@ describe('BlsService', () => {
   });
 
   describe('getPublicKeysRaw', () => {
+    it('should return undefined if getPublicKeys returns undefined', async () => {
+      jest.spyOn(indexerService, 'getPublicKeys').mockResolvedValue(undefined);
+
+      const result = await blsService['getPublicKeysRaw'](0, 1);
+
+      expect(result).toBeUndefined();
+    });
+
     it('should return public keys if getPublicKeys returns an array', async () => {
       const publicKeys = ['publicKey1', 'publicKey2'];
       jest.spyOn(indexerService, 'getPublicKeys').mockResolvedValue(publicKeys);

--- a/src/test/unit/services/bls.spec.ts
+++ b/src/test/unit/services/bls.spec.ts
@@ -100,14 +100,6 @@ describe('BlsService', () => {
   });
 
   describe('getPublicKeysRaw', () => {
-    it('should return empty array if getPublicKeys returns undefined', async () => {
-      jest.spyOn(indexerService, 'getPublicKeys').mockResolvedValue(undefined);
-
-      const result = await blsService['getPublicKeysRaw'](0, 1);
-
-      expect(result).toEqual([]);
-    });
-
     it('should return public keys if getPublicKeys returns an array', async () => {
       const publicKeys = ['publicKey1', 'publicKey2'];
       jest.spyOn(indexerService, 'getPublicKeys').mockResolvedValue(publicKeys);


### PR DESCRIPTION
## Reasoning
- by default, cross chain transfers (which are marked as `unsigned` at protocol level) did not appear on the explorer on various pages that included transactions
  
## Proposed Changes
- if the new API query is set (`withCrossChainTransfers`), then the transactions' endpoints should also include cross chain transfers as transactions 

## How to test
- `http://localhost:3001/accounts/erd1edypnrzwpun2zdcy95qzkq0tln9en39zdqpdlagfccwxzlkdgyeshulrlz/transactions?from=0&size=25&withCrossChainTransfers=true&fields=txHash,originalTxHash,receiver,receiverAssets,receiverShard,sender,senderAssets,senderShard,status,value,timestamp,round,tokenValue,tokenIdentifier,function,action,type,guardianSignature,relayer,isRelayed,relayedVersion&withUsername=true&withTxsRelayedByAddress=true` should include the cross chain transfer transaction(s)
