### PR TITLE
add transactions 'isScCall' filter support

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -629,6 +629,14 @@ export class ElasticIndexerHelper {
         ]));
     }
 
+    if (filter.isScCall !== undefined) {
+      if (filter.isScCall) {
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('isScCall', true));
+      } else {
+        elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
+      }
+    }
+
     return elasticQuery;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -636,11 +636,9 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.isScCall !== undefined) {
-      if (filter.isScCall) {
-        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('isScCall', true));
-      } else {
-        elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
-      }
+      elasticQuery = filter.isScCall
+        ? elasticQuery.withMustCondition(QueryType.Match('isScCall', true))
+        : elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
     }
 
     return elasticQuery;

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -424,6 +424,14 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMatchCondition('round', filter.round);
     }
 
+    if (filter.isScCall !== undefined) {
+      if (filter.isScCall) {
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('isScCall', true));
+      } else {
+        elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
+      }
+    }
+
     return elasticQuery;
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -425,11 +425,9 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.isScCall !== undefined) {
-      if (filter.isScCall) {
-        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('isScCall', true));
-      } else {
-        elasticQuery = elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
-      }
+      elasticQuery = filter.isScCall
+        ? elasticQuery.withMustCondition(QueryType.Match('isScCall', true))
+        : elasticQuery.withMustNotCondition(QueryType.Match('isScCall', true));
     }
 
     return elasticQuery;

--- a/src/common/indexer/entities/transaction.ts
+++ b/src/common/indexer/entities/transaction.ts
@@ -34,4 +34,5 @@ export interface Transaction {
   relayer: string;
   relayerSignature: string;
   isRelayed: boolean;
+  isScCall: boolean;
 }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -877,6 +877,7 @@ export class AccountController {
   @ApiQuery({ name: 'computeScamInfo', required: false, type: Boolean })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns isRelayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
   async getAccountTransactions(
@@ -905,6 +906,7 @@ export class AccountController {
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
   ) {
@@ -925,6 +927,7 @@ export class AccountController {
       order,
       senderOrReceiver,
       isRelayed,
+      isScCall,
       round,
       withRelayedScresults,
     });
@@ -949,6 +952,7 @@ export class AccountController {
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns isRelayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
   async getAccountTransactionsCount(
     @Param('address', ParseAddressPipe) address: string,
@@ -966,6 +970,7 @@ export class AccountController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
 
   ): Promise<number> {
@@ -984,6 +989,7 @@ export class AccountController {
       after,
       senderOrReceiver,
       isRelayed,
+      isScCall,
       round,
       withRelayedScresults,
     }), address);
@@ -1010,6 +1016,7 @@ export class AccountController {
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false, isArray: true, style: 'form', explode: false })
   @ApiQuery({ name: 'relayer', description: 'Address of the relayer', required: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -1042,6 +1049,7 @@ export class AccountController {
     @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
     @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
@@ -1070,6 +1078,7 @@ export class AccountController {
       round,
       withRefunds,
       withTxsRelayedByAddress,
+      isScCall,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -1092,6 +1101,7 @@ export class AccountController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfersCount(
@@ -1109,6 +1119,7 @@ export class AccountController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -1126,6 +1137,7 @@ export class AccountController {
       after,
       senderOrReceiver,
       round,
+      isScCall,
       withRefunds,
     }));
   }
@@ -1148,6 +1160,7 @@ export class AccountController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       address,
@@ -1165,6 +1178,7 @@ export class AccountController {
       senderOrReceiver,
       round,
       withRefunds,
+      isScCall,
     }));
   }
 

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -212,6 +212,7 @@ export class TokenController {
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withScResults', description: 'Return scResults for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions', required: false, type: Boolean })
@@ -237,6 +238,7 @@ export class TokenController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
     @Query('fields', ParseArrayPipe) fields?: string[],
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withScResults', ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
@@ -267,6 +269,7 @@ export class TokenController {
       after,
       order,
       round,
+      isScCall,
       withRelayedScresults,
     });
     TransactionFilter.validate(transactionFilter, size);
@@ -294,6 +297,7 @@ export class TokenController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
   async getTokenTransactionsCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
@@ -308,6 +312,7 @@ export class TokenController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
   ) {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -327,6 +332,7 @@ export class TokenController {
       after,
       round,
       withRelayedScresults,
+      isScCall,
     }));
   }
 
@@ -390,6 +396,7 @@ export class TokenController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
   @ApiQuery({ name: 'fields', description: 'List of fields to filter by', required: false, isArray: true, style: 'form', explode: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -411,6 +418,7 @@ export class TokenController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
@@ -437,6 +445,7 @@ export class TokenController {
       after,
       order,
       round,
+      isScCall,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -458,6 +467,7 @@ export class TokenController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Filter by round number', required: false })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   async getTokenTransfersCount(
     @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -471,6 +481,7 @@ export class TokenController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
   ): Promise<number> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -490,6 +501,7 @@ export class TokenController {
       before,
       after,
       round,
+      isScCall,
     }));
   }
 
@@ -508,6 +520,7 @@ export class TokenController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('round', ParseIntPipe) round?: number,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
   ): Promise<number> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -527,6 +540,7 @@ export class TokenController {
       before,
       after,
       round,
+      isScCall,
     }));
   }
 

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -23,6 +23,7 @@ export class TransactionFilter {
   type?: TransactionType;
   tokens?: string[];
   senderOrReceiver?: string;
+  isScCall?: boolean;
   isRelayed?: boolean;
   relayer?: string;
   round?: number;

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -110,6 +110,9 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true, required: false })
   relayerSignature: string | undefined = undefined;
 
+  @ApiProperty({ type: Boolean, nullable: true, required: false })
+  isScCall: boolean | undefined = undefined;
+
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -49,6 +49,7 @@ export class TransactionController {
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
   @ApiQuery({ name: 'relayer', description: 'Search by a relayer address', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
   getTransactions(
@@ -77,6 +78,7 @@ export class TransactionController {
     @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
   ) {
@@ -98,6 +100,7 @@ export class TransactionController {
       order,
       relayer,
       isRelayed,
+      isScCall,
       round,
       withRelayedScresults: withRelayedScresults,
     });
@@ -127,6 +130,7 @@ export class TransactionController {
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'relayer', description: 'Filter by a relayer address', required: false })
   @ApiQuery({ name: 'withRelayedScresults', description: 'If set to true, will include smart contract results that resemble relayed transactions', required: false, type: Boolean })
   getTransactionCount(
@@ -145,6 +149,7 @@ export class TransactionController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
@@ -162,6 +167,7 @@ export class TransactionController {
       condition,
       relayer,
       isRelayed,
+      isScCall,
       round,
       withRelayedScresults: withRelayedScresults,
     }));
@@ -185,6 +191,7 @@ export class TransactionController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRelayedScresults', ParseBoolPipe) withRelayedScresults?: boolean,
   ): Promise<number> {
     return this.transactionService.getTransactionCount(new TransactionFilter({
@@ -203,6 +210,7 @@ export class TransactionController {
       isRelayed,
       relayer,
       round,
+      isScCall,
       withRelayedScresults: withRelayedScresults,
     }));
   }

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -40,6 +40,7 @@ export class TransferController {
   @ApiQuery({ name: 'function', description: 'Filter transfers by function name', required: false })
   @ApiQuery({ name: 'relayer', description: 'Filter by relayer address', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', description: 'Returns scam information', required: false, type: Boolean })
   @ApiQuery({ name: 'withUsername', description: 'Integrates username in assets for all addresses present in the transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withBlockInfo', description: 'Returns sender / receiver block details', required: false, type: Boolean })
@@ -66,6 +67,7 @@ export class TransferController {
     @Query('fields', ParseArrayPipe) fields?: string[],
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withScamInfo', ParseBoolPipe) withScamInfo?: boolean,
     @Query('withUsername', ParseBoolPipe) withUsername?: boolean,
     @Query('withBlockInfo', ParseBoolPipe) withBlockInfo?: boolean,
@@ -95,6 +97,7 @@ export class TransferController {
       isRelayed,
       round,
       withRefunds,
+      isScCall,
     }),
       new QueryPagination({ from, size }),
       options,
@@ -119,6 +122,7 @@ export class TransferController {
   @ApiQuery({ name: 'round', description: 'Round number', required: false })
   @ApiQuery({ name: 'relayer', description: 'Filter by the relayer address', required: false })
   @ApiQuery({ name: 'isRelayed', description: 'Returns relayed transactions details', required: false, type: Boolean })
+  @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfersCount(
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -135,6 +139,7 @@ export class TransferController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -153,6 +158,7 @@ export class TransferController {
       isRelayed,
       round,
       withRefunds,
+      isScCall,
     }));
   }
 
@@ -173,6 +179,7 @@ export class TransferController {
     @Query('round', ParseIntPipe) round?: number,
     @Query('relayer', ParseAddressPipe) relayer?: string,
     @Query('isRelayed', ParseBoolPipe) isRelayed?: boolean,
+    @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
@@ -191,6 +198,7 @@ export class TransferController {
       relayer,
       isRelayed,
       withRefunds,
+      isScCall,
     }));
   }
 }

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -429,6 +429,7 @@ describe('Account Service', () => {
         version: 2,
         relayer: '',
         isRelayed: false,
+        isScCall: true,
         relayerSignature: '',
       });
 

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -187,6 +187,7 @@ describe('TransactionService', () => {
         version: 1,
         relayer: 'erd1sdrjn0uuulydacwjam3v5afl427ptk797fpcujpfcsakfck8aqjquq9afc',
         isRelayed: true,
+        isScCall: true,
         relayerSignature: 'bc51e9032332740d60c404d4bf553ae225ca77a70ad799a1cdfc6e73609be8ec62e89ac6e2c2621ffbfb89e6fab620c137010662f3ebea9c422c9f1dbec04a03',
       },
       {
@@ -227,6 +228,7 @@ describe('TransactionService', () => {
         version: 1,
         relayer: 'erd1sdrjn0uuulydacwjam3v5afl427ptk797fpcujpfcsakfck8aqjquq9afc',
         isRelayed: true,
+        isScCall: true,
         relayerSignature: 'bc51e9032332740d60c404d4bf553ae225ca77a70ad799a1cdfc6e73609be8ec62e89ac6e2c2621ffbfb89e6fab620c137010662f3ebea9c422c9f1dbec04a03',
       },
     ];


### PR DESCRIPTION
  
## Proposed Changes
-  Added `isScCall` in transactions / transfers response
-  Added support for `isScCall` filter for `accounts, tokens, transactions, transfers` endpoints

## How to test
- `<api>/accounts/:address/transactions?isScCall=true`
- `<api>/accounts/:address/transactions?isScCall=false`
- `<api>/accounts/:address/transfers?isScCall=true`
- `<api>/accounts/:address/transfers?isScCall=false`
- `<api>/tokens/:token/transactions?isScCall=true`
- `<api>/tokens/:token/transactions?isScCall=false`
- `<api>/tokens/:token/transfers?isScCall=true`
- `<api>/tokens/:token/transfers?isScCall=false`
- `<api>transfers?isScCall=true`
-  `<api>transfers?isScCall=false`
- `<api>transactions?isScCall=true`
- `<api>transactions?isScCall=false`
