### PR TITLE
update chain simulator github action

### DIFF
--- a/.github/workflows/chain-simulator-e2e-tests.yml
+++ b/.github/workflows/chain-simulator-e2e-tests.yml
@@ -1,7 +1,10 @@
 name: Chain simulator e2e tests workflow
 
 on:
+  push:
+    branches: [main, development]
   pull_request:
+    branches: [main, development]
 
 jobs:
   test-chainsimulator-e2e:


### PR DESCRIPTION
## Reasoning
- missing triggers for `main` -> `development` branch github actions for chain simulator
  
