### PR TITLE
Export NFT/SFT/MetaESDT hash field

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -262,14 +262,7 @@ export class EsdtAddressService {
       nft.uris = dataSourceNft.uris ? dataSourceNft.uris.filter((x: any) => x) : [];
       nft.name = dataSourceNft.name;
       nft.timestamp = dataSourceNft.timestamp;
-      if (dataSourceNft.hash) {
-        const decodedHex = BinaryUtils.base64Decode(dataSourceNft.hash);
-        if (decodedHex.startsWith('proof:')) {
-          nft.hash = decodedHex;
-        } else {
-          nft.hash = dataSourceNft.hash;
-        }
-      }
+      nft.hash = TokenHelpers.getNftProof(dataSourceNft.hash) || '';
 
       if (nft.uris && nft.uris.length > 0) {
         try {

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -262,6 +262,14 @@ export class EsdtAddressService {
       nft.uris = dataSourceNft.uris ? dataSourceNft.uris.filter((x: any) => x) : [];
       nft.name = dataSourceNft.name;
       nft.timestamp = dataSourceNft.timestamp;
+      if (dataSourceNft.hash) {
+        const decodedHex = BinaryUtils.base64Decode(dataSourceNft.hash);
+        if (decodedHex.startsWith('proof:')) {
+          nft.hash = decodedHex;
+        } else {
+          nft.hash = dataSourceNft.hash;
+        }
+      }
 
       if (nft.uris && nft.uris.length > 0) {
         try {

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -262,7 +262,7 @@ export class EsdtAddressService {
       nft.uris = dataSourceNft.uris ? dataSourceNft.uris.filter((x: any) => x) : [];
       nft.name = dataSourceNft.name;
       nft.timestamp = dataSourceNft.timestamp;
-      nft.hash = TokenHelpers.getNftProof(dataSourceNft.hash) || '';
+      nft.hash = TokenHelpers.getNftProof(dataSourceNft.hash) ?? '';
 
       if (nft.uris && nft.uris.length > 0) {
         try {

--- a/src/endpoints/nfts/entities/nft.ts
+++ b/src/endpoints/nfts/entities/nft.ts
@@ -20,6 +20,9 @@ export class Nft {
   @ApiProperty({ type: String })
   collection: string = '';
 
+  @ApiProperty({ type: String })
+  hash: string = '';
+
   @ApiProperty({ type: Number, nullable: true })
   timestamp?: number = undefined;
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -348,7 +348,9 @@ export class NftService {
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
         nft.name = elasticNftData.name;
-        nft.hash = BinaryUtils.base64Decode(elasticNftData.hash);
+        if (elasticNftData.hash) {
+          nft.hash = BinaryUtils.base64Decode(elasticNftData.hash);
+        }
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%
         nft.attributes = elasticNftData.attributes;

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -348,7 +348,7 @@ export class NftService {
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
         nft.name = elasticNftData.name;
-        nft.hash = elasticNftData.hash;
+        nft.hash = BinaryUtils.base64Decode(elasticNftData.hash);
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%
         nft.attributes = elasticNftData.attributes;

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -349,7 +349,12 @@ export class NftService {
       if (elasticNftData) {
         nft.name = elasticNftData.name;
         if (elasticNftData.hash) {
-          nft.hash = BinaryUtils.base64Decode(elasticNftData.hash);
+          const decodedHex = BinaryUtils.base64Decode(elasticNftData.hash);
+          if (decodedHex.startsWith('proof:')) {
+            nft.hash = decodedHex;
+          } else {
+            nft.hash = elasticNftData.hash;
+          }
         }
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -18,13 +18,12 @@ import { EsdtDataSource } from "../esdt/entities/esdt.data.source";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { PersistenceService } from "src/common/persistence/persistence.service";
 import { MexTokenService } from "../mex/mex.token.service";
-import { BinaryUtils, NumberUtils, RecordUtils, BatchUtils, TokenUtils } from "@multiversx/sdk-nestjs-common";
+import { BinaryUtils, NumberUtils, RecordUtils, BatchUtils, TokenUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { IndexerService } from "src/common/indexer/indexer.service";
 import { LockedAssetService } from "../../common/locked-asset/locked-asset.service";
 import { CollectionAccount } from "../collections/entities/collection.account";
-import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { NftRankAlgorithm } from "src/common/assets/entities/nft.rank.algorithm";
 import { NftRarity } from "./entities/nft.rarity";
 import { NftRarities } from "./entities/nft.rarities";
@@ -349,6 +348,7 @@ export class NftService {
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
         nft.name = elasticNftData.name;
+        nft.hash = elasticNftData.hash;
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%
         nft.attributes = elasticNftData.attributes;
@@ -593,6 +593,16 @@ export class NftService {
 
   async getAccountEsdtByCollection(identifier: string, pagination?: QueryPagination) {
     return await this.indexerService.getAccountsEsdtByCollection([identifier], pagination);
+  }
+
+  // TODO: use this function to determine if a MetaESDT is a proof if we decide to add API filters to extract all the proofs
+  getNftProofHash(nft: Nft): string | undefined{
+    const hashField = BinaryUtils.base64Decode(nft.hash);
+    if (nft.type !== NftType.MetaESDT || !hashField.startsWith('proof:')) {
+      return undefined;
+    }
+
+    return hashField.split('proof:')[1];
   }
 
   private getNftRarity(elasticNft: any, algorithm: NftRankAlgorithm): NftRarity | undefined {

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -348,7 +348,7 @@ export class NftService {
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
         nft.name = elasticNftData.name;
-        nft.hash = nft.hash = TokenHelpers.getNftProof(elasticNftData.hash) || '';
+        nft.hash = TokenHelpers.getNftProof(elasticNftData.hash) ?? '';
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%
         nft.attributes = elasticNftData.attributes;

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -348,14 +348,7 @@ export class NftService {
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
         nft.name = elasticNftData.name;
-        if (elasticNftData.hash) {
-          const decodedHex = BinaryUtils.base64Decode(elasticNftData.hash);
-          if (decodedHex.startsWith('proof:')) {
-            nft.hash = decodedHex;
-          } else {
-            nft.hash = elasticNftData.hash;
-          }
-        }
+        nft.hash = nft.hash = TokenHelpers.getNftProof(elasticNftData.hash) || '';
         nft.creator = elasticNftData.creator;
         nft.royalties = elasticNftData.royalties ? elasticNftData.royalties / 100 : undefined; // 10.000 => 100%
         nft.attributes = elasticNftData.attributes;

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -5,6 +5,7 @@ import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles"
 import { TokenRoles } from "src/endpoints/tokens/entities/token.roles";
 import { ApiUtils } from '@multiversx/sdk-nestjs-http';
 import '@multiversx/sdk-nestjs-common/lib/utils/extensions/string.extensions';
+import { BinaryUtils } from "@multiversx/sdk-nestjs-common";
 
 export class TokenHelpers {
   static canBool(string: string) {
@@ -95,5 +96,18 @@ export class TokenHelpers {
 
   static getCollectionIdentifier(nftIdentifier: string): string {
     return nftIdentifier.split('-').slice(0, 2).join('-');
+  }
+
+  static getNftProof(hash: string): string | undefined {
+    if (!hash) {
+      return undefined;
+    }
+
+    const decodedHex = BinaryUtils.base64Decode(hash);
+    if (decodedHex.startsWith('proof:')) {
+      return decodedHex;
+    } else {
+      return hash;
+    }
   }
 }


### PR DESCRIPTION
## Reasoning
- the `hash` field of NFTs/SFTs/MetaESDTs was not reflected on the API
  
## Proposed Changes
- return `hash` field as well

## How to test
- 
- 
- 
