### PR TITLE
Add block proof support

### DIFF
--- a/src/endpoints/blocks/entities/block.proof.ts
+++ b/src/endpoints/blocks/entities/block.proof.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BlockProofDto {
+  @ApiProperty({
+    type: String,
+    description: "Bitmap representing public keys involved in the proof",
+    example: "7702",
+  })
+  pubKeysBitmap?: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Aggregated BLS signature for the proof",
+    example: "50224d66a42a019991d16f25dba375b581f279d4394d4c254876c1484f61bed90fb20456f8af107c54e4eed1763e2a92",
+  })
+  aggregatedSignature?: string;
+
+  @ApiProperty({
+    type: String,
+    description: "Hash of the block header being proven",
+    example: "414d526161587ae9f53453aa0392971272c48dbb3cc54a33448972d388e0deeb",
+  })
+  headerHash?: string;
+
+  @ApiProperty({type: Number, description: "Epoch number of the block header", example: 130})
+  headerEpoch?: number;
+
+  @ApiProperty({type: Number, description: "Nonce value of the block header", example: 13137})
+  headerNonce?: number;
+
+  @ApiProperty({type: Number, description: "Round number of the block header", example: 13163})
+  headerRound?: number;
+}

--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -1,6 +1,7 @@
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
 import { ApiProperty } from "@nestjs/swagger";
 import { Identity } from "src/endpoints/identities/entities/identity";
+import { BlockProofDto } from "./block.proof";
 
 export class Block {
   constructor(init?: Partial<Block>) {
@@ -63,6 +64,12 @@ export class Block {
 
   @ApiProperty({ type: String, nullable: true, required: false })
   scheduledRootHash: string | undefined = undefined;
+
+  @ApiProperty({ type: BlockProofDto, nullable: true, required: false })
+  previousHeaderProof: BlockProofDto | undefined = undefined;
+
+  @ApiProperty({ type: BlockProofDto, nullable: true, required: false })
+  proof: BlockProofDto | undefined = undefined;
 
   static mergeWithElasticResponse<T extends Block>(newBlock: T, blockRaw: any): T {
     blockRaw.shard = blockRaw.shardId;


### PR DESCRIPTION
## Reasoning
- new (not yet released) versions of the protocol (andromeda) have 2 new fields on blocks
  
## Proposed Changes
- return these 2 new fields if they exist
- the object just needed to be extended, because the deserialization will fill them

## How to test
- 
