### PR TITLE
remove the cache key computation for the next day

### DIFF
--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -638,11 +638,7 @@ export class CacheInfo {
     const isCurrentDate = priceDate.toISODateString() === new Date().toISODateString();
     const ttl = isCurrentDate ? Constants.oneMinute() * 5 : Constants.oneWeek();
 
-    let key = priceDate.toISODateString();
-    if (!isCurrentDate) {
-      key = priceDate.startOfDay().addDays(1).toISODateString();
-    }
-
+    const key = priceDate.toISODateString();
     return {
       key: `data-api:price:${identifier}:${key}`,
       ttl,


### PR DESCRIPTION
## Reasoning
- there is no need in altering the date to set in the data api token price cache key
  
## Proposed Changes
- remove date altering

## How to test
- 
- 
- 
