### PR TITLE
Compute media url links

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -55,7 +55,7 @@ features:
   mediaRedirect:
     enabled: false
     storageUrls:
-      - 'https://s3.amazonaws.com/media.elrond.com'
+      - 'https://s3.amazonaws.com/devnet-media.elrond.com'
   auth:
     enabled: false
     maxExpirySeconds: 86400

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -111,7 +111,7 @@ features:
   mediaRedirect:
     enabled: false
     storageUrls:
-      - 'https://s3.amazonaws.com/media.elrond.com'
+      - 'https://s3.amazonaws.com/testnet-media.elrond.com'
 image:
   width: 600
   height: 600

--- a/src/endpoints/media/media.controller.ts
+++ b/src/endpoints/media/media.controller.ts
@@ -24,7 +24,7 @@ export class MediaController {
     response.setHeader('location', redirectUrl);
     response.setHeader('cache-control', 'max-age=60');
     response.setHeader('Access-Control-Allow-Origin', '*');
-    response.setHeader('Content-Security-Policy', "default-src 'self'; img-src 'self' https://*.amazonaws.com");
+    response.setHeader('Content-Security-Policy', "default-src 'self'; img-src 'self' https://*.amazonaws.com; connect-src 'self' https://*.amazonaws.com; frame-src https://*.amazonaws.com; navigate-to https://*.amazonaws.com;");
 
     return response.redirect(301, redirectUrl);
   }

--- a/src/endpoints/media/media.controller.ts
+++ b/src/endpoints/media/media.controller.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import { MediaService } from "./media.service";
 import { ApiService } from "@multiversx/sdk-nestjs-http";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
+import https from 'https';
 
 @Controller()
 @ApiTags('media')
@@ -31,6 +32,10 @@ export class MediaController {
         // @ts-ignore
         responseType: 'stream',
         timeout: 60_000, // 60 seconds timeout
+        httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36'
+        }
       });
 
       res.setHeader('content-type', response.headers['content-type']);

--- a/src/endpoints/media/media.controller.ts
+++ b/src/endpoints/media/media.controller.ts
@@ -1,31 +1,61 @@
-import { Controller, Get, NotFoundException, Param, Res } from "@nestjs/common";
+import { Controller, Get, InternalServerErrorException, NotFoundException, Param, Req, Res } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
-import { Response } from "express";
+import { Request, Response } from "express";
 import { MediaService } from "./media.service";
+import { ApiService } from "@multiversx/sdk-nestjs-http";
+import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 
 @Controller()
 @ApiTags('media')
 export class MediaController {
+  private readonly logger = new OriginLogger(MediaController.name);
+
   constructor(
     private readonly mediaService: MediaService,
+    private readonly apiService: ApiService,
   ) { }
 
   @Get("/media/:uri(*)")
   async redirectToMediaUri(
     @Param('uri') uri: string,
-    @Res() response: Response
+    @Req() req: Request,
+    @Res() res: Response
   ) {
     const redirectUrl = await this.mediaService.getRedirectUrl(uri);
     if (!redirectUrl) {
       throw new NotFoundException('Not found');
     }
 
-    response.statusMessage = 'Found';
-    response.setHeader('location', redirectUrl);
-    response.setHeader('cache-control', 'max-age=60');
-    response.setHeader('Access-Control-Allow-Origin', '*');
-    response.setHeader('Content-Security-Policy', "default-src 'self'; img-src 'self' https://*.amazonaws.com; connect-src 'self' https://*.amazonaws.com; frame-src https://*.amazonaws.com; navigate-to https://*.amazonaws.com;");
+    try {
+      const response = await this.apiService.get(redirectUrl, {
+        // @ts-ignore
+        responseType: 'stream',
+        timeout: 60_000, // 60 seconds timeout
+      });
 
-    return response.redirect(301, redirectUrl);
+      res.setHeader('content-type', response.headers['content-type']);
+      res.setHeader('content-length', response.headers['content-length']);
+      res.setHeader('cache-control', 'max-age=60');
+      res.setHeader('Access-Control-Allow-Origin', '*');
+
+      response.data.pipe(res);
+
+      response.data.on('error', (error: any) => {
+        this.logger?.error(`Error streaming the resource: ${redirectUrl}`);
+        this.logger?.error(error);
+
+        throw new InternalServerErrorException('Failed to fetch URL');
+      });
+
+      req.on('close', () => {
+        response.data?.destroy();
+      });
+
+      return;
+    } catch (error) {
+      this.logger.error(`Failed to fetch URL: ${redirectUrl}`);
+
+      throw new InternalServerErrorException('Failed to fetch URL');
+    }
   }
 }

--- a/src/endpoints/media/media.controller.ts
+++ b/src/endpoints/media/media.controller.ts
@@ -24,6 +24,8 @@ export class MediaController {
     response.setHeader('location', redirectUrl);
     response.setHeader('cache-control', 'max-age=60');
     response.setHeader('Access-Control-Allow-Origin', '*');
+    response.setHeader('Content-Security-Policy', "default-src 'self'; img-src 'self' https://*.amazonaws.com");
+
     return response.redirect(301, redirectUrl);
   }
 }

--- a/src/endpoints/media/media.controller.ts
+++ b/src/endpoints/media/media.controller.ts
@@ -23,6 +23,7 @@ export class MediaController {
     response.statusMessage = 'Found';
     response.setHeader('location', redirectUrl);
     response.setHeader('cache-control', 'max-age=60');
-    return response.redirect(redirectUrl);
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    return response.redirect(301, redirectUrl);
   }
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -55,9 +55,9 @@ export class NftService {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
     this.DEFAULT_MEDIA = [
       {
-        url: NftMediaService.NFT_THUMBNAIL_DEFAULT,
-        originalUrl: NftMediaService.NFT_THUMBNAIL_DEFAULT,
-        thumbnailUrl: NftMediaService.NFT_THUMBNAIL_DEFAULT,
+        url: this.nftMediaService.NFT_THUMBNAIL_DEFAULT,
+        originalUrl: this.nftMediaService.NFT_THUMBNAIL_DEFAULT,
+        thumbnailUrl: this.nftMediaService.NFT_THUMBNAIL_DEFAULT,
         fileType: 'image/png',
         fileSize: 29512,
       },
@@ -596,7 +596,7 @@ export class NftService {
   }
 
   // TODO: use this function to determine if a MetaESDT is a proof if we decide to add API filters to extract all the proofs
-  getNftProofHash(nft: Nft): string | undefined{
+  getNftProofHash(nft: Nft): string | undefined {
     const hashField = BinaryUtils.base64Decode(nft.hash);
     if (nft.type !== NftType.MetaESDT || !hashField.startsWith('proof:')) {
       return undefined;

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -18,8 +18,8 @@ import { CachingUtils } from "src/utils/caching.utils";
 export class NftMediaService {
   private readonly logger = new OriginLogger(NftMediaService.name);
   private readonly IPFS_REQUEST_TIMEOUT = Constants.oneSecond() * 30 * 1000;
-  private readonly NFT_THUMBNAIL_PREFIX;
-  public static readonly NFT_THUMBNAIL_DEFAULT = 'https://media.elrond.com/nfts/thumbnail/default.png';
+  private readonly NFT_THUMBNAIL_PREFIX: string;
+  public readonly NFT_THUMBNAIL_DEFAULT: string;
 
   constructor(
     private readonly cachingService: CacheService,
@@ -28,7 +28,8 @@ export class NftMediaService {
     private readonly persistenceService: PersistenceService,
     @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
   ) {
-    this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
+    this.NFT_THUMBNAIL_PREFIX = `${this.apiConfigService.getExternalMediaUrl()}/nfts/asset`;
+    this.NFT_THUMBNAIL_DEFAULT = `${this.apiConfigService.getMediaUrl()}/nfts/thumbnail/default.png`;
   }
 
   async getMedia(identifier: string): Promise<NftMedia[] | null> {
@@ -112,7 +113,7 @@ export class NftMediaService {
         nftMedia.thumbnailUrl = `${this.apiConfigService.getExternalMediaUrl()}/nfts/thumbnail/${nft.collection}-${TokenHelpers.getUrlHash(nftMedia.url)}`;
       } else {
         this.logger.log(`File size '${fileProperties.contentLength}' not accepted for NFT with identifier '${nft.identifier}'`);
-        nftMedia.thumbnailUrl = NftMediaService.NFT_THUMBNAIL_DEFAULT;
+        nftMedia.thumbnailUrl = this.NFT_THUMBNAIL_DEFAULT;
       }
 
       nftMedia.fileType = fileProperties.contentType;

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -135,7 +135,7 @@ export class NftQueueController {
       }
 
       if (nft.media && !settings.skipRefreshThumbnail) {
-        const mediaItems = nft.media.filter(x => x.thumbnailUrl !== NftMediaService.NFT_THUMBNAIL_DEFAULT);
+        const mediaItems = nft.media.filter(x => x.thumbnailUrl !== this.nftMediaService.NFT_THUMBNAIL_DEFAULT);
 
         await Promise.all(mediaItems.map(media => this.generateThumbnail(nft, media, settings.forceRefreshThumbnail)));
       }


### PR DESCRIPTION
## Reasoning
- the default NFT thumbnail link was not dynamic
  
## Proposed Changes
- the default NFT thumbnail link is built according to the config

## How to test
- `/nfts` should return the correct link in the `media` array
