### PR TITLE
remove async await for sync functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "semi": ["error"],
     "comma-dangle": ["error", "always-multiline"],
     "eol-last": ["error"],
+    "@typescript-eslint/await-thenable": "error",
   },
   ignorePatterns: ['.eslintrc.js'],
 };

--- a/src/common/rabbitmq/rabbitmq.nft.handler.service.ts
+++ b/src/common/rabbitmq/rabbitmq.nft.handler.service.ts
@@ -28,7 +28,7 @@ export class RabbitMqNftHandlerService {
       return null;
     }
 
-    await this.cachingService.setLocal(
+    this.cachingService.setLocal(
       CacheInfo.CollectionType(collectionIdentifier).key,
       type,
       CacheInfo.CollectionType(collectionIdentifier).ttl

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -407,10 +407,10 @@ export class CacheWarmerService {
 
   private async invalidateKey(key: string, data: any, ttl: number) {
     await this.cachingService.set(key, data, ttl);
-    await this.refreshCacheKey(key, ttl);
+    this.refreshCacheKey(key, ttl);
   }
 
-  private async refreshCacheKey(key: string, ttl: number) {
-    await this.clientProxy.emit('refreshCacheKey', { key, ttl });
+  private refreshCacheKey(key: string, ttl: number) {
+    this.clientProxy.emit('refreshCacheKey', { key, ttl });
   }
 }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -87,7 +87,7 @@ export class BlockService {
     if (!blses) {
       blses = await this.blsService.getPublicKeys(shardId, epoch);
 
-      await this.cachingService.setLocal(CacheInfo.ShardAndEpochBlses(shardId, epoch).key, blses, CacheInfo.ShardAndEpochBlses(shardId, epoch).ttl);
+      this.cachingService.setLocal(CacheInfo.ShardAndEpochBlses(shardId, epoch).key, blses, CacheInfo.ShardAndEpochBlses(shardId, epoch).ttl);
     }
 
     proposer = blses[proposer];

--- a/src/endpoints/caching/local.cache.controller.ts
+++ b/src/endpoints/caching/local.cache.controller.ts
@@ -36,8 +36,8 @@ export class LocalCacheController {
     status: 200,
     description: 'Key has been updated',
   })
-  async setCache(@Param('key') key: string, @Body() cacheValue: CacheValue) {
-    await this.cachingService.setLocal(key, cacheValue.value, cacheValue.ttl);
+  setCache(@Param('key') key: string, @Body() cacheValue: CacheValue) {
+    this.cachingService.setLocal(key, cacheValue.value, cacheValue.ttl);
   }
 
   @UseGuards(NativeAuthGuard, JwtAdminGuard)

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -243,8 +243,8 @@ export class CollectionService {
     }
   }
 
-  async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoles[]> {
-    return await this.getNftCollectionRolesFromElasticResponse(elasticCollection);
+  getNftCollectionRoles(elasticCollection: any): CollectionRoles[] {
+    return this.getNftCollectionRolesFromElasticResponse(elasticCollection);
   }
 
   async getNftCollectionRolesFromGateway(elasticCollection: any): Promise<CollectionRoles[]> {

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -367,7 +367,7 @@ export class EsdtAddressService {
 
     const ttl = await this.protocolService.getSecondsRemainingUntilNextRound();
 
-    await this.cachingService.setLocal(`address:${address}:esdts`, esdts, ttl);
+    this.cachingService.setLocal(`address:${address}:esdts`, esdts, ttl);
 
     return esdts;
   }

--- a/src/endpoints/mex/mex.farm.service.ts
+++ b/src/endpoints/mex/mex.farm.service.ts
@@ -24,7 +24,7 @@ export class MexFarmService {
   async refreshMexFarms(): Promise<void> {
     const farms = await this.getAllMexFarmsRaw();
     await this.cachingService.setRemote(CacheInfo.MexFarms.key, farms, CacheInfo.MexFarms.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexFarms.key, farms, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexFarms.key, farms, Constants.oneSecond() * 30);
   }
 
   async getMexFarms(pagination: QueryPagination): Promise<MexFarm[]> {

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -28,7 +28,7 @@ export class MexPairService {
   async refreshMexPairs(): Promise<void> {
     const pairs = await this.getAllMexPairsRaw(false);
     await this.cachingService.setRemote(CacheInfo.MexPairs.key, pairs, CacheInfo.MexPairs.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexPairs.key, pairs, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexPairs.key, pairs, Constants.oneSecond() * 30);
   }
 
   async getMexPairs(from: number, size: number, filter?: MexPairsFilter): Promise<any> {

--- a/src/endpoints/mex/mex.settings.service.ts
+++ b/src/endpoints/mex/mex.settings.service.ts
@@ -37,11 +37,11 @@ export class MexSettingsService {
   async refreshSettings(): Promise<void> {
     const settings = await this.getSettingsRaw();
     await this.cachingService.setRemote(CacheInfo.MexSettings.key, settings, CacheInfo.MexSettings.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexSettings.key, settings, Constants.oneMinute() * 10);
+    this.cachingService.setLocal(CacheInfo.MexSettings.key, settings, Constants.oneMinute() * 10);
 
     const contracts = await this.getMexContractsRaw();
     await this.cachingService.setRemote(CacheInfo.MexContracts.key, contracts, CacheInfo.MexContracts.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexContracts.key, contracts, Constants.oneMinute() * 10);
+    this.cachingService.setLocal(CacheInfo.MexContracts.key, contracts, Constants.oneMinute() * 10);
   }
 
   async getSettings(): Promise<MexSettings | null> {
@@ -65,7 +65,7 @@ export class MexSettingsService {
     let contracts = await this.cachingService.getLocal<Set<string>>(CacheInfo.MexContracts.key);
     if (!contracts) {
       contracts = await this.getMexContractsRaw();
-      await this.cachingService.setLocal(CacheInfo.MexContracts.key, contracts, Constants.oneMinute() * 10);
+      this.cachingService.setLocal(CacheInfo.MexContracts.key, contracts, Constants.oneMinute() * 10);
     }
 
     return contracts;

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -31,19 +31,19 @@ export class MexTokenService {
   async refreshMexTokens(): Promise<void> {
     const tokens = await this.getAllMexTokensRaw();
     await this.cachingService.setRemote(CacheInfo.MexTokens.key, tokens, CacheInfo.MexTokens.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexTokens.key, tokens, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexTokens.key, tokens, Constants.oneSecond() * 30);
 
     const tokenTypes = await this.getAllMexTokenTypesRaw();
     await this.cachingService.setRemote(CacheInfo.MexTokenTypes.key, tokenTypes, CacheInfo.MexTokenTypes.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexTokenTypes.key, tokenTypes, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexTokenTypes.key, tokenTypes, Constants.oneSecond() * 30);
 
     const indexedTokens = await this.getIndexedMexTokensRaw();
     await this.cachingService.setRemote(CacheInfo.MexTokensIndexed.key, indexedTokens, CacheInfo.MexTokensIndexed.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexTokensIndexed.key, indexedTokens, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexTokensIndexed.key, indexedTokens, Constants.oneSecond() * 30);
 
     const indexedPrices = await this.getMexPricesRaw();
     await this.cachingService.setRemote(CacheInfo.MexPrices.key, indexedPrices, CacheInfo.MexPrices.ttl);
-    await this.cachingService.setLocal(CacheInfo.MexPrices.key, indexedPrices, Constants.oneSecond() * 30);
+    this.cachingService.setLocal(CacheInfo.MexPrices.key, indexedPrices, Constants.oneSecond() * 30);
   }
 
   async getMexTokens(queryPagination: QueryPagination): Promise<MexToken[]> {

--- a/src/endpoints/mex/mex.warmer.service.ts
+++ b/src/endpoints/mex/mex.warmer.service.ts
@@ -56,10 +56,10 @@ export class MexWarmerService {
 
   private async invalidateKey(key: string, data: any, ttl: number) {
     await this.cachingService.set(key, data, ttl);
-    await this.refreshCacheKey(key, ttl);
+    this.refreshCacheKey(key, ttl);
   }
 
-  private async refreshCacheKey(key: string, ttl: number) {
-    await this.clientProxy.emit('refreshCacheKey', { key, ttl });
+  private refreshCacheKey(key: string, ttl: number) {
+    this.clientProxy.emit('refreshCacheKey', { key, ttl });
   }
 }

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -391,7 +391,7 @@ export class NodeService {
     const currentEpoch = await this.blockService.getCurrentEpoch();
     if (this.apiConfigService.isStakingV4Enabled() && currentEpoch >= this.apiConfigService.getStakingV4ActivationEpoch()) {
       const auctions = await this.gatewayService.getValidatorAuctions();
-      await this.processAuctions(nodes, auctions);
+      this.processAuctions(nodes, auctions);
     }
 
     await this.applyNodeUnbondingPeriods(nodes);
@@ -412,8 +412,8 @@ export class NodeService {
     }
   }
 
-  async processAuctions(nodes: Node[], auctions: Auction[]) {
-    const minimumAuctionStake = await this.stakeService.getMinimumAuctionStake(auctions);
+  processAuctions(nodes: Node[], auctions: Auction[]) {
+    const minimumAuctionStake = this.stakeService.getMinimumAuctionStake(auctions);
     const dangerZoneThreshold = BigInt(minimumAuctionStake) * BigInt(105) / BigInt(100);
     for (const node of nodes) {
       let position = 1;

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -91,7 +91,7 @@ export class TokenService {
 
     token = ApiUtils.mergeObjects(new TokenDetailed(), token);
 
-    await this.applyTickerFromAssets(token);
+    this.applyTickerFromAssets(token);
 
     await this.applySupply(token, supplyOptions);
 
@@ -380,7 +380,7 @@ export class TokenService {
 
     tokenWithBalance.identifier = token.identifier;
 
-    await this.applyTickerFromAssets(tokenWithBalance);
+    this.applyTickerFromAssets(tokenWithBalance);
 
     await this.applySupply(tokenWithBalance);
 

--- a/src/endpoints/transactions/transaction-action/recognizers/staking/transaction.action.stake.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/staking/transaction.action.stake.recognizer.service.ts
@@ -46,7 +46,7 @@ export class StakeActionRecognizerService implements TransactionActionRecognizer
         providersDetails[provider.provider] = { providerName, providerAvatar };
       }
 
-      await this.cachingService.setLocal('plugins:staking:providerAddresses', providersDetails, Constants.oneHour());
+      this.cachingService.setLocal('plugins:staking:providerAddresses', providersDetails, Constants.oneHour());
     }
 
     return providersDetails;

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -53,7 +53,7 @@ export class NftMediaService {
       CacheInfo.NftMedia(nft.identifier).ttl
     );
 
-    await this.clientProxy.emit('refreshCacheKey', {
+    this.clientProxy.emit('refreshCacheKey', {
       key: CacheInfo.NftMedia(nft.identifier).key,
       ttl: CacheInfo.NftMedia(nft.identifier).ttl,
     });

--- a/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
@@ -56,7 +56,7 @@ export class NftMetadataService {
       CacheInfo.NftMetadata(nft.identifier).ttl
     );
 
-    await this.clientProxy.emit('refreshCacheKey', {
+    this.clientProxy.emit('refreshCacheKey', {
       key: CacheInfo.NftMetadata(nft.identifier).key,
       ttl: CacheInfo.NftMetadata(nft.identifier).ttl,
     });


### PR DESCRIPTION
## Reasoning
- when a function which is synchronous is awaited, it introduces an overhead for encapsulating the response into a promise
  
## Proposed Changes
- remove async await for sync functions
- add new linter rule to prevent these cases