### PR TITLE
added missing relayer fields for sending txs

### DIFF
--- a/src/endpoints/transactions/entities/transaction.create.ts
+++ b/src/endpoints/transactions/entities/transaction.create.ts
@@ -49,4 +49,10 @@ export class TransactionCreate {
 
   @ApiProperty()
   guardianSignature?: string = undefined;
+
+  @ApiProperty()
+  relayer?: string = undefined;
+
+  @ApiProperty()
+  relayerSignature?: string = undefined;
 }


### PR DESCRIPTION
## Reasoning
- `relayer` and `relayerSignature` fields were missing from the class that mapped the transaction to be sent
  
## Proposed Changes
- add missing fields

## How to test
- 
- 
- 
