### PR TITLE
fix token isPaused property

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -890,7 +890,7 @@ export class ElasticIndexerService implements IndexerInterface {
   async getAllFungibleTokens(): Promise<any[]> {
     const query = ElasticQuery.create()
       .withMustMatchCondition('type', TokenType.FungibleESDT)
-      .withFields(["name", "type", "currentOwner", "numDecimals", "properties", "timestamp", "ownersHistory"])
+      .withFields(["name", "type", "currentOwner", "numDecimals", "properties", "timestamp", "ownersHistory", "paused"])
       .withMustNotExistCondition('identifier')
       .withPagination({ from: 0, size: 1000 });
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -227,7 +227,7 @@ export class EsdtService {
       canAddSpecialRoles: elasticProperties.properties?.canAddSpecialRoles ?? false,
       canTransferNFTCreateRole: elasticProperties.properties?.canTransferNFTCreateRole ?? false,
       NFTCreateStopped: elasticProperties.properties?.NFTCreateStopped ?? false,
-      isPaused: elasticProperties.properties?.isPaused ?? false,
+      isPaused: elasticProperties.paused ?? false,
       timestamp: elasticProperties.timestamp,
     });
 


### PR DESCRIPTION
## Reasoning
- `isPaused` property for tokens were not handle properly
  
## Proposed Changes
- when fetch all token properties from ES, also fetch `paused` property

## How to test
- `<api>/tokens/OURO-9ecd6a` -> `isPaused` property should be true
