### PR TITLE
fix after query param for mex/tokens/daily

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -183,8 +183,10 @@ export class MexController {
   @ApiNotFoundResponse({ description: 'Price not available for given token identifier' })
   async getTokenPricesDayResolution(
     @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('after') after: string): Promise<MexTokenChart[] | undefined> {
-    const charts = await this.mexTokenChartsService.getTokenPricesDayResolution(identifier, after);
+    @Query('after') after: string,
+    @Query('before') before: string
+  ): Promise<MexTokenChart[] | undefined> {
+    const charts = await this.mexTokenChartsService.getTokenPricesDayResolution(identifier, after, before);
     if (!charts) {
       throw new NotFoundException('Price not available for given token identifier');
     }

--- a/src/endpoints/mex/mex.token.charts.service.ts
+++ b/src/endpoints/mex/mex.token.charts.service.ts
@@ -56,14 +56,12 @@ export class MexTokenChartsService {
       return undefined;
     }
 
-    const shouldFetchAllData = before && !after;
-
     const query = gql`
       query tokenPriceDayResolution {
         latestCompleteValues(
           series: "${tokenIdentifier}",
           metric: "priceUSD"
-          ${!shouldFetchAllData && after ? `, start: "${after}"` : ''}
+          ${after ? `, start: "${after}"` : ''}
         ) {
           timestamp
           value

--- a/src/endpoints/mex/mex.token.charts.service.ts
+++ b/src/endpoints/mex/mex.token.charts.service.ts
@@ -50,7 +50,7 @@ export class MexTokenChartsService {
     );
   }
 
-  async getTokenPricesDayResolutionRaw(tokenIdentifier: string, after: string): Promise<MexTokenChart[] | undefined> {
+  async getTokenPricesDayResolutionRaw(tokenIdentifier: string, after?: string): Promise<MexTokenChart[] | undefined> {
     const isMexToken = await this.isMexToken(tokenIdentifier);
     if (!isMexToken) {
       return undefined;
@@ -61,7 +61,7 @@ export class MexTokenChartsService {
         latestCompleteValues(
           series: "${tokenIdentifier}",
           metric: "priceUSD",
-          start: "${after}"
+          ${after ? `, start: "${after}"` : ''}
         ) {
           timestamp
           value

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -162,9 +162,16 @@ export class CacheInfo {
     };
   }
 
-  static TokenDailyChart(tokenIdentifier: string, after: string): CacheInfo {
+  static TokenDailyChart(tokenIdentifier: string, after?: string, before?: string): CacheInfo {
+    const keyParts = [`tokenDailyChart:${tokenIdentifier}`];
+    if (after) {
+      keyParts.push(`after:${after}`);
+    }
+    if (before) {
+      keyParts.push(`before:${before}`);
+    }
     return {
-      key: `tokenDailyChart:${tokenIdentifier}:${after}`,
+      key: keyParts.join(':'),
       ttl: Constants.oneDay(),
     };
   }


### PR DESCRIPTION
## **BugFix after param**

### Reasoning
- if `after` param was not added, `start` graphql param was undefined and graphql returns 400 Bad Request 
  
### Proposed Changes
- add `after` graphql query param only if after is defined with value

### How to test
- `<api>/mex/tokens/prices/daily/TADA-5c032c` -> should return an array of values
- `mex/tokens/prices/daily/TADA-5c032c?after=1707688800` -> should return values that begins with the specified after value 

## **Include `before` param**
### Reasoning
- we need to have also `before` query timestamp to be able to return multiple values before the given daily token timestamp

### Proposed Changes
- added `before` query param
- If we have `before` but no `after`, we fetch all data (since we can't filter by end date in GraphQL) and filter in memory
- If we have `after` but no `before`, we use the GraphQL start parameter to filter at the source
- If we have `both`, we fetch from `after` and filter by `before` in memory

### How to test
- `mex/tokens/prices/daily/TADA-5c032c?before=1707516000` -> should return values before the given timestamp
- `mex/tokens/prices/daily/TADA-5c032c?before=1707516000&after=1707516000` -> should return values before the given timestamp and after the give timestamp
