### PR TITLE
remove query filters for mex/tokens/daily

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -178,13 +178,15 @@ export class MexController {
   }
 
   @Get('mex/tokens/prices/daily/:identifier')
-  @ApiOperation({ summary: 'xExchange token prices daily', description: 'Returns token prices daily' })
+  @ApiOperation({
+    summary: 'xExchange token prices daily',
+    description: 'Returns token prices daily, ordered by timestamp in ascending order. The entries represent the latest complete daily values for the given token series.',
+  })
   @ApiOkResponse({ type: [MexTokenChart] })
   @ApiNotFoundResponse({ description: 'Price not available for given token identifier' })
   async getTokenPricesDayResolution(
-    @Param('identifier', ParseTokenPipe) identifier: string,
-    @Query('after') after: string): Promise<MexTokenChart[] | undefined> {
-    const charts = await this.mexTokenChartsService.getTokenPricesDayResolution(identifier, after);
+    @Param('identifier', ParseTokenPipe) identifier: string): Promise<MexTokenChart[] | undefined> {
+    const charts = await this.mexTokenChartsService.getTokenPricesDayResolution(identifier);
     if (!charts) {
       throw new NotFoundException('Price not available for given token identifier');
     }

--- a/src/endpoints/mex/mex.token.charts.service.ts
+++ b/src/endpoints/mex/mex.token.charts.service.ts
@@ -42,15 +42,15 @@ export class MexTokenChartsService {
     }
   }
 
-  async getTokenPricesDayResolution(tokenIdentifier: string, after: string): Promise<MexTokenChart[] | undefined> {
+  async getTokenPricesDayResolution(tokenIdentifier: string): Promise<MexTokenChart[] | undefined> {
     return await this.cachingService.getOrSet(
-      CacheInfo.TokenDailyChart(tokenIdentifier, after).key,
-      async () => await this.getTokenPricesDayResolutionRaw(tokenIdentifier, after),
-      CacheInfo.TokenDailyChart(tokenIdentifier, after).ttl,
+      CacheInfo.TokenDailyChart(tokenIdentifier).key,
+      async () => await this.getTokenPricesDayResolutionRaw(tokenIdentifier),
+      CacheInfo.TokenDailyChart(tokenIdentifier).ttl,
     );
   }
 
-  async getTokenPricesDayResolutionRaw(tokenIdentifier: string, after: string): Promise<MexTokenChart[] | undefined> {
+  async getTokenPricesDayResolutionRaw(tokenIdentifier: string): Promise<MexTokenChart[] | undefined> {
     const isMexToken = await this.isMexToken(tokenIdentifier);
     if (!isMexToken) {
       return undefined;
@@ -61,7 +61,6 @@ export class MexTokenChartsService {
         latestCompleteValues(
           series: "${tokenIdentifier}",
           metric: "priceUSD",
-          start: "${after}"
         ) {
           timestamp
           value

--- a/src/test/unit/services/mex.token.charts.spec.ts
+++ b/src/test/unit/services/mex.token.charts.spec.ts
@@ -94,7 +94,7 @@ describe('MexTokenChartsService', () => {
       jest.spyOn(mexTokenService, 'getMexTokenByIdentifier').mockResolvedValue(mockToken);
       jest.spyOn(mexTokenChartsService as any, 'isMexToken').mockReturnValue(true);
 
-      const result = await mexTokenChartsService.getTokenPricesDayResolutionRaw('TOKEN-123456', '1683561648');
+      const result = await mexTokenChartsService.getTokenPricesDayResolutionRaw('TOKEN-123456');
 
       if (result) {
         expect(result).toHaveLength(2);
@@ -107,7 +107,7 @@ describe('MexTokenChartsService', () => {
     it('should return an empty array when no data is available', async () => {
       jest.spyOn(graphQlService, 'getExchangeServiceData').mockResolvedValue({});
       jest.spyOn(mexTokenChartsService as any, 'isMexToken').mockReturnValue(true);
-      const result = await mexTokenChartsService.getTokenPricesDayResolutionRaw('TOKEN-123456', '1683561648');
+      const result = await mexTokenChartsService.getTokenPricesDayResolutionRaw('TOKEN-123456');
 
       expect(result).toEqual([]);
     });

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -162,9 +162,9 @@ export class CacheInfo {
     };
   }
 
-  static TokenDailyChart(tokenIdentifier: string, after: string): CacheInfo {
+  static TokenDailyChart(tokenIdentifier: string): CacheInfo {
     return {
-      key: `tokenDailyChart:${tokenIdentifier}:${after}`,
+      key: `tokenDailyChart:${tokenIdentifier}`,
       ttl: Constants.oneDay(),
     };
   }


### PR DESCRIPTION
 
## Proposed Changes
- remove after query param for daily mex tokens prices

## How to test
- `<api>/mex/tokens/prices/daily/TADA-5c032c` -> should return all daily token prices
