### PR TITLE
Extend features flags config values

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -51,7 +51,7 @@ features:
     serviceUrl: 'https://devnet-data-api.multiversx.com'
   assetsFetch:
     enabled: true
-    assetesUrl: 'https://tools.multiversx.com/assets-cdn'
+    assetsUrl: 'https://tools.multiversx.com/assets-cdn'
   mediaRedirect:
     enabled: false
     storageUrls:
@@ -112,7 +112,7 @@ features:
     enabled: true
     serviceUrl: 'https://devnet-api.multiversx.com'
   tokensFetch:
-    enabled: true
+    enabled: false
     serviceUrl: 'https://devnet-api.multiversx.com'
   providersFetch:
     enabled: true

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -116,7 +116,7 @@ features:
     serviceUrl: 'https://api.multiversx.com'
   assetsFetch:
     enabled: false
-    assetesUrl: 'https://tools.multiversx.com/assets-cdn'
+    asseteUrl: 'https://tools.multiversx.com/assets-cdn'
 image:
   width: 600
   height: 600

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -109,14 +109,14 @@ features:
     enabled: true
     serviceUrl: 'https://api.multiversx.com'
   tokensFetch:
-    enabled: true
+    enabled: false
     serviceUrl: 'https://api.multiversx.com'
   providersFetch:
     enabled: true
     serviceUrl: 'https://api.multiversx.com'
   assetsFetch:
     enabled: true
-    assetesUrl: 'https://tools.multiversx.com/assets-cdn'
+    assetsUrl: 'https://tools.multiversx.com/assets-cdn'
   mediaRedirect:
     enabled: false
     storageUrls:

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -108,14 +108,14 @@ features:
     enabled: true
     serviceUrl: 'https://testnet-api.multiversx.com'
   tokensFetch:
-    enabled: true
+    enabled: false
     serviceUrl: 'https://testnet-api.multiversx.com'
   providersFetch:
     enabled: true
     serviceUrl: 'https://testnet-api.multiversx.com'
   assetsFetch:
     enabled: true
-    assetesUrl: 'https://tools.multiversx.com/assets-cdn'
+    assetsUrl: 'https://tools.multiversx.com/assets-cdn'
   mediaRedirect:
     enabled: false
     storageUrls:

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -893,7 +893,9 @@ export class ApiConfigService {
   }
 
   getAssetsCdnUrl(): string {
-    return this.configService.get<string>('features.assetsFetch.assetesUrl') ?? 'https://tools.multiversx.com/assets-cdn';
+    return this.configService.get<string>('features.assetsFetch.assetsUrl')
+      ?? this.configService.get<string>('features.assetsFetch.assetesUrl')
+      ?? 'https://tools.multiversx.com/assets-cdn';
   }
 
   isTokensFetchFeatureEnabled(): boolean {

--- a/src/endpoints/network/entities/feature.configs.ts
+++ b/src/endpoints/network/entities/feature.configs.ts
@@ -5,8 +5,23 @@ export class FeatureConfigs {
     Object.assign(this, init);
   }
 
+  @ApiProperty({ description: 'Events notifier flag activation value' })
+  eventsNotifier: boolean = false;
+
+  @ApiProperty({ description: 'Guest caching flag activation value' })
+  guestCaching: boolean = false;
+
+  @ApiProperty({ description: 'Transaction pool flag activation value' })
+  transactionPool: boolean = false;
+
+  @ApiProperty({ description: 'Transaction pool warmer flag activation value' })
+  transactionPoolWarmer: boolean = false;
+
   @ApiProperty({ description: 'Update Collection extra details flag activation value' })
   updateCollectionExtraDetails: boolean = false;
+
+  @ApiProperty({ description: 'Accounts extra details update flag activation value' })
+  updateAccountsExtraDetails: boolean = false;
 
   @ApiProperty({ description: 'Marketplace flag activation value' })
   marketplace: boolean = false;
@@ -14,6 +29,60 @@ export class FeatureConfigs {
   @ApiProperty({ description: 'Exchange flag activation value' })
   exchange: boolean = false;
 
-  @ApiProperty({ description: 'DataApi flag activation value' })
+  @ApiProperty({ description: 'Data API flag activation value' })
   dataApi: boolean = false;
+
+  @ApiProperty({ description: 'Authentication flag activation value' })
+  auth: boolean = false;
+
+  @ApiProperty({ description: 'Staking V4 flag activation value' })
+  stakingV4: boolean = false;
+
+  @ApiProperty({ description: 'Chain Andromeda flag activation value' })
+  chainAndromeda: boolean = false;
+
+  @ApiProperty({ description: 'Node epochs left flag activation value' })
+  nodeEpochsLeft: boolean = false;
+
+  @ApiProperty({ description: 'Transaction processor flag activation value' })
+  transactionProcessor: boolean = false;
+
+  @ApiProperty({ description: 'Transaction completed flag activation value' })
+  transactionCompleted: boolean = false;
+
+  @ApiProperty({ description: 'Transaction batch flag activation value' })
+  transactionBatch: boolean = false;
+
+  @ApiProperty({ description: 'Deep history flag activation value' })
+  deepHistory: boolean = false;
+
+  @ApiProperty({ description: 'Elastic circuit breaker flag activation value' })
+  elasticCircuitBreaker: boolean = false;
+
+  @ApiProperty({ description: 'Status checker flag activation value' })
+  statusChecker: boolean = false;
+
+  @ApiProperty({ description: 'NFT scam info flag activation value' })
+  nftScamInfo: boolean = false;
+
+  @ApiProperty({ description: 'NFT processing flag activation value' })
+  processNfts: boolean = false;
+
+  @ApiProperty({ description: 'TPS flag activation value' })
+  tps: boolean = false;
+
+  @ApiProperty({ description: 'Nodes fetch flag activation value' })
+  nodesFetch: boolean = false;
+
+  @ApiProperty({ description: 'Tokens fetch flag activation value' })
+  tokensFetch: boolean = false;
+
+  @ApiProperty({ description: 'Providers fetch flag activation value' })
+  providersFetch: boolean = false;
+
+  @ApiProperty({ description: 'Assets fetch flag activation value' })
+  assetsFetch: boolean = false;
+
+  @ApiProperty({ description: 'Media redirect flag activation value' })
+  mediaRedirect: boolean = false;
 }

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -312,10 +312,33 @@ export class NetworkService {
     }
 
     const features = new FeatureConfigs({
+      eventsNotifier: this.apiConfigService.isEventsNotifierFeatureActive(),
+      guestCaching: this.apiConfigService.isGuestCacheFeatureActive(),
+      transactionPool: this.apiConfigService.isTransactionPoolEnabled(),
+      transactionPoolWarmer: this.apiConfigService.getIsCacheWarmerCronActive(),
       updateCollectionExtraDetails: this.apiConfigService.isUpdateCollectionExtraDetailsEnabled(),
+      updateAccountsExtraDetails: this.apiConfigService.isUpdateAccountExtraDetailsEnabled(),
       marketplace: this.apiConfigService.isMarketplaceFeatureEnabled(),
       exchange: this.apiConfigService.isExchangeEnabled(),
       dataApi: this.apiConfigService.isDataApiFeatureEnabled(),
+      auth: this.apiConfigService.getIsAuthActive(),
+      stakingV4: this.apiConfigService.isStakingV4Enabled(),
+      chainAndromeda: this.apiConfigService.isChainAndromedaEnabled(),
+      nodeEpochsLeft: this.apiConfigService.isNodeEpochsLeftEnabled(),
+      transactionProcessor: this.apiConfigService.getIsTransactionProcessorCronActive(),
+      transactionCompleted: this.apiConfigService.getIsTransactionCompletedCronActive(),
+      transactionBatch: this.apiConfigService.getIsTransactionBatchCronActive(),
+      deepHistory: this.apiConfigService.isDeepHistoryGatewayEnabled(),
+      elasticCircuitBreaker: this.apiConfigService.isElasticCircuitBreakerEnabled(),
+      statusChecker: this.apiConfigService.getIsApiStatusCheckerActive(),
+      nftScamInfo: this.apiConfigService.getIsNftScamInfoEnabled(),
+      processNfts: this.apiConfigService.getIsProcessNftsFlagActive(),
+      tps: this.apiConfigService.isTpsEnabled(),
+      nodesFetch: this.apiConfigService.isNodesFetchFeatureEnabled(),
+      tokensFetch: this.apiConfigService.isTokensFetchFeatureEnabled(),
+      providersFetch: this.apiConfigService.isProvidersFetchFeatureEnabled(),
+      assetsFetch: this.apiConfigService.isAssetsCdnFeatureEnabled(),
+      mediaRedirect: this.apiConfigService.isMediaRedirectFeatureEnabled(),
     });
 
     let indexerVersion: string | undefined;


### PR DESCRIPTION
## Reasoning
- not all the features activation flags were exposed via Rest API
  
## Proposed Changes
- add missing flags

## How to test
- check `localhost:3001/about` endpoint
