### PR TITLE
fix transfers count with relayed txs

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1115,6 +1115,7 @@ export class AccountController {
   @ApiQuery({ name: 'isScCall', description: 'Returns sc call transactions details', required: false, type: Boolean })
   @ApiQuery({ name: 'senderOrReceiver', description: 'One address that current address interacted with', required: false })
   @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
+  @ApiQuery({ name: 'withTxsRelayedByAddress', description: 'Include transactions that were relayed by the address', required: false })
   async getAccountTransfersCount(
     @Param('address', ParseAddressPipe) address: string,
     @Query('sender', ParseAddressArrayPipe) sender?: string[],
@@ -1132,6 +1133,7 @@ export class AccountController {
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
+    @Query('withTxsRelayedByAddress', ParseBoolPipe) withTxsRelayedByAddress?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       address,
@@ -1150,6 +1152,7 @@ export class AccountController {
       round,
       isScCall,
       withRefunds,
+      withTxsRelayedByAddress,
     }));
   }
 
@@ -1172,6 +1175,7 @@ export class AccountController {
     @Query('senderOrReceiver', ParseAddressPipe) senderOrReceiver?: string,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
     @Query('isScCall', ParseBoolPipe) isScCall?: boolean,
+    @Query('withTxsRelayedByAddress', ParseBoolPipe) withTxsRelayedByAddress?: boolean,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
       address,
@@ -1190,6 +1194,7 @@ export class AccountController {
       round,
       withRefunds,
       isScCall,
+      withTxsRelayedByAddress,
     }));
   }
 


### PR DESCRIPTION
## Reasoning
[#174 ](https://github.com/multiversx/mx-explorer-dapp/issues/174)
  
## Proposed Changes
- allow the endpoint to receive the flag (the explorer already does it) and forward it to ES query

## How to test
- http://localhost:3001/accounts/erd18taz9feuez07qew9zu48yxk98p9x0h7m0y8mdtmjreyfwpnzekkqvtrr7f/transfers/c?withTxsRelayedByAddress=true should return ~500 txs at the time of writing
