### PR TITLE
Extend AWS S3 config

### DIFF
--- a/config/config.devnet-old.yaml
+++ b/config/config.devnet-old.yaml
@@ -70,7 +70,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'devnet-old-media.elrond.com'
   s3Region: ''
-  # s3Endpoint: ''
+  s3Endpoint: ''
 urls:
   self: 'https://devnet-old-api.multiversx.com'
   elastic:

--- a/config/config.devnet-old.yaml
+++ b/config/config.devnet-old.yaml
@@ -70,6 +70,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'devnet-old-media.elrond.com'
   s3Region: ''
+  # s3Endpoint: ''
 urls:
   self: 'https://devnet-old-api.multiversx.com'
   elastic:

--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -122,7 +122,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'devnet-media.elrond.com'
   s3Region: ''
-  # s3Endpoint: ''
+  s3Endpoint: ''
 urls:
   self: 'https://devnet-api.multiversx.com'
   elastic:

--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -122,6 +122,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'devnet-media.elrond.com'
   s3Region: ''
+  # s3Endpoint: ''
 urls:
   self: 'https://devnet-api.multiversx.com'
   elastic:

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -126,7 +126,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'media.elrond.com'
   s3Region: ''
-  # s3Endpoint: ''
+  s3Endpoint: ''
 urls:
   self: 'http://localhost:3001'
   elastic:

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -126,6 +126,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'media.elrond.com'
   s3Region: ''
+  # s3Endpoint: ''
 urls:
   self: 'http://localhost:3001'
   elastic:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -126,7 +126,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'media.elrond.com'
   s3Region: ''
-  # s3Endpoint: ''
+  s3Endpoint: ''
 urls:
   self: 'https://api.multiversx.com'
   elastic:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -126,6 +126,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'media.elrond.com'
   s3Region: ''
+  # s3Endpoint: ''
 urls:
   self: 'https://api.multiversx.com'
   elastic:

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -125,6 +125,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'testnet-media.elrond.com'
   s3Region: ''
+  # s3Endpoint: ''
 urls:
   self: 'https://testnet-api.multiversx.com'
   elastic:

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -125,7 +125,7 @@ aws:
   s3Secret: ''
   s3Bucket: 'testnet-media.elrond.com'
   s3Region: ''
-  # s3Endpoint: ''
+  s3Endpoint: ''
 urls:
   self: 'https://testnet-api.multiversx.com'
   elastic:

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -559,6 +559,10 @@ export class ApiConfigService {
     return s3Region;
   }
 
+  getAwsS3Endpoint(): string | undefined {
+    return this.configService.get<string>('aws.s3Endpoint');
+  }
+
   getMetaChainShardId(): number {
     const metaChainShardId = this.configService.get<number>('metaChainShardId');
     if (metaChainShardId === undefined) {

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -560,7 +560,8 @@ export class ApiConfigService {
   }
 
   getAwsS3Endpoint(): string | undefined {
-    return this.configService.get<string>('aws.s3Endpoint');
+    const s3Endpoint = this.configService.get<string>('aws.s3Endpoint');
+    return s3Endpoint && s3Endpoint.length > 0 ? s3Endpoint : undefined;
   }
 
   getMetaChainShardId(): number {

--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/aws.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/aws.service.ts
@@ -15,6 +15,7 @@ export class AWSService {
         secretAccessKey: this.apiConfigService.getAwsS3Secret(),
       },
       region: this.apiConfigService.getAwsS3Region(),
+      endpoint: this.apiConfigService.getAwsS3Endpoint(),
     });
 
     await s3.putObject({
@@ -22,6 +23,7 @@ export class AWSService {
       Key: path,
       Body: buffer,
       ContentType: type,
+      ACL: "public-read",
     });
 
     return this.getItemPath(path);


### PR DESCRIPTION
## Reasoning
- we want to be able to upload files to other providers besides AWS S3, but we also needed to add an extra config for the bucket endpoint and set the view permissions
  
## Proposed Changes
- added `aws.s3Endpoint` to the s3 config and the `public-read` option when uploading a file