### PR TITLE
add execution order sorting using miniBlocksDetails from Elasticsearch

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -250,6 +250,15 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getItem('blocks', 'hash', hash);
   }
 
+  async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
+    const elasticQuery = ElasticQuery.create()
+      .withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlocksHashes', miniBlockHash)])
+      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+
+    const result = await this.elasticService.getList('blocks', '_search', elasticQuery);
+    return result.length > 0 ? result[0] : undefined;
+  }
+
   async getMiniBlock(miniBlockHash: string): Promise<any> {
     return await this.elasticService.getItem('miniblocks', 'miniBlockHash', miniBlockHash);
   }

--- a/src/common/indexer/entities/block.ts
+++ b/src/common/indexer/entities/block.ts
@@ -4,6 +4,7 @@ export interface Block {
   round: number;
   epoch: number;
   miniBlocksHashes: string[];
+  miniBlocksDetails?: MiniBlockDetails[];
   notarizedBlocksHashes?: string[];
   proposer: number;
   validators: number[],
@@ -24,4 +25,16 @@ export interface Block {
   gasRefunded: string;
   gasPenalized: number;
   maxGasLimit: string;
+}
+
+export interface MiniBlockDetails {
+  firstProcessedTx: number;
+  lastProcessedTx: number;
+  senderShard: number;
+  receiverShard: number;
+  mbIndex: number;
+  type: string;
+  procType: string;
+  txsHashes: string[];
+  executionOrderTxsIndices: number[];
 }

--- a/src/common/indexer/entities/index.ts
+++ b/src/common/indexer/entities/index.ts
@@ -1,7 +1,7 @@
 export { Account } from './account';
 export { AccountHistory } from './account.history';
 export { AccountTokenHistory } from './account.token.history';
-export { Block } from './block';
+export { Block, MiniBlockDetails } from './block';
 export { Collection } from './collection';
 export { MiniBlock } from './miniblock';
 export { Operation } from './operation';

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -74,6 +74,8 @@ export interface IndexerInterface {
 
   getBlock(hash: string): Promise<Block>
 
+  getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined>
+
   getMiniBlock(miniBlockHash: string): Promise<MiniBlock>
 
   getMiniBlocks(pagination: QueryPagination, filter: MiniBlockFilter): Promise<MiniBlock[]>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -167,6 +167,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
+    return await this.indexerInterface.getBlockByMiniBlockHash(miniBlockHash);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getMiniBlock(miniBlockHash: string): Promise<MiniBlock> {
     return await this.indexerInterface.getMiniBlock(miniBlockHash);
   }

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -17,6 +17,7 @@ export class TransactionQueryOptions {
   withUsername?: boolean;
   withBlockInfo?: boolean;
   withActionTransferValue?: boolean;
+  withTxsOrder?: boolean;
 
   static applyDefaultOptions(size: number, options: TransactionQueryOptions): TransactionQueryOptions {
     if (size <= TransactionQueryOptions.SCAM_INFO_MAX_SIZE) {

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -47,6 +47,7 @@ export class TransferController {
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transfers. When "withLogs" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transfers. When "withOperations" parameter is applied, complexity estimation is 200', required: false })
   @ApiQuery({ name: 'withActionTransferValue', description: 'Returns value in USD and EGLD for transferred tokens within the action attribute', required: false })
+  @ApiQuery({ name: 'withTxsOrder', description: 'Sort transactions by execution order from block', required: false })
   @ApiQuery({ name: 'withRefunds', description: 'Include refund transactions', required: false })
   async getAccountTransfers(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -74,10 +75,11 @@ export class TransferController {
     @Query('withLogs', ParseBoolPipe) withLogs?: boolean,
     @Query('withOperations', ParseBoolPipe) withOperations?: boolean,
     @Query('withActionTransferValue', ParseBoolPipe) withActionTransferValue?: boolean,
+    @Query('withTxsOrder', ParseBoolPipe) withTxsOrder?: boolean,
     @Query('withRefunds', ParseBoolPipe) withRefunds?: boolean,
   ): Promise<Transaction[]> {
     const options = TransactionQueryOptions.applyDefaultOptions(
-      size, new TransactionQueryOptions({ withScamInfo, withUsername, withBlockInfo, withLogs, withOperations, withActionTransferValue }),
+      size, new TransactionQueryOptions({ withScamInfo, withUsername, withBlockInfo, withLogs, withOperations, withActionTransferValue, withTxsOrder }),
     );
 
     return await this.transferService.getTransfers(new TransactionFilter({

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -68,13 +68,20 @@ export class TransferService {
         txHashToOrder[txHash] = executionIndex;
       }
 
+      const txHashToTransfer: Record<string, any> = {};
+      for (const transfer of elasticTransfers) {
+        if (transfer.txHash) {
+          txHashToTransfer[transfer.txHash] = transfer;
+        }
+      }
+
       for (const elasticTransfer of elasticTransfers) {
         const txHash = elasticTransfer.originalTxHash || elasticTransfer.txHash;
         if (txHashToOrder.hasOwnProperty(txHash)) {
           elasticTransfer.order = txHashToOrder[txHash];
         } else {
           if (elasticTransfer.originalTxHash) {
-            const transaction = elasticTransfers.find(x => x.txHash === elasticTransfer.originalTxHash);
+            const transaction = txHashToTransfer[elasticTransfer.originalTxHash];
             if (transaction) {
               elasticTransfer.order = (transaction.nonce * 10) + 1;
             } else {

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -87,8 +87,8 @@ export class TransferService {
       }
 
       return elasticTransfers.sortedDescending(
-        (item) => item.timestamp,
-        (item) => -item.order
+        (item) => -item.order,
+        (item) => item.timestamp
       );
 
     } catch (error) {


### PR DESCRIPTION
## Reasoning
- Current transfer sorting uses nonce-based ordering (`nonce * 10 + 1`) which doesn't reflect actual blockchain execution order
- Elasticsearch blocks index contains `executionOrderTxsIndices` with real execution sequence

## Proposed Changes
- Add `withTxsOrder` boolean parameter to `/transfers` endpoint
- Implement execution order sorting using `miniBlocksDetails` from Elasticsearch blocks

## How to test
- `<api>/transfers?miniBlockHash= e61015d617eb00a33f4c83267f89d53740e209440d81e0f0e8e58b3efefb489a&withTxsOrder=true&size=10`

transactions sorted by `executionOrderTxsIndices` from blockchain
transactions with execution order `0` appears first, then `1`, then `2`, etc.

- `<api>/transfers?miniBlockHash=e61015d617eb00a33f4c83267f89d53740e209440d81e0f0e8e58b3efefb489a&size=10`

transactions sorted by `nonce * 10` + 1 for smart contract results
