### PR TITLE
fix userUndelegatedList field

### DIFF
--- a/src/endpoints/delegation/delegation.service.ts
+++ b/src/endpoints/delegation/delegation.service.ts
@@ -74,7 +74,7 @@ export class DelegationService {
 
       return data.map((delegation: any) => new AccountDelegation({
         ...delegation,
-        userUndelegatedList: delegation.userUndelegatedList || [],
+        userUndelegatedList: delegation.userUndelegatedList ?? [],
       }));
     } catch (error) {
       this.logger.error(`Error when getting account delegation details for address ${address}`);

--- a/src/endpoints/delegation/delegation.service.ts
+++ b/src/endpoints/delegation/delegation.service.ts
@@ -71,7 +71,11 @@ export class DelegationService {
   async getDelegationForAddress(address: string): Promise<AccountDelegation[]> {
     try {
       const { data } = await this.apiService.get(`${this.apiConfigService.getDelegationUrl()}/accounts/${address}/delegations`);
-      return data;
+
+      return data.map((delegation: any) => new AccountDelegation({
+        ...delegation,
+        userUndelegatedList: delegation.userUndelegatedList || [],
+      }));
     } catch (error) {
       this.logger.error(`Error when getting account delegation details for address ${address}`);
       this.logger.error(error);

--- a/src/test/unit/services/delegation.spec.ts
+++ b/src/test/unit/services/delegation.spec.ts
@@ -251,5 +251,27 @@ describe('Delegation Service', () => {
       expect(result[0].userUndelegatedList).toEqual([]);
       expect(mockGetFn).toHaveBeenCalledWith(`${apiConfigService.getDelegationUrl()}/accounts/${mockAddress}/delegations`);
     });
+
+    it('should preserve explicitly returned empty userUndelegatedList arrays from external API', async () => {
+      const mockResponseWithExplicitEmptyArray = [
+        {
+          address: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          contract: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqq6nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          userUnBondable: '1000000000000000000',
+          userActiveStake: '0',
+          claimableRewards: '0',
+          userUndelegatedList: [],
+        },
+      ];
+
+      const mockGetFn = jest.fn().mockResolvedValue({ data: mockResponseWithExplicitEmptyArray });
+      jest.spyOn(apiService, 'get').mockImplementation(mockGetFn);
+
+      const result = await delegationService.getDelegationForAddress(mockAddress);
+
+      expect(result).toEqual(mockResponseWithExplicitEmptyArray);
+      expect(result[0].userUndelegatedList).toEqual([]);
+      expect(mockGetFn).toHaveBeenCalledWith(`${apiConfigService.getDelegationUrl()}/accounts/${mockAddress}/delegations`);
+    });
   });
 });

--- a/src/test/unit/services/delegation.spec.ts
+++ b/src/test/unit/services/delegation.spec.ts
@@ -219,5 +219,37 @@ describe('Delegation Service', () => {
       await expect(delegationService.getDelegationForAddress(mockAddress)).rejects.toThrow(mockError);
       expect(mockGetFn).toHaveBeenCalledWith(`${apiConfigService.getDelegationUrl()}/accounts/${mockAddress}/delegations`);
     });
+
+    it('should initialize empty userUndelegatedList when the field is missing from external API response', async () => {
+      const mockResponseWithMissingField = [
+        {
+          address: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          contract: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqq6nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          userUnBondable: '1000000000000000000',
+          userActiveStake: '0',
+          claimableRewards: '0',
+        },
+      ];
+
+      const expectedResult = [
+        {
+          address: 'erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          contract: 'erd1qqqqqqqqqqqqqqqqqqqqqqqqqq6nzrxnyhzer9lmudqhjgy7ycqjjyknz',
+          userUnBondable: '1000000000000000000',
+          userActiveStake: '0',
+          claimableRewards: '0',
+          userUndelegatedList: [],
+        },
+      ];
+
+      const mockGetFn = jest.fn().mockResolvedValue({ data: mockResponseWithMissingField });
+      jest.spyOn(apiService, 'get').mockImplementation(mockGetFn);
+
+      const result = await delegationService.getDelegationForAddress(mockAddress);
+
+      expect(result).toEqual(expectedResult);
+      expect(result[0].userUndelegatedList).toEqual([]);
+      expect(mockGetFn).toHaveBeenCalledWith(`${apiConfigService.getDelegationUrl()}/accounts/${mockAddress}/delegations`);
+    });
   });
 });


### PR DESCRIPTION
## Reasoning
- https://github.com/multiversx/mx-api-service/issues/1151
  
## Proposed Changes
- mark userUndelegatedList as [] if is missing

## How to test
- <api>/accounts/:address/delegation -> use an address that have some undelegated EGLD