### PR TITLE
collections count subType required false fix

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -111,6 +111,7 @@ export class CollectionController {
   @ApiQuery({ name: 'canAddUri', description: 'Filter by address with canAddUri role', required: false })
   @ApiQuery({ name: 'canTransferRole', description: 'Filter by address with canTransferRole role', required: false })
   @ApiQuery({ name: 'excludeMetaESDT', description: 'Do not include collections of type "MetaESDT" in the response', required: false })
+  @ApiQuery({ name: 'subType', description: 'Filter by type (NonFungibleESDTv2/DynamicNonFungibleESDT/DynamicSemiFungibleESDT)', required: false })
   @ApiOkResponse({ type: Number })
   async getCollectionCount(
     @Query('search') search?: string,


### PR DESCRIPTION
## Reasoning
- collections count subType query is by default required 
  
## Proposed Changes
- make subType query filter required false

## How to test
- access API swagger docs -> collections count -> check if subType is not required
