### PR TITLE
use events index instead of logs

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -594,14 +594,14 @@ export class ElasticIndexerService implements IndexerInterface {
   async getTransactionLogs(hashes: string[]): Promise<any[]> {
     const queries = [];
     for (const hash of hashes) {
-      queries.push(QueryType.Match('_id', hash));
+      queries.push(QueryType.Match('txHash', hash));
     }
 
     const elasticQueryLogs = ElasticQuery.create()
       .withPagination({ from: 0, size: 10000 })
       .withCondition(QueryConditionOptions.should, queries);
 
-    return await this.elasticService.getList('logs', 'id', elasticQueryLogs);
+    return await this.elasticService.getList('events', 'id', elasticQueryLogs);
   }
 
   async getTransactionScResults(txHash: string): Promise<any[]> {

--- a/src/common/indexer/entities/index.ts
+++ b/src/common/indexer/entities/index.ts
@@ -12,5 +12,5 @@ export { Tag } from './tag';
 export { Token } from './token';
 export { TokenAccount, TokenType } from './token.account';
 export { Transaction } from './transaction';
-export { TransactionLog, TransactionLogEvent } from './transaction.log';
+export { TransactionLog, TransactionLogEvent, ElasticTransactionLogEvent } from './transaction.log';
 export { TransactionReceipt } from './transaction.receipt';

--- a/src/common/indexer/entities/transaction.log.ts
+++ b/src/common/indexer/entities/transaction.log.ts
@@ -13,3 +13,15 @@ export interface TransactionLogEvent {
   data?: string;
   order: number;
 }
+
+export interface ElasticTransactionLogEvent {
+  address: string;
+  identifier: string;
+  topics: string[];
+  data?: string;
+  order: number;
+  txHash: string;
+  originalTxHash: string;
+  logAddress: string;
+  additionalData?: string[];
+}

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -12,7 +12,7 @@ import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.r
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TokenAssets } from "../assets/entities/token.assets";
 import { QueryPagination } from "../entities/query.pagination";
-import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
+import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt } from "./entities";
 import { AccountAssets } from "../assets/entities/account.assets";
 import { ProviderDelegators } from "./entities/provider.delegators";
 import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
@@ -134,7 +134,7 @@ export interface IndexerInterface {
 
   getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<Token[]>
 
-  getTransactionLogs(hashes: string[]): Promise<TransactionLog[]>
+  getTransactionLogs(hashes: string[]): Promise<ElasticTransactionLogEvent[]>
 
   getTransactionScResults(txHash: string): Promise<ScResult[]>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -11,7 +11,7 @@ import { TransactionFilter } from "src/endpoints/transactions/entities/transacti
 import { MetricsEvents } from "src/utils/metrics-events.constants";
 import { TokenAssets } from "../assets/entities/token.assets";
 import { QueryPagination } from "../entities/query.pagination";
-import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, TransactionLog, TransactionReceipt } from "./entities";
+import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt } from "./entities";
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
@@ -302,7 +302,7 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  async getTransactionLogs(hashes: string[]): Promise<TransactionLog[]> {
+  async getTransactionLogs(hashes: string[]): Promise<ElasticTransactionLogEvent[]> {
     return await this.indexerInterface.getTransactionLogs(hashes);
   }
 

--- a/src/endpoints/transactions/entities/transaction.log.event.ts
+++ b/src/endpoints/transactions/entities/transaction.log.event.ts
@@ -22,5 +22,8 @@ export class TransactionLogEvent {
   data: string = '';
 
   @ApiProperty()
+  order: number = 0;
+
+  @ApiProperty()
   additionalData: string[] | undefined = undefined;
 }


### PR DESCRIPTION
## Reasoning
- the `logs` index will be deprecated in future protocol releases
  
## Proposed Changes
- use the `events` index to fetch the log events
- map them to the old data format in order to not alter the API responses

## How to test
- compare endpoints that expose logs with this branch and `development` branch. the results should be semantically the same
