### PR TITLE
Enhance account filtering by adding 'withBalance' query option

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -1,5 +1,5 @@
 import { AddressUtils, BinaryUtils } from "@multiversx/sdk-nestjs-common";
-import { AbstractQuery, ElasticQuery, MatchQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs-elastic";
+import { AbstractQuery, ElasticQuery, MatchQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThan, RangeGreaterThanOrEqual, RangeLowerThan, RangeLowerThanOrEqual } from "@multiversx/sdk-nestjs-elastic";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -715,6 +715,14 @@ export class ElasticIndexerHelper {
 
     if (filter.search) {
       elasticQuery = elasticQuery.withSearchWildcardCondition(filter.search, ['address', 'api_assets.name']);
+    }
+
+    if (filter.withBalance !== undefined) {
+      if (filter.withBalance) {
+        elasticQuery = elasticQuery.withRangeFilter('balanceNum', new RangeGreaterThan(0));
+      } else {
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('balanceNum', 0));
+      }
     }
 
     return elasticQuery;

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -150,6 +150,7 @@ export class AccountController {
   @ApiQuery({ name: 'search', description: 'Search by account address, assets name', required: false })
   @ApiQuery({ name: 'excludeTags', description: 'Exclude specific tags from result', required: false })
   @ApiQuery({ name: 'hasAssets', description: 'Returns a list of accounts that have assets', required: false })
+  @ApiQuery({ name: 'withBalance', description: 'Filter accounts by balance (true = balance > 0, false = balance = 0)', required: false, type: Boolean })
   async getAccountsCount(
     @Query("ownerAddress", ParseAddressPipe) ownerAddress?: string,
     @Query("isSmartContract", ParseBoolPipe) isSmartContract?: boolean,
@@ -158,6 +159,7 @@ export class AccountController {
     @Query("excludeTags", ParseArrayPipe) excludeTags?: string[],
     @Query("hasAssets", ParseBoolPipe) hasAssets?: boolean,
     @Query("search") search?: string,
+    @Query("withBalance", ParseBoolPipe) withBalance?: boolean,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(
       new AccountQueryOptions(
@@ -169,6 +171,7 @@ export class AccountController {
           excludeTags,
           hasAssets,
           search,
+          withBalance,
         }));
   }
 
@@ -182,6 +185,7 @@ export class AccountController {
     @Query("excludeTags", ParseArrayPipe) excludeTags?: string[],
     @Query("hasAssets", ParseBoolPipe) hasAssets?: boolean,
     @Query("search") search?: string,
+    @Query("withBalance", ParseBoolPipe) withBalance?: boolean,
   ): Promise<number> {
     return await this.accountService.getAccountsCount(
       new AccountQueryOptions(
@@ -193,6 +197,7 @@ export class AccountController {
           excludeTags,
           hasAssets,
           search,
+          withBalance,
         }));
   }
 

--- a/src/endpoints/accounts/entities/account.query.options.ts
+++ b/src/endpoints/accounts/entities/account.query.options.ts
@@ -22,6 +22,7 @@ export class AccountQueryOptions {
   excludeTags?: string[];
   hasAssets?: boolean;
   search?: string;
+  withBalance?: boolean;
 
   validate(size: number) {
     if (this.withDeployInfo && size > 25) {
@@ -53,6 +54,7 @@ export class AccountQueryOptions {
       this.excludeTags !== undefined ||
       this.hasAssets !== undefined ||
       this.search !== undefined ||
-      this.addresses !== undefined;
+      this.addresses !== undefined ||
+      this.withBalance !== undefined;
   }
 }


### PR DESCRIPTION
# Proposed Changes
- added `withBalance` query options to be able to return all the accounts with balance greater than 0

## How to test
- `<api>/accounts/count?withBalance=true` -> should return accounts count with balance > 0
- `<api>/accounts/count?withBalance=false` -> should return accounts count with balance  0 and active

