### PR TITLE
add events filtered by order

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -810,6 +810,10 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withMustMatchCondition('address', filter.address);
     }
 
+    if (filter.order) {
+      elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('order', filter.order));
+    }
+
     return elasticQuery;
   }
 }

--- a/src/endpoints/events/entities/events.filter.ts
+++ b/src/endpoints/events/entities/events.filter.ts
@@ -10,4 +10,5 @@ export class EventsFilter {
   shard: number = 0;
   before: number = 0;
   after: number = 0;
+  order: number = 0;
 }

--- a/src/endpoints/events/events.controller.ts
+++ b/src/endpoints/events/events.controller.ts
@@ -25,6 +25,7 @@ export class EventsController {
   @ApiQuery({ name: 'shard', description: 'Event shard id', required: false })
   @ApiQuery({ name: 'before', description: 'Event before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'Event after timestamp', required: false })
+  @ApiQuery({ name: 'order', description: 'Event order', required: false })
   async getEvents(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -34,10 +35,11 @@ export class EventsController {
     @Query('shard', ParseIntPipe) shard: number,
     @Query('before', ParseIntPipe) before: number,
     @Query('after', ParseIntPipe) after: number,
+    @Query('order', ParseIntPipe) order: number,
   ): Promise<Events[]> {
     return await this.eventsService.getEvents(
       new QueryPagination({ from, size }),
-      new EventsFilter({ address, identifier, txHash, shard, after, before }));
+      new EventsFilter({ address, identifier, txHash, shard, after, before, order }));
   }
 
   @Get('/events/count')

--- a/src/test/unit/services/events.spec.ts
+++ b/src/test/unit/services/events.spec.ts
@@ -93,6 +93,50 @@ describe('EventsService', () => {
       expect(result).toEqual([]);
       expect(indexerService.getEvents).toHaveBeenCalledWith(pagination, filter);
     });
+
+    it('should return events in the correct order', async () => {
+      const pagination: QueryPagination = { from: 0, size: 10 };
+      const filter: EventsFilter = new EventsFilter({ order: 1 });
+
+      const mockElasticEvents = [
+        generateMockEvent(),
+        generateMockEvent({ _id: "5d4a7cd39caf55aaaef038d2fe5fd864b01db2170253c158-1-1", identifier: 'ESDTNFTCreate' }),
+      ];
+
+      const expectedEvents = [
+        createExpectedEvent("7e3faa2a4ea5cfe8667f2e13eb27076b0452742dbe01044871c8ea109f73ebed", "transferValueOnly"),
+        createExpectedEvent("5d4a7cd39caf55aaaef038d2fe5fd864b01db2170253c158-1-1", "ESDTNFTCreate"),
+      ];
+
+      mockIndexerService.getEvents.mockResolvedValue(mockElasticEvents);
+
+      const result = await service.getEvents(pagination, filter);
+
+      expect(result).toEqual(expectedEvents);
+      expect(indexerService.getEvents).toHaveBeenCalledWith(pagination, filter);
+    });
+
+    it('should return events filtered by shard', async () => {
+      const pagination: QueryPagination = { from: 0, size: 10 };
+      const filter: EventsFilter = new EventsFilter({ shard: 1 });
+
+      const mockElasticEvents = [
+        generateMockEvent(),
+        generateMockEvent({ _id: "5d4a7cd39caf55aaaef038d2fe5fd864b01db2170253c158-1-1", identifier: 'ESDTNFTCreate' }),
+      ];
+
+      const expectedEvents = [
+        createExpectedEvent("7e3faa2a4ea5cfe8667f2e13eb27076b0452742dbe01044871c8ea109f73ebed", "transferValueOnly"),
+        createExpectedEvent("5d4a7cd39caf55aaaef038d2fe5fd864b01db2170253c158-1-1", "ESDTNFTCreate"),
+      ];
+
+      mockIndexerService.getEvents.mockResolvedValue(mockElasticEvents);
+
+      const result = await service.getEvents(pagination, filter);
+
+      expect(result).toEqual(expectedEvents);
+      expect(indexerService.getEvents).toHaveBeenCalledWith(pagination, filter);
+    });
   });
 
   describe('getEventsCount', () => {


### PR DESCRIPTION
 
## Proposed Changes
- added `order` filter to be able to return all the events in a specific order of execution
- update `events.spec.ts` file with more tests

## How to test
- `<api>/events?order=2` -> should return all events with order field = 2

