### PR TITLE
fix image/svg+xml type

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -164,7 +164,8 @@ export class NftMediaService {
   }
 
   private isContentTypeAccepted(contentType: string): boolean {
-    return Object.values(MediaMimeTypeEnum).includes(contentType as MediaMimeTypeEnum);
+    const baseContentType = contentType.split(';')[0].trim();
+    return Object.values(MediaMimeTypeEnum).includes(baseContentType as MediaMimeTypeEnum);
   }
 
   private isFileSizeAccepted(fileSize: number): boolean {


### PR DESCRIPTION
## Reasoning
- NFTs with SVG content type image/svg+xml; charset=utf-8 were being rejected due to strict content type validation
- The validation only accepted exact matches without parameters (charset, boundary, etc.)
  
## Proposed Changes
- Updated isContentTypeAccepted() method in NftMediaService to extract base content type before validation 
- Split content type on semicolon and trim whitespace to handle parameters like charset=utf-8
