### PR TITLE
optimized account raw parallel execution

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -182,17 +182,20 @@ export class AccountService {
       }
 
       if (AddressUtils.isSmartContractAddress(address) && account.code) {
-        const deployTxHash = await this.getAccountDeployedTxHash(address);
+        const [deployTxHash, deployedAt, isVerified] = await Promise.all([
+          this.getAccountDeployedTxHash(address),
+          this.getAccountDeployedAt(address),
+          this.getAccountIsVerified(address, account.codeHash),
+        ]);
+
         if (deployTxHash) {
           account.deployTxHash = deployTxHash;
         }
 
-        const deployedAt = await this.getAccountDeployedAt(address);
         if (deployedAt) {
           account.deployedAt = deployedAt;
         }
 
-        const isVerified = await this.getAccountIsVerified(address, account.codeHash);
         if (isVerified) {
           account.isVerified = isVerified;
         }


### PR DESCRIPTION
## Reasoning
* Sequential async operations in `getAccountRaw` method causing performance bottleneck
* Three independent calls (`getAccountDeployedTxHash`, `getAccountDeployedAt`, `getAccountIsVerified` ) executed sequentially
  
## Proposed Changes
- Replace sequential await calls with Promise.all() for parallel execution

## How to test
- Call `/accounts/{address}` endpoint for smart contract addresses

