### PR TITLE
enable scrolling for custom subscriptions

### DIFF
--- a/src/crons/websocket/events.custom.gateway.ts
+++ b/src/crons/websocket/events.custom.gateway.ts
@@ -59,10 +59,18 @@ export class EventsCustomGateway {
 
   async pushEventsForTimestampMs(timestampMs: number): Promise<void> {
     try {
-      const allEvents = await this.eventsService.getEvents(
-        new QueryPagination({ size: 10000 }),
-        new EventsFilter({ before: timestampMs, after: timestampMs }),
-      );
+      const allEvents = [];
+      let eventsBatch = [];
+      let from = 0;
+      const size = 10000;
+      do {
+        eventsBatch = await this.eventsService.getEvents(
+          new QueryPagination({ from, size }),
+          new EventsFilter({ before: timestampMs, after: timestampMs }),
+        );
+        allEvents.push(...eventsBatch);
+        from += eventsBatch.length;
+      } while (eventsBatch.length === size);
 
       const eventsFilteredForBroadcast: Map<string, Events[]> = new Map();
 

--- a/src/crons/websocket/transaction.custom.gateway.ts
+++ b/src/crons/websocket/transaction.custom.gateway.ts
@@ -54,10 +54,18 @@ export class TransactionsCustomGateway {
 
   async pushTransactionsForTimestampMs(timestampMs: number): Promise<void> {
     try {
-      const allTransactions = await this.transactionService.getTransactions(
-        new TransactionFilter({ before: timestampMs, after: timestampMs }),
-        new QueryPagination({ size: 10000 }) // TODO: handle pagination with more than 10k txs
-      );
+      const allTransactions = [];
+      let transactionsBatch = [];
+      let from = 0;
+      const size = 10000;
+      do {
+        transactionsBatch = await this.transactionService.getTransactions(
+          new TransactionFilter({ before: timestampMs, after: timestampMs }),
+          new QueryPagination({ from, size }),
+        );
+        allTransactions.push(...transactionsBatch);
+        from += transactionsBatch.length;
+      } while (transactionsBatch.length === size);
 
       const txFilteredForBroadcast: Map<string, Transaction[]> = new Map();
       for (const transaction of allTransactions) {

--- a/src/crons/websocket/transfers.custom.gateway.ts
+++ b/src/crons/websocket/transfers.custom.gateway.ts
@@ -56,11 +56,19 @@ export class TransfersCustomGateway {
   async pushTransfersForTimestampMs(timestampMs: number): Promise<void> {
     try {
       const options = new TransactionQueryOptions({ withScamInfo: false, withUsername: true, withBlockInfo: false, withLogs: false, withOperations: false, withActionTransferValue: false, withTxsOrder: false });
-      const allTransfers = await this.transferService.getTransfers(
-        new TransactionFilter({ before: timestampMs, after: timestampMs, withTxsRelayedByAddress: true }),
-        new QueryPagination({ size: 10000 }), // TODO: handle pagination with more than 10k txs
-        options,
-      );
+      const allTransfers = [];
+      let transfersBatch = [];
+      let from = 0;
+      const size = 10000;
+      do {
+        transfersBatch = await this.transferService.getTransfers(
+          new TransactionFilter({ before: timestampMs, after: timestampMs, withTxsRelayedByAddress: true }),
+          new QueryPagination({ from, size }),
+          options,
+        );
+        allTransfers.push(...transfersBatch);
+        from += transfersBatch.length;
+      } while (transfersBatch.length === size);
 
       const transfersFilteredForBroadcast: Map<string, Transaction[]> = new Map();
 


### PR DESCRIPTION
## Reasoning
- Custom websocket subscriptions were limited to a single page of 10k results, which could miss data for larger timestamps.
- The scrolling behavior needed to be consistent across custom events, transactions, and transfers.
- This change ensures the cron handlers load the full result set before broadcasting.

## Proposed Changes
- Added paginated fetching loops for custom events, transactions, and transfers until all matching records are loaded.
- Kept the existing room filtering and broadcast logic unchanged, but applied it to the complete accumulated dataset.
- Removed the previous single-page 10k limit from the custom websocket cron handlers.

## How to test
- Subscribe to a custom events/transactions/transfers stream for a timestamp that returns more than 10k records and verify all items are delivered.
- Test a smaller dataset to confirm behavior remains unchanged.
- Validate unsubscribe still works correctly for each custom subscription type.