### PR TITLE
Fix price issue

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -829,7 +829,11 @@ export class TokenService {
           const priceSourcetype = token.assets?.priceSource?.type;
 
           if (priceSourcetype === TokenAssetsPriceSourceType.dataApi) {
-            token.price = await this.dataApiService.getEsdtTokenPrice(token.identifier);
+            const dataApiPrice = await this.dataApiService.getEsdtTokenPrice(token.identifier);
+            if (dataApiPrice) {
+              // keep DEX price if data api price is not available, otherwise override it
+              token.price = dataApiPrice;
+            }
           } else if (priceSourcetype === TokenAssetsPriceSourceType.customUrl && token.assets?.priceSource?.url) {
             const pathToPrice = token.assets?.priceSource?.path ?? "0.usdPrice";
             const customHeaders = this.apiConfigService.getHeadersForCustomUrl(token.assets.priceSource.url);


### PR DESCRIPTION
## Reasoning
- data api price is not working on devnet and an undefined price overrides xexchange price
  
## Proposed Changes
- override xexchange price only when data api price is available

## How to test
- `WBTC-05fd5b` price and other tokens prices should have the price returned on `/tokens/:identifier`
