### PR TITLE
reduce default broadcast interval for devnet ws

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -25,7 +25,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 6000
+    broadcastIntervalMs: 1000
   eventsNotifier:
     enabled: false
     port: 5674


### PR DESCRIPTION
## Reasoning
- when supernova is live on devnet, default config should be updated
  
## Proposed Changes
- update ws default broadcast interval
 
## How to test
- broadcast should happen every 1 second by default
