### PR TITLE
Collection search after

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -122,6 +122,7 @@ export class CollectionService {
         canUpgrade: props?.canUpgrade,
         canAddSpecialRoles: props?.canAddSpecialRoles,
         decimals: isMetaESDT ? esCollection.numDecimals : undefined,
+        searchAfter: esCollection.searchAfter,
       });
 
       nftCollection.ticker = nftCollection.assets ? ticker : nftCollection.collection;

--- a/src/endpoints/collections/entities/nft.collection.ts
+++ b/src/endpoints/collections/entities/nft.collection.ts
@@ -79,4 +79,7 @@ export class NftCollection {
 
   @ApiProperty({ type: Number, nullable: true, required: false })
   nftCount: number | undefined = undefined;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  searchAfter: string | undefined = undefined;
 }

--- a/src/endpoints/nfts/entities/nft.ts
+++ b/src/endpoints/nfts/entities/nft.ts
@@ -108,4 +108,7 @@ export class Nft {
 
   @ApiProperty({ type: Number, nullable: true, required: false })
   unlockEpoch?: number | undefined = undefined;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  searchAfter?: string | undefined = undefined;
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -433,6 +433,7 @@ export class NftService {
       nft.collection = elasticNft.token;
       nft.nonce = parseInt('0x' + nft.identifier.split('-')[2]);
       nft.timestamp = elasticNft.timestamp;
+      nft.searchAfter = elasticNft.searchAfter;
 
       if (elasticNft.nft_scamInfoType && elasticNft.nft_scamInfoType !== 'none') {
         nft.scamInfo = new ScamInfo({

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -188,7 +188,7 @@ export class CacheInfo {
 
   static Nfts(queryPagination: QueryPagination): CacheInfo {
     return {
-      key: `nfts:${queryPagination.from}:${queryPagination.size}`,
+      key: `nfts:${queryPagination.from}:${queryPagination.size}:${queryPagination.searchAfter}`,
       ttl: Constants.oneSecond() * 6,
     };
   }
@@ -288,7 +288,7 @@ export class CacheInfo {
 
   static Collections(pagination: QueryPagination): CacheInfo {
     return {
-      key: `collections:${pagination.from}:${pagination.size}`,
+      key: `collections:${pagination.from}:${pagination.size}:${pagination.searchAfter}`,
       ttl: Constants.oneSecond() * 6,
     };
   }


### PR DESCRIPTION
## Reasoning
- The `searchAfter` cursor-based pagination was already supported as a query param, but the cursor was never returned to the client, making it impossible to request the next page.
- The same gap existed on the NFT endpoints: `Nft` had no `searchAfter` field, so the Elasticsearch sort value resolved on the indexer entity was silently dropped when mapping to the API response.
- The `nfts` and `collections` cache keys were built only from `from` and `size`, so two requests with the same page size but different cursors collided and returned the wrong (cached) page.

## Proposed Changes
- Expose `searchAfter` on the `NftCollection` and `Nft` response entities (optional, documented via `@ApiProperty` so it shows up in Swagger).
- Populate the cursor when mapping Elasticsearch documents: `esCollection.searchAfter` in `CollectionService` and `elasticNft.searchAfter` in `NftService`.
- Include `searchAfter` in the `CacheInfo.Nfts` and `CacheInfo.Collections` cache keys to avoid cross-cursor cache collisions.

## How to test
- `GET /collections?size=10` and `GET /nfts?size=10` — each returned item should now contain a `searchAfter` value, and the last item's cursor is the one to paginate with.
- Call `GET /collections?size=10&searchAfter=<cursor from last item>` (and the same for `/nfts`) and confirm the next page starts right after the previous one, with no duplicated or skipped entries.
- Issue two consecutive requests with the same `size` but different `searchAfter` values within the 6s cache TTL and confirm they return different pages (cache key no longer collides).
