### PR TITLE
Fix collections sorting fallback

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -361,7 +361,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
     if (sort === SortCollections.verifiedAndHolderCount) {
       elasticQuery = elasticQuery.withSort([
-        { name: 'api_isVerified', order, missing: "_last" },
+        { name: 'api_isVerified', order, missing: false },
         { name: 'api_holderCount', order, missing: 0 },
         { name: 'token', order },
         { name: 'nonce', order, missing: 0 },

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -361,8 +361,8 @@ export class ElasticIndexerService implements IndexerInterface {
 
     if (sort === SortCollections.verifiedAndHolderCount) {
       elasticQuery = elasticQuery.withSort([
-        { name: 'api_isVerified', order },
-        { name: 'api_holderCount', order },
+        { name: 'api_isVerified', order, missing: "_last" },
+        { name: 'api_holderCount', order, missing: 0 },
         { name: 'token', order },
         { name: 'nonce', order, missing: 0 },
         { name: 'timestamp', order },

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -361,7 +361,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
     if (sort === SortCollections.verifiedAndHolderCount) {
       elasticQuery = elasticQuery.withSort([
-        { name: 'api_isVerified', order, missing: false },
+        { name: 'api_isVerified', order, missing: 0 },
         { name: 'api_holderCount', order, missing: 0 },
         { name: 'token', order },
         { name: 'nonce', order, missing: 0 },


### PR DESCRIPTION
## Reasoning
- When sorting collections by `verifiedAndHolderCount`, `api_isVerified` and `api_holderCount` are not present on every document in the `tokens` index.
- Without an explicit fallback, a missing value was interpreted as a very large negative number, which broke the `searchAfter` cursor and returned an internal server error.
- Elasticsearch sorts booleans as `0`/`1`, so a missing `api_isVerified` should simply be treated as `false`, i.e. `0`.

## Proposed Changes
- Add `missing: 0` to the `api_isVerified` sort field, so collections without the flag sort as not verified.
- Add `missing: 0` to the `api_holderCount` sort field, so collections without a holder count sort as zero holders.

## How to test
- `GET /collections?sort=verifiedAndHolderCount&size=25` should return 200.
- Paginate further with the `searchAfter` cursor returned by the last item and confirm it works.
