### PR TITLE
Exclude egld-000000 from tokens count response

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -235,7 +235,7 @@ export class TokenService {
   async getTokenCount(filter: TokenFilter): Promise<number> {
     const tokens = await this.getFilteredTokens(filter);
 
-    return tokens.length;
+    return tokens.length - 1; // exclude EGLD-000000, remove when EGLD-000000 is no longer manually added
   }
 
   async getTokenCountForAddress(address: string, filter: TokenFilter): Promise<number> {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -132,9 +132,7 @@ export class TokenService {
       this.applyTickerFromAssets(token);
     }
 
-    return tokens
-      .map(item => ApiUtils.mergeObjects(new TokenDetailed(), item))
-      .filter(t => t.identifier !== this.egldIdentifierInMultiTransfer);
+    return tokens.map(item => ApiUtils.mergeObjects(new TokenDetailed(), item));
   }
 
   applyTickerFromAssets(token: Token) {
@@ -197,7 +195,7 @@ export class TokenService {
       tokens = tokens.filter(token => token.assets?.priceSource?.type === filter.priceSource);
     }
 
-    return tokens;
+    return tokens.filter(token => token.identifier !== this.egldIdentifierInMultiTransfer);
   }
 
   private sortTokens(tokens: TokenDetailed[], sort: TokenSort, order: SortOrder): TokenDetailed[] {
@@ -235,8 +233,7 @@ export class TokenService {
   async getTokenCount(filter: TokenFilter): Promise<number> {
     const tokens = await this.getFilteredTokens(filter);
 
-    // exclude EGLD-000000, remove when EGLD-000000 is no longer manually added
-    return tokens.filter(token => token.identifier !== 'EGLD-000000').length;
+    return tokens.length;
   }
 
   async getTokenCountForAddress(address: string, filter: TokenFilter): Promise<number> {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -235,7 +235,8 @@ export class TokenService {
   async getTokenCount(filter: TokenFilter): Promise<number> {
     const tokens = await this.getFilteredTokens(filter);
 
-    return tokens.length - 1; // exclude EGLD-000000, remove when EGLD-000000 is no longer manually added
+    // exclude EGLD-000000, remove when EGLD-000000 is no longer manually added
+    return tokens.filter(token => token.identifier !== 'EGLD-000000').length;
   }
 
   async getTokenCountForAddress(address: string, filter: TokenFilter): Promise<number> {


### PR DESCRIPTION
## Reasoning
- `EGLD-000000` is a synthetic entry added manually to the tokens list (for multi-transfer support). It was filtered out only in `getTokens`, so `GET /tokens/count` returned a value 1 higher than the number of tokens actually listed by `GET /tokens`.

## Proposed Changes
- Moved the `EGLD-000000` exclusion from `getTokens` into `getFilteredTokens`, so every consumer of the filtered list (list, count, tokens for address) sees the same set of tokens.

## How to test
- Compare `GET /tokens/count` with the number of items returned by `GET /tokens?size=10000` — the values should match, and `EGLD-000000` should not appear in the list.
- Repeat with filters applied (e.g. `?type=FungibleESDT`, `?search=...`) and check that list and count stay consistent.