### PR TITLE
WS fixes + improvements

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -25,7 +25,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 1000
+    broadcastIntervalMs: 600
   eventsNotifier:
     enabled: false
     port: 5674

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -25,7 +25,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 1000
+    broadcastIntervalMs: 600
   eventsNotifier:
     enabled: false
     port: 5674

--- a/src/crons/websocket/custom.subscriptions.data.fetcher.ts
+++ b/src/crons/websocket/custom.subscriptions.data.fetcher.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@nestjs/common';
+import { OriginLogger } from '@multiversx/sdk-nestjs-common';
+import { QueryPagination } from 'src/common/entities/query.pagination';
+import { Transaction } from 'src/endpoints/transactions/entities/transaction';
+import { TransactionDetailed } from 'src/endpoints/transactions/entities/transaction.detailed';
+import { TransactionFilter } from 'src/endpoints/transactions/entities/transaction.filter';
+import { TransactionQueryOptions } from 'src/endpoints/transactions/entities/transactions.query.options';
+import { TransactionType } from 'src/endpoints/transactions/entities/transaction.type';
+import { TransferService } from 'src/endpoints/transfers/transfer.service';
+import { EventsService } from 'src/endpoints/events/events.service';
+import { EventsFilter } from 'src/endpoints/events/entities/events.filter';
+import { Events } from 'src/endpoints/events/entities/events';
+
+export class CustomSubscriptionsRoundData {
+  constructor(init?: Partial<CustomSubscriptionsRoundData>) {
+    Object.assign(this, init);
+  }
+
+  transactions: Transaction[] = [];
+  transfers: Transaction[] = [];
+  events: Events[] = [];
+}
+
+@Injectable()
+export class CustomSubscriptionsDataFetcher {
+  private readonly logger = new OriginLogger(CustomSubscriptionsDataFetcher.name);
+
+  private static readonly batchSize = 10000;
+
+  constructor(
+    private readonly transferService: TransferService,
+    private readonly eventsService: EventsService,
+  ) { }
+
+  // Fetches everything the custom subscription gateways need for a given round, once.
+  // The 'operations' index holds both transactions and smart contract results, so the
+  // transactions payload is derived from the transfers payload instead of being queried again.
+  async fetchRoundData(timestampMs: number): Promise<CustomSubscriptionsRoundData> {
+    const [transfers, events] = await Promise.all([
+      this.fetchTransfers(timestampMs),
+      this.fetchEvents(timestampMs),
+    ]);
+
+    return new CustomSubscriptionsRoundData({
+      transfers,
+      transactions: this.extractTransactions(transfers),
+      events,
+    });
+  }
+
+  private async fetchTransfers(timestampMs: number): Promise<Transaction[]> {
+    try {
+      const size = CustomSubscriptionsDataFetcher.batchSize;
+      const filter = new TransactionFilter({ before: timestampMs, after: timestampMs, withTxsRelayedByAddress: true });
+      const options = new TransactionQueryOptions({ withScamInfo: false, withUsername: true, withBlockInfo: false, withLogs: false, withOperations: false, withActionTransferValue: false, withTxsOrder: false });
+
+      const allTransfers: Transaction[] = [];
+
+      let batch = await this.transferService.getTransfers(filter, new QueryPagination({ size }), options);
+      allTransfers.push(...batch);
+
+      while (batch.length === size) {
+        const searchAfter = batch[batch.length - 1].searchAfter;
+        if (searchAfter == null) {
+          break;
+        }
+
+        batch = await this.transferService.getTransfers(filter, new QueryPagination({ size, searchAfter }), options);
+
+        allTransfers.push(...batch);
+      }
+
+      return allTransfers;
+    } catch (error) {
+      this.logger.error(`Error fetching transfers for timestamp '${timestampMs}'`);
+      this.logger.error(error);
+      return [];
+    }
+  }
+
+  private async fetchEvents(timestampMs: number): Promise<Events[]> {
+    try {
+      const size = CustomSubscriptionsDataFetcher.batchSize;
+      const filter = new EventsFilter({ before: timestampMs, after: timestampMs });
+
+      const allEvents: Events[] = [];
+
+      let batch = await this.eventsService.getEvents(new QueryPagination({ size }), filter);
+      allEvents.push(...batch);
+
+      while (batch.length === size) {
+        const searchAfter = batch[batch.length - 1].searchAfter;
+        if (searchAfter == null) {
+          break;
+        }
+
+        batch = await this.eventsService.getEvents(new QueryPagination({ size, searchAfter }), filter);
+
+        allEvents.push(...batch);
+      }
+
+      return allEvents;
+    } catch (error) {
+      this.logger.error(`Error fetching events for timestamp '${timestampMs}'`);
+      this.logger.error(error);
+      return [];
+    }
+  }
+
+  // Transactions are the 'normal' subset of the operations returned for transfers. They are
+  // cloned so that clearing the type does not alter the objects broadcast on the transfers channel.
+  private extractTransactions(transfers: Transaction[]): Transaction[] {
+    const transactions: Transaction[] = [];
+
+    for (const transfer of transfers) {
+      if (transfer.type !== TransactionType.Transaction) {
+        continue;
+      }
+
+      const transaction = Object.assign(new TransactionDetailed(), transfer);
+      transaction.type = undefined;
+
+      transactions.push(transaction);
+    }
+
+    return transactions;
+  }
+}

--- a/src/crons/websocket/custom.subscriptions.data.fetcher.ts
+++ b/src/crons/websocket/custom.subscriptions.data.fetcher.ts
@@ -52,7 +52,7 @@ export class CustomSubscriptionsDataFetcher {
     try {
       const size = CustomSubscriptionsDataFetcher.batchSize;
       const filter = new TransactionFilter({ before: timestampMs, after: timestampMs, withTxsRelayedByAddress: true });
-      const options = new TransactionQueryOptions({ withScamInfo: false, withUsername: true, withBlockInfo: false, withLogs: false, withOperations: false, withActionTransferValue: false, withTxsOrder: false });
+      const options = new TransactionQueryOptions({ withScamInfo: false, withUsername: true, withBlockInfo: false, withLogs: false, withOperations: false, withActionTransferValue: false, withTxsOrder: false, withCanBeIgnoredFlag: true });
 
       const allTransfers: Transaction[] = [];
 
@@ -70,7 +70,7 @@ export class CustomSubscriptionsDataFetcher {
         allTransfers.push(...batch);
       }
 
-      return allTransfers;
+      return allTransfers.filter((transfer) => transfer.canBeIgnored !== true);
     } catch (error) {
       this.logger.error(`Error fetching transfers for timestamp '${timestampMs}'`);
       this.logger.error(error);

--- a/src/crons/websocket/events.custom.gateway.ts
+++ b/src/crons/websocket/events.custom.gateway.ts
@@ -2,13 +2,10 @@ import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, M
 import { Server, Socket } from 'socket.io';
 import { UseFilters, UseInterceptors } from '@nestjs/common';
 import { OriginLogger } from '@multiversx/sdk-nestjs-common';
-import { QueryPagination } from 'src/common/entities/query.pagination';
 import { WsValidationPipe } from 'src/utils/ws-validation.pipe';
 import { WebsocketExceptionsFilter } from 'src/utils/ws-exceptions.filter';
 import { RoomKeyGenerator } from './room.key.generator';
-import { EventsService } from 'src/endpoints/events/events.service';
 import { EventsCustomSubscribePayload } from 'src/endpoints/events/entities/events.custom.subscribe';
-import { EventsFilter } from 'src/endpoints/events/entities/events.filter';
 import { Events } from 'src/endpoints/events/entities/events';
 import { LockingGuardInterceptor } from 'src/utils/locking.guard.interceptor';
 
@@ -21,10 +18,6 @@ export class EventsCustomGateway {
 
   @WebSocketServer()
   server!: Server;
-
-  constructor(
-    private readonly eventsService: EventsService,
-  ) { }
 
   @UseInterceptors(LockingGuardInterceptor)
   @SubscribeMessage('subscribeCustomEvents')
@@ -57,29 +50,11 @@ export class EventsCustomGateway {
     return { status: 'unsubscribed' };
   }
 
-  async pushEventsForTimestampMs(timestampMs: number): Promise<void> {
+  pushEventsForTimestampMs(timestampMs: number, events: Events[]): void {
     try {
-      const allEvents: Events[] = [];
-      const size = 10000;
-      const filter = new EventsFilter({ before: timestampMs, after: timestampMs });
-
-      let batch = await this.eventsService.getEvents(new QueryPagination({ size }), filter);
-      allEvents.push(...batch);
-
-      while (batch.length === size) {
-        const searchAfter = batch[batch.length - 1].searchAfter;
-        if (searchAfter == null) {
-          break;
-        }
-
-        batch = await this.eventsService.getEvents(new QueryPagination({ size, searchAfter }), filter);
-
-        allEvents.push(...batch);
-      }
-
       const eventsFilteredForBroadcast: Map<string, Events[]> = new Map();
 
-      for (const event of allEvents) {
+      for (const event of events) {
         const roomKeys = RoomKeyGenerator.generate(
           EventsCustomGateway.keyPrefix,
           event,

--- a/src/crons/websocket/network.gateway.ts
+++ b/src/crons/websocket/network.gateway.ts
@@ -38,7 +38,7 @@ export class NetworkGateway {
   async pushStats() {
     if (this.server.sockets.adapter.rooms.has('statsRoom')) {
       try {
-        const stats = await this.networkService.getStats();
+        const stats = await this.networkService.getStats(true);
         this.server.to('statsRoom').emit('statsUpdate', stats);
       } catch (error) {
         this.logger.error(error);

--- a/src/crons/websocket/transaction.custom.gateway.ts
+++ b/src/crons/websocket/transaction.custom.gateway.ts
@@ -1,8 +1,5 @@
 import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { TransactionService } from '../../endpoints/transactions/transaction.service';
-import { TransactionFilter } from '../../endpoints/transactions/entities/transaction.filter';
-import { QueryPagination } from 'src/common/entities/query.pagination';
 import { WsValidationPipe } from 'src/utils/ws-validation.pipe';
 import { WebsocketExceptionsFilter } from 'src/utils/ws-exceptions.filter';
 import { UseFilters, UseInterceptors } from '@nestjs/common';
@@ -19,10 +16,6 @@ export class TransactionsCustomGateway {
   static keyPrefix = 'custom-tx-';
   @WebSocketServer()
   server!: Server;
-
-  constructor(
-    private readonly transactionService: TransactionService,
-  ) { }
 
   @UseInterceptors(LockingGuardInterceptor)
   @SubscribeMessage('subscribeCustomTransactions')
@@ -52,28 +45,10 @@ export class TransactionsCustomGateway {
     return { status: 'unsubscribed' };
   }
 
-  async pushTransactionsForTimestampMs(timestampMs: number): Promise<void> {
+  pushTransactionsForTimestampMs(timestampMs: number, transactions: Transaction[]): void {
     try {
-      const allTransactions: Transaction[] = [];
-      const size = 10000;
-      const filter = new TransactionFilter({ before: timestampMs, after: timestampMs });
-
-      let batch = await this.transactionService.getTransactions(filter, new QueryPagination({ size }));
-      allTransactions.push(...batch);
-
-      while (batch.length === size) {
-        const searchAfter = batch[batch.length - 1].searchAfter;
-        if (searchAfter == null) {
-          break;
-        }
-
-        batch = await this.transactionService.getTransactions(filter, new QueryPagination({ size, searchAfter }));
-
-        allTransactions.push(...batch);
-      }
-
       const txFilteredForBroadcast: Map<string, Transaction[]> = new Map();
-      for (const transaction of allTransactions) {
+      for (const transaction of transactions) {
         const roomKeys = RoomKeyGenerator.generate(
           TransactionsCustomGateway.keyPrefix,
           transaction,

--- a/src/crons/websocket/transfers.custom.gateway.ts
+++ b/src/crons/websocket/transfers.custom.gateway.ts
@@ -1,7 +1,5 @@
 import { WebSocketGateway, WebSocketServer, SubscribeMessage, ConnectedSocket, MessageBody } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { TransactionFilter } from '../../endpoints/transactions/entities/transaction.filter';
-import { QueryPagination } from 'src/common/entities/query.pagination';
 import { WsValidationPipe } from 'src/utils/ws-validation.pipe';
 import { WebsocketExceptionsFilter } from 'src/utils/ws-exceptions.filter';
 import { UseFilters, UseInterceptors } from '@nestjs/common';
@@ -9,9 +7,7 @@ import { OriginLogger } from '@multiversx/sdk-nestjs-common';
 import { RoomKeyGenerator } from './room.key.generator';
 import { Transaction } from 'src/endpoints/transactions/entities/transaction';
 import { LockingGuardInterceptor } from 'src/utils/locking.guard.interceptor';
-import { TransferService } from 'src/endpoints/transfers/transfer.service';
 import { TransferCustomSubscribePayload } from 'src/endpoints/websocket/entities/transfers.custom.payload';
-import { TransactionQueryOptions } from 'src/endpoints/transactions/entities/transactions.query.options';
 
 @UseFilters(WebsocketExceptionsFilter)
 @WebSocketGateway({ cors: { origin: '*' }, path: '/ws/subscription' })
@@ -20,10 +16,6 @@ export class TransfersCustomGateway {
   static keyPrefix = 'custom-transfer-';
   @WebSocketServer()
   server!: Server;
-
-  constructor(
-    private readonly transferService: TransferService,
-  ) { }
 
   @UseInterceptors(LockingGuardInterceptor)
   @SubscribeMessage('subscribeCustomTransfers')
@@ -53,30 +45,11 @@ export class TransfersCustomGateway {
     return { status: 'unsubscribed' };
   }
 
-  async pushTransfersForTimestampMs(timestampMs: number): Promise<void> {
+  pushTransfersForTimestampMs(timestampMs: number, transfers: Transaction[]): void {
     try {
-      const allTransfers: Transaction[] = [];
-      const size = 10000;
-      const filter = new TransactionFilter({ before: timestampMs, after: timestampMs, withTxsRelayedByAddress: true });
-      const options = new TransactionQueryOptions({ withScamInfo: false, withUsername: true, withBlockInfo: false, withLogs: false, withOperations: false, withActionTransferValue: false, withTxsOrder: false });
-
-      let batch = await this.transferService.getTransfers(filter, new QueryPagination({ size }), options);
-      allTransfers.push(...batch);
-
-      while (batch.length === size) {
-        const searchAfter = batch[batch.length - 1].searchAfter;
-        if (searchAfter == null) {
-          break;
-        }
-
-        batch = await this.transferService.getTransfers(filter, new QueryPagination({ size, searchAfter }), options);
-
-        allTransfers.push(...batch);
-      }
-
       const transfersFilteredForBroadcast: Map<string, Transaction[]> = new Map();
 
-      for (const transfer of allTransfers) {
+      for (const transfer of transfers) {
         const roomKeys = RoomKeyGenerator.generate(
           TransfersCustomGateway.keyPrefix,
           transfer,

--- a/src/crons/websocket/websocket.cron.service.ts
+++ b/src/crons/websocket/websocket.cron.service.ts
@@ -12,9 +12,7 @@ import { MetricsEvents } from 'src/utils/metrics-events.constants';
 import { Server } from 'socket.io';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { CacheInfo } from 'src/utils/cache.info';
-import { RoundService } from 'src/endpoints/rounds/round.service';
-import { RoundFilter } from 'src/endpoints/rounds/entities/round.filter';
-import { ElasticQuery, ElasticService, QueryType } from '@multiversx/sdk-nestjs-elastic';
+import { ElasticQuery, ElasticService, ElasticSortOrder, QueryType } from '@multiversx/sdk-nestjs-elastic';
 import { NetworkService } from 'src/endpoints/network/network.service';
 import { Stats } from 'src/endpoints/network/entities/stats';
 import { TransactionsCustomGateway } from './transaction.custom.gateway';
@@ -38,7 +36,6 @@ export class WebsocketCronService implements OnModuleInit {
     private readonly eventsGateway: EventsGateway,
     private readonly eventEmitter: EventEmitter2,
     private readonly cacheService: CacheService,
-    private readonly roundService: RoundService,
     private readonly elasticService: ElasticService,
     private readonly networkService: NetworkService,
     private readonly transactionsCustomGateway: TransactionsCustomGateway,
@@ -136,13 +133,13 @@ export class WebsocketCronService implements OnModuleInit {
       return;
     }
 
-    const latestRoundOnChainData = await this.getLatestRoundOnChainData();
-    const statsPromise = this.networkService.getStats();
-    latestRoundOnChainData.timestampMs = latestRoundOnChainData.timestampMs ?? latestRoundOnChainData.timestamp * 1000;
+    const latestRoundOnChainTimestamp = await this.getLatestRoundOnChainTimestamp();
+    const statsPromise = this.networkService.getStats(false);
+    latestRoundOnChainTimestamp.timestampMs = latestRoundOnChainTimestamp.timestampMs ?? latestRoundOnChainTimestamp.timestamp * 1000;
 
     let roundToProcessTimestampMs = await this.cacheService.getOrSetLocal(
       CacheInfo.WsTimestampMsToProcess().key,
-      async () => await Promise.resolve(latestRoundOnChainData.timestampMs ?? latestRoundOnChainData.timestamp * 1000),
+      async () => await Promise.resolve(latestRoundOnChainTimestamp.timestampMs ?? latestRoundOnChainTimestamp.timestamp * 1000),
       CacheInfo.WsTimestampMsToProcess().ttl,
     );
 
@@ -150,7 +147,7 @@ export class WebsocketCronService implements OnModuleInit {
 
     const pollingDelay = stats.refreshRate / 10;
     const pollingMaxAttempts = 15;
-    while (roundToProcessTimestampMs <= latestRoundOnChainData.timestampMs) {
+    while (roundToProcessTimestampMs <= latestRoundOnChainTimestamp.timestampMs) {
       await this.pollUntil(async () => await this.isElasticDataAvailableForTimestampMs(roundToProcessTimestampMs, stats), pollingDelay, pollingMaxAttempts);
 
       // fetch the round data once, then let each gateway build its own response out of it
@@ -223,8 +220,17 @@ export class WebsocketCronService implements OnModuleInit {
     });
   }
 
-  private async getLatestRoundOnChainData() {
-    const rounds = await this.roundService.getRounds(new RoundFilter({ size: 1 }));
+  private async getLatestRoundOnChainTimestamp(): Promise<{ timestampMs?: number; timestamp: number }> {
+    const elasticQuery = ElasticQuery.create().
+      withSort([
+        { name: 'timestampMs', order: ElasticSortOrder.descending, missing: 0 },
+        { name: "timestamp", order: ElasticSortOrder.descending },
+      ])
+      .withPagination({ from: 0, size: 1 })
+      .withFields(['timestampMs', 'timestamp']);
+
+    const rounds = await this.elasticService.getList('rounds', 'round', elasticQuery);
+    console.log(rounds)
     return rounds[0];
   }
 

--- a/src/crons/websocket/websocket.cron.service.ts
+++ b/src/crons/websocket/websocket.cron.service.ts
@@ -22,6 +22,7 @@ import { ConnectionHandler } from './connection.handler';
 import { EventsCustomGateway } from './events.custom.gateway';
 import { TransfersCustomGateway } from './transfers.custom.gateway';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { CustomSubscriptionsDataFetcher } from './custom.subscriptions.data.fetcher';
 
 @Injectable()
 @WebSocketGateway({ cors: { origin: '*' }, path: '/ws/subscription' })
@@ -46,6 +47,7 @@ export class WebsocketCronService implements OnModuleInit {
     private readonly transfersCustomGateway: TransfersCustomGateway,
     private readonly apiConfigService: ApiConfigService,
     private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly customSubscriptionsDataFetcher: CustomSubscriptionsDataFetcher,
   ) { }
 
 
@@ -135,6 +137,7 @@ export class WebsocketCronService implements OnModuleInit {
     }
 
     const latestRoundOnChainData = await this.getLatestRoundOnChainData();
+    const statsPromise = this.networkService.getStats();
     latestRoundOnChainData.timestampMs = latestRoundOnChainData.timestampMs ?? latestRoundOnChainData.timestamp * 1000;
 
     let roundToProcessTimestampMs = await this.cacheService.getOrSetLocal(
@@ -143,26 +146,27 @@ export class WebsocketCronService implements OnModuleInit {
       CacheInfo.WsTimestampMsToProcess().ttl,
     );
 
-    const stats = await this.networkService.getStats();
+    const stats = await statsPromise;
 
     const pollingDelay = stats.refreshRate / 10;
     const pollingMaxAttempts = 15;
     while (roundToProcessTimestampMs <= latestRoundOnChainData.timestampMs) {
       await this.pollUntil(async () => await this.isElasticDataAvailableForTimestampMs(roundToProcessTimestampMs, stats), pollingDelay, pollingMaxAttempts);
 
-      // call gateways to process logic for custom subscriptions
-      await Promise.all([
-        this.transactionsCustomGateway.pushTransactionsForTimestampMs(roundToProcessTimestampMs),
-        this.eventsCustomGateway.pushEventsForTimestampMs(roundToProcessTimestampMs),
-        this.transfersCustomGateway.pushTransfersForTimestampMs(roundToProcessTimestampMs),
-      ]);
+      // fetch the round data once, then let each gateway build its own response out of it
+      const roundData = await this.customSubscriptionsDataFetcher.fetchRoundData(roundToProcessTimestampMs);
+
+      this.transfersCustomGateway.pushTransfersForTimestampMs(roundToProcessTimestampMs, roundData.transfers);
+      this.eventsCustomGateway.pushEventsForTimestampMs(roundToProcessTimestampMs, roundData.events);
+      this.transactionsCustomGateway.pushTransactionsForTimestampMs(roundToProcessTimestampMs, roundData.transactions);
+
       roundToProcessTimestampMs += stats.refreshRate;
+      this.cacheService.setLocal(
+        CacheInfo.WsTimestampMsToProcess().key,
+        roundToProcessTimestampMs,
+        CacheInfo.WsTimestampMsToProcess().ttl,
+      );
     }
-    this.cacheService.setLocal(
-      CacheInfo.WsTimestampMsToProcess().key,
-      roundToProcessTimestampMs,
-      CacheInfo.WsTimestampMsToProcess().ttl,
-    );
   }
 
   @Cron('*/10 * * * * *')

--- a/src/crons/websocket/websocket.cron.service.ts
+++ b/src/crons/websocket/websocket.cron.service.ts
@@ -230,7 +230,7 @@ export class WebsocketCronService implements OnModuleInit {
       .withFields(['timestampMs', 'timestamp']);
 
     const rounds = await this.elasticService.getList('rounds', 'round', elasticQuery);
-    console.log(rounds)
+
     return rounds[0];
   }
 

--- a/src/crons/websocket/websocket.subscription.module.ts
+++ b/src/crons/websocket/websocket.subscription.module.ts
@@ -12,7 +12,6 @@ import { TransactionsGateway } from './transaction.gateway';
 import { PoolGateway } from './pool.gateway';
 import { EventsGateway } from './events.gateway';
 import { ConnectionHandler } from './connection.handler';
-import { RoundModule } from 'src/endpoints/rounds/round.module';
 import { TransactionsCustomGateway } from './transaction.custom.gateway';
 import { EventsCustomGateway } from './events.custom.gateway';
 import { ApiConfigModule } from 'src/common/api-config/api.config.module';
@@ -33,7 +32,6 @@ import { CustomSubscriptionsDataFetcher } from './custom.subscriptions.data.fetc
     NetworkModule,
     PoolModule,
     EventsModule,
-    RoundModule,
     TransferModule,
     ApiConfigModule,
     ApiMetricsModule,

--- a/src/crons/websocket/websocket.subscription.module.ts
+++ b/src/crons/websocket/websocket.subscription.module.ts
@@ -21,6 +21,7 @@ import { TransferModule } from 'src/endpoints/transfers/transfer.module';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { PersistenceModule } from 'src/common/persistence/persistence.module';
+import { CustomSubscriptionsDataFetcher } from './custom.subscriptions.data.fetcher';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { PersistenceModule } from 'src/common/persistence/persistence.module';
   ],
   providers: [
     WebsocketCronService,
+    CustomSubscriptionsDataFetcher,
     ConnectionHandler,
     BlocksGateway,
     NetworkGateway,

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -122,6 +122,8 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true, required: false })
   searchAfter?: string | undefined;
 
+  canBeIgnored?: boolean | undefined;
+
   getDate(): Date | undefined {
     if (this.timestamp) {
       return new Date(this.timestamp * 1000);

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -19,6 +19,9 @@ export class TransactionQueryOptions {
   withActionTransferValue?: boolean;
   withTxsOrder?: boolean;
 
+  // used only internal
+  withCanBeIgnoredFlag?: boolean = false;
+
   static applyDefaultOptions(size: number, options: TransactionQueryOptions): TransactionQueryOptions {
     if (size <= TransactionQueryOptions.SCAM_INFO_MAX_SIZE) {
       options.withScamInfo = true;

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -131,6 +131,11 @@ export class TransferService {
     for (const elasticOperation of elasticOperations) {
       const transaction = ApiUtils.mergeObjects(new TransactionDetailed(), elasticOperation);
       transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
+
+      if (queryOptions.withCanBeIgnoredFlag) {
+        transaction.canBeIgnored = elasticOperation.canBeIgnored;
+      }
+
       if (elasticOperation.relayer) {
         transaction.relayer = elasticOperation.relayer;
         transaction.isRelayed = true;


### PR DESCRIPTION
## Reasoning
Custom WebSocket subscriptions queried Elastic three times per round — once per gateway — even though the transactions query hits the same `operations` index as the transfers one, so the same data was fetched and enriched twice on the latency-critical path.

## Proposed Changes
- Add `CustomSubscriptionsDataFetcher`: fetches a round's data once and derives the transactions payload from the transfers result. The three custom gateways no longer query Elastic — they receive the data and only match rooms and emit, so their push methods are now synchronous.
- Drop `canBeIgnored` operations from custom transfers, via a new internal `withCanBeIgnoredFlag` query option so the flag survives entity mapping into `Transaction`.
- Read the latest round timestamp straight from the `rounds` index instead of going through `RoundService` (which also ran a `getCurrentEpoch` query first), and drop `RoundModule` from the subscription module.
- Start `getStats` in parallel with the round lookup, and persist the round cursor inside the loop so a polling timeout no longer re-broadcasts rounds that were already sent.
- `NetworkGateway.pushStats` calls `getStats(true)` to bypass the cache.
- `broadcastIntervalMs` 1000 → 600 on devnet and testnet.

## How to test
- Subscribe to custom transactions/transfers/events and confirm the same messages arrive as before, with refunds no longer delivered on the transfers channel.
- Check the Elastic query count per round drops from three to two.
