### PR TITLE
Use elastic multiple search for network stats

### DIFF
--- a/src/common/indexer/elastic/circuit-breaker/circuit.breaker.proxy.module.ts
+++ b/src/common/indexer/elastic/circuit-breaker/circuit.breaker.proxy.module.ts
@@ -8,6 +8,7 @@ import { EsCircuitBreakerProxy } from "./circuit.breaker.proxy.service";
   imports: [
     ApiConfigModule,
     DynamicModuleUtils.getElasticModule(),
+    DynamicModuleUtils.getApiModule(),
   ],
   providers: [EsCircuitBreakerProxy],
   exports: [EsCircuitBreakerProxy],

--- a/src/common/indexer/elastic/circuit-breaker/circuit.breaker.proxy.service.ts
+++ b/src/common/indexer/elastic/circuit-breaker/circuit.breaker.proxy.service.ts
@@ -2,6 +2,7 @@ import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { ElasticQuery, ElasticService } from "@multiversx/sdk-nestjs-elastic";
 import { Injectable, ServiceUnavailableException } from "@nestjs/common";
 import { ApiConfigService } from "../../../api-config/api.config.service";
+import { ApiService } from "@multiversx/sdk-nestjs-http";
 
 @Injectable()
 export class EsCircuitBreakerProxy {
@@ -15,6 +16,7 @@ export class EsCircuitBreakerProxy {
   constructor(
     readonly apiConfigService: ApiConfigService,
     private readonly elasticService: ElasticService,
+    private readonly apiService: ApiService,
   ) {
     this.enabled = apiConfigService.isElasticCircuitBreakerEnabled();
     this.config = apiConfigService.getElasticCircuitBreakerConfig();
@@ -100,6 +102,14 @@ export class EsCircuitBreakerProxy {
   // eslint-disable-next-line require-await
   async get(url: string): Promise<any> {
     return this.withCircuitBreaker(() => this.elasticService.get(url));
+  }
+
+  //TODO: use elasticService when it will support custom headers
+  // ElasticService.post cannot set headers, and axios mangles an ndjson body when the content type
+  // says json, so bulk endpoints such as _msearch go through the api service directly.
+  // eslint-disable-next-line require-await
+  async postNdjson(url: string, body: string): Promise<any> {
+    return this.withCircuitBreaker(() => this.apiService.post(url, body, { headers: { 'Content-Type': 'application/x-ndjson' } }));
   }
 
   // eslint-disable-next-line require-await

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -17,7 +17,7 @@ import { TokenFilter } from "src/endpoints/tokens/entities/token.filter";
 import { Block } from "../entities/block";
 import { Tag } from "../entities/tag";
 import { ElasticIndexerHelper } from "./elastic.indexer.helper";
-import { AccountType, TokenType } from "../entities";
+import { AccountType, TokenType, StatsCounts } from "../entities";
 import { SortCollections } from "src/endpoints/collections/entities/sort.collections";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
 import { AccountSort } from "src/endpoints/accounts/entities/account.sort";
@@ -61,6 +61,40 @@ export class ElasticIndexerService implements IndexerInterface {
       .withCondition(QueryConditionOptions.must, [QueryType.Match("deployer", address)]);
 
     return await this.elasticService.getCount('scdeploys', elasticQuery);
+  }
+
+  // The stats page needs four counts at once. They live in three different indices, so they go out
+  // as a single _msearch instead of four separate round trips.
+  async getStatsCounts(): Promise<StatsCounts> {
+    const requests: { index: string, query: ElasticQuery }[] = [
+      { index: 'blocks', query: ElasticQuery.create().withCondition(QueryConditionOptions.must, await this.indexerHelper.buildElasticBlocksFilter(new BlockFilter())) },
+      { index: 'accounts', query: this.indexerHelper.buildAccountFilterQuery(new AccountQueryOptions()) },
+      { index: 'operations', query: this.indexerHelper.buildTransactionFilterQuery(new TransactionFilter()) },
+      { index: 'operations', query: this.indexerHelper.buildResultsFilterQuery(new SmartContractResultFilter()) },
+    ];
+
+    const body = requests
+      .map(request => `${JSON.stringify({ index: request.index })}\n${JSON.stringify({ query: request.query.toJson().query, size: 0, track_total_hits: true })}\n`)
+      .join('');
+
+    // without this the sub-searches are run with a lower concurrency than four parallel requests would get
+    const result = await this.elasticService.postNdjson(`${this.apiConfigService.getElasticUrl()}/_msearch?max_concurrent_searches=${requests.length}`, body);
+
+    const counts = requests.map((request, index) => {
+      const response = result?.data?.responses?.[index];
+      if (!response || response.error) {
+        throw new Error(`Could not read the '${request.index}' count from the stats _msearch response: ${JSON.stringify(response?.error)}`);
+      }
+
+      return response.hits.total.value;
+    });
+    console.log(counts)
+    return new StatsCounts({
+      blocks: counts[0],
+      accounts: counts[1],
+      transactions: counts[2],
+      scResults: counts[3],
+    });
   }
 
   async getBlocksCount(filter: BlockFilter): Promise<number> {

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -88,7 +88,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
       return response.hits.total.value;
     });
-    console.log(counts)
+
     return new StatsCounts({
       blocks: counts[0],
       accounts: counts[1],

--- a/src/common/indexer/entities/index.ts
+++ b/src/common/indexer/entities/index.ts
@@ -16,3 +16,4 @@ export { TransactionLog, TransactionLogEvent, ElasticTransactionLogEvent } from 
 export { TransactionReceipt } from './transaction.receipt';
 export { ElasticSortable } from './elastic.sortable';
 export { AccountType } from './account.type';
+export { StatsCounts } from './stats.counts';

--- a/src/common/indexer/entities/stats.counts.ts
+++ b/src/common/indexer/entities/stats.counts.ts
@@ -1,0 +1,10 @@
+export class StatsCounts {
+  constructor(init?: Partial<StatsCounts>) {
+    Object.assign(this, init);
+  }
+
+  blocks: number = 0;
+  accounts: number = 0;
+  transactions: number = 0;
+  scResults: number = 0;
+}

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -12,7 +12,7 @@ import { TokenWithRolesFilter } from "src/endpoints/tokens/entities/token.with.r
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TokenAssets } from "../assets/entities/token.assets";
 import { QueryPagination } from "../entities/query.pagination";
-import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt, AccountType } from "./entities";
+import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt, AccountType, StatsCounts } from "./entities";
 import { AccountAssets } from "../assets/entities/account.assets";
 import { ProviderDelegators } from "./entities/provider.delegators";
 import { ApplicationFilter } from "src/endpoints/applications/entities/application.filter";
@@ -27,6 +27,8 @@ export interface IndexerInterface {
   getAccountDeploysCount(address: string): Promise<number>
 
   getBlocksCount(filter: BlockFilter): Promise<number>
+
+  getStatsCounts(): Promise<StatsCounts>
 
   getBlocks(filter: BlockFilter, queryPagination: QueryPagination): Promise<Block[]>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -11,7 +11,7 @@ import { TransactionFilter } from "src/endpoints/transactions/entities/transacti
 import { MetricsEvents } from "src/utils/metrics-events.constants";
 import { TokenAssets } from "../assets/entities/token.assets";
 import { QueryPagination } from "../entities/query.pagination";
-import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt, AccountType } from "./entities";
+import { Account, AccountHistory, AccountTokenHistory, Block, Collection, MiniBlock, Operation, Round, ScDeploy, ScResult, Tag, Token, TokenAccount, Transaction, ElasticTransactionLogEvent, TransactionReceipt, AccountType, StatsCounts } from "./entities";
 import { IndexerInterface } from "./indexer.interface";
 import { LogPerformanceAsync } from "src/utils/log.performance.decorator";
 import { AccountQueryOptions } from "src/endpoints/accounts/entities/account.query.options";
@@ -493,5 +493,10 @@ export class IndexerService implements IndexerInterface {
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getAccountNftReceivedTimestamps(address: string, identifiers: string[]): Promise<Record<string, number>> {
     return await this.indexerInterface.getAccountNftReceivedTimestamps(address, identifiers);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getStatsCounts(): Promise<StatsCounts> {
+    return await this.indexerInterface.getStatsCounts();
   }
 }

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -1,11 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { Stats } from 'src/endpoints/network/entities/stats';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
-import { AccountService } from '../accounts/account.service';
 import { BlockService } from '../blocks/block.service';
-import { BlockFilter } from '../blocks/entities/block.filter';
-import { TransactionFilter } from '../transactions/entities/transaction.filter';
-import { TransactionService } from '../transactions/transaction.service';
 import { VmQueryService } from '../vm.query/vm.query.service';
 import { NetworkConstants } from './entities/constants';
 import { Economics } from './entities/economics';
@@ -17,13 +13,11 @@ import { BinaryUtils, NumberUtils, OriginLogger } from '@multiversx/sdk-nestjs-c
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { About } from './entities/about';
 import { PluginService } from 'src/common/plugins/plugin.service';
-import { SmartContractResultService } from '../sc-results/scresult.service';
 import { TokenService } from '../tokens/token.service';
-import { AccountQueryOptions } from '../accounts/entities/account.query.options';
 import { DataApiService } from 'src/common/data-api/data-api.service';
 import { FeatureConfigs } from './entities/feature.configs';
 import { IndexerService } from 'src/common/indexer/indexer.service';
-import { SmartContractResultFilter } from '../sc-results/entities/smart.contract.result.filter';
+import { StatsCounts } from 'src/common/indexer/entities';
 
 @Injectable()
 export class NetworkService {
@@ -37,16 +31,10 @@ export class NetworkService {
     private readonly vmQueryService: VmQueryService,
     @Inject(forwardRef(() => BlockService))
     private readonly blockService: BlockService,
-    @Inject(forwardRef(() => AccountService))
-    private readonly accountService: AccountService,
-    @Inject(forwardRef(() => TransactionService))
-    private readonly transactionService: TransactionService,
     private readonly dataApiService: DataApiService,
     @Inject(forwardRef(() => StakeService))
     private readonly stakeService: StakeService,
     private readonly pluginService: PluginService,
-    @Inject(forwardRef(() => SmartContractResultService))
-    private readonly smartContractResultService: SmartContractResultService,
     private readonly indexerService: IndexerService,
   ) { }
 
@@ -195,23 +183,17 @@ export class NetworkService {
     return BinaryUtils.base64ToBigInt(totalWaitingStakeBase64);
   }
 
-  async getStats(): Promise<Stats> {
+  async getStats(noCache?: boolean): Promise<Stats> {
     const metaChainShard = this.apiConfigService.getMetaChainShardId();
 
     const [
       networkConfig,
       networkStatus,
-      blocksCount,
-      accountsCount,
-      transactionsCount,
-      scResultsCount,
+      counts,
     ] = await Promise.all([
       this.gatewayService.getNetworkConfig(),
       this.gatewayService.getNetworkStatus(metaChainShard),
-      this.blockService.getBlocksCount(new BlockFilter()),
-      this.accountService.getAccountsCount(new AccountQueryOptions()),
-      this.transactionService.getTransactionCount(new TransactionFilter()),
-      this.smartContractResultService.getScResultsCount(new SmartContractResultFilter()),
+      this.getStatsCounts(noCache),
     ]);
 
     const { erd_num_shards_without_meta: shards, erd_round_duration: refreshRate } = networkConfig;
@@ -219,15 +201,27 @@ export class NetworkService {
 
     return {
       shards,
-      blocks: blocksCount,
-      accounts: accountsCount,
-      transactions: transactionsCount + scResultsCount,
-      scResults: scResultsCount,
+      blocks: counts.blocks,
+      accounts: counts.accounts,
+      transactions: counts.transactions + counts.scResults,
+      scResults: counts.scResults,
       refreshRate,
       epoch,
       roundsPassed: roundsPassed % roundsPerEpoch,
       roundsPerEpoch,
     };
+  }
+
+  private async getStatsCounts(noCache?: boolean): Promise<StatsCounts> {
+    if (!noCache) {
+      return await this.cachingService.getOrSet(
+        CacheInfo.StatsCounts.key,
+        async () => await this.indexerService.getStatsCounts(),
+        CacheInfo.StatsCounts.ttl,
+      );
+    }
+
+    return await this.indexerService.getStatsCounts();
   }
 
   async getApr(): Promise<{ apr: number; topUpApr: number; baseApr: number }> {

--- a/src/test/unit/services/network.spec.ts
+++ b/src/test/unit/services/network.spec.ts
@@ -18,15 +18,13 @@ import { TokenService } from "src/endpoints/tokens/token.service";
 import { TransactionService } from "src/endpoints/transactions/transaction.service";
 import { VmQueryService } from "src/endpoints/vm.query/vm.query.service";
 import { CacheInfo } from "src/utils/cache.info";
+import { StatsCounts } from "src/common/indexer/entities";
 
 describe('NetworkService', () => {
   let networkService: NetworkService;
   let apiConfigService: ApiConfigService;
   let gatewayService: GatewayService;
-  let blockService: BlockService;
-  let accountService: AccountService;
-  let transactionService: TransactionService;
-  let smartContractResultService: SmartContractResultService;
+  let indexerService: IndexerService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -129,6 +127,7 @@ describe('NetworkService', () => {
           provide: IndexerService,
           useValue: {
             getIndexerVersion: jest.fn(),
+            getStatsCounts: jest.fn(),
           },
         },
       ],
@@ -137,10 +136,7 @@ describe('NetworkService', () => {
     networkService = moduleRef.get<NetworkService>(NetworkService);
     apiConfigService = moduleRef.get<ApiConfigService>(ApiConfigService);
     gatewayService = moduleRef.get<GatewayService>(GatewayService);
-    blockService = moduleRef.get<BlockService>(BlockService);
-    accountService = moduleRef.get<AccountService>(AccountService);
-    transactionService = moduleRef.get<TransactionService>(TransactionService);
-    smartContractResultService = moduleRef.get<SmartContractResultService>(SmartContractResultService);
+    indexerService = moduleRef.get<IndexerService>(IndexerService);
   });
 
   it('service should be defined', () => {
@@ -348,20 +344,21 @@ describe('NetworkService', () => {
       jest.spyOn(apiConfigService, 'getMetaChainShardId').mockReturnValue(4294967295);
       jest.spyOn(gatewayService, 'getNetworkConfig').mockResolvedValue(mockNetworkConfig);
       jest.spyOn(gatewayService, 'getNetworkStatus').mockResolvedValue(mockNetworkStatus);
-      jest.spyOn(blockService, 'getBlocksCount').mockResolvedValue(97128014);
-      jest.spyOn(accountService, 'getAccountsCount').mockResolvedValue(2429648);
-      jest.spyOn(transactionService, 'getTransactionCount').mockResolvedValue(87054604);
-      jest.spyOn(smartContractResultService, 'getScResultsCount').mockResolvedValue(271213143);
+      jest.spyOn(indexerService, 'getStatsCounts').mockResolvedValue(new StatsCounts({
+        blocks: 97128014,
+        accounts: 2429648,
+        transactions: 87054604,
+        scResults: 271213143,
+      }));
+      // the counts are read through the cache, so let the cache run its factory
+      jest.spyOn(networkService['cachingService'], 'getOrSet').mockImplementation(async (_key, factory: any) => await factory());
 
       const result = await networkService.getStats();
 
       expect(apiConfigService.getMetaChainShardId).toHaveBeenCalled();
       expect(gatewayService.getNetworkConfig).toHaveBeenCalled();
       expect(gatewayService.getNetworkStatus).toHaveBeenCalled();
-      expect(blockService.getBlocksCount).toHaveBeenCalled();
-      expect(accountService.getAccountsCount).toHaveBeenCalled();
-      expect(transactionService.getTransactionCount).toHaveBeenCalled();
-      expect(smartContractResultService.getScResultsCount).toHaveBeenCalled();
+      expect(indexerService.getStatsCounts).toHaveBeenCalledTimes(1);
 
       expect(result).toEqual(expect.objectContaining({
         shards: 3,

--- a/src/test/unit/utils/circuit.breaker.proxy.spec.ts
+++ b/src/test/unit/utils/circuit.breaker.proxy.spec.ts
@@ -33,7 +33,7 @@ describe('EsCircuitBreakerProxy', () => {
       getElasticCircuitBreakerConfig: jest.fn().mockReturnValue(defaultConfig),
     } as any;
 
-    proxy = new EsCircuitBreakerProxy(mockApiConfigService, mockElasticService);
+    proxy = new EsCircuitBreakerProxy(mockApiConfigService, mockElasticService, { post: jest.fn() } as any);
   });
 
   afterEach(() => {

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -117,6 +117,11 @@ export class CacheInfo {
     ttl: Constants.oneSecond(),
   };
 
+  static StatsCounts: CacheInfo = {
+    key: 'stats:counts',
+    ttl: Constants.oneSecond(),
+  };
+
   static IdentityProfilesKeybases: CacheInfo = {
     key: 'identityProfilesKeybases',
     ttl: Constants.oneHour(),


### PR DESCRIPTION
## Reasoning
- `GET /network/stats` issued four separate Elastic count requests (blocks, accounts, transactions, scResults), one per count.
- They are independent queries with no dependency between them, so `_msearch` can batch all four into a single HTTP request.

## Proposed Changes
- Add `IndexerService.getStatsCounts()`, backed by one `_msearch` in `ElasticIndexerService`, returning all four counts as `StatsCounts`.
- `NetworkService.getStats` now makes that single call; the unused `AccountService` / `TransactionService` / `SmartContractResultService` dependencies were dropped.
- Add `postNdjson` to `EsCircuitBreakerProxy`: `ElasticService.post` cannot set headers, and axios corrupts an ndjson body when the content type is `application/json`. Requests still go through the circuit breaker.
- Pass `max_concurrent_searches`, otherwise `_msearch` runs the sub-searches less concurrently than four parallel requests would.
- Cache the unified result under `CacheInfo.StatsCounts` (1s TTL) to preserve the caching the individual counts had, and keep honouring `noCache`.

## How to test
- `GET /network/stats` returns the same values as before; counts verified against the four individual `_count` queries on devnet (blocks, accounts, transactions, scResults all matched).
- Elastic receives one request per second for these counts instead of 2-4 per call.
- `GET /network/stats?noCache=true` bypasses the cache.
- `npm run test -- circuit.breaker.proxy` passes.
