### PR TITLE
Transfers/Transactions performance improvements

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.service.ts
@@ -29,7 +29,7 @@ export class TransactionActionMexRecognizerService implements TransactionActionR
     }
 
     const settings = await this.mexSettingsService.getSettings();
-    return settings !== undefined;
+    return settings != null;
   }
 
   async recognize(metadata: TransactionMetadata): Promise<TransactionAction | undefined> {

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -32,13 +32,21 @@ export class TransactionActionService {
     if (this.recognizers.length === 0) {
       const isMexActive = await this.mexRecognizer.isActive();
       if (isMexActive) {
-        this.recognizers.push(this.mexRecognizer);
+        this.recognizers = [
+          this.mexRecognizer,
+          this.metabondingRecognizer,
+          this.esdtNftRecognizer,
+          this.stakeRecognizer,
+          this.scCallRecognizer
+        ];
+      } else {
+        this.recognizers = [
+          this.metabondingRecognizer,
+          this.esdtNftRecognizer,
+          this.stakeRecognizer,
+          this.scCallRecognizer
+        ];
       }
-
-      this.recognizers.push(this.metabondingRecognizer);
-      this.recognizers.push(this.esdtNftRecognizer);
-      this.recognizers.push(this.stakeRecognizer);
-      this.recognizers.push(this.scCallRecognizer);
     }
 
     return this.recognizers;

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -28,25 +28,18 @@ export class TransactionActionService {
     private readonly metabondingRecognizer: MetabondingActionRecognizerService,
   ) { }
 
-  private async getRecognizers() {
+  private async getRecognizers(): Promise<TransactionActionRecognizerInterface[]> {
     if (this.recognizers.length === 0) {
       const isMexActive = await this.mexRecognizer.isActive();
-      if (isMexActive) {
-        this.recognizers = [
-          this.mexRecognizer,
-          this.metabondingRecognizer,
-          this.esdtNftRecognizer,
-          this.stakeRecognizer,
-          this.scCallRecognizer
-        ];
-      } else {
-        this.recognizers = [
-          this.metabondingRecognizer,
-          this.esdtNftRecognizer,
-          this.stakeRecognizer,
-          this.scCallRecognizer
-        ];
-      }
+
+      const recognizers = [
+        this.metabondingRecognizer,
+        this.esdtNftRecognizer,
+        this.stakeRecognizer,
+        this.scCallRecognizer,
+      ];
+
+      this.recognizers = isMexActive ? [this.mexRecognizer, ...recognizers] : recognizers;
     }
 
     return this.recognizers;

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -464,14 +464,10 @@ export class TransactionService {
     }
   }
 
-  // resolves the pending results for the whole page with a single batched cache read, instead of
-  // one round-trip per transaction
   private async applyPendingResults(transactions: Transaction[]): Promise<void> {
     const twentyMinutes = Constants.oneMinute() * 20 * 1000;
     const timestampLimit = (new Date().getTime() - twentyMinutes) / 1000;
 
-    // single pass: collect the recent transactions and their cache keys at the same time, instead
-    // of filtering and then mapping over the result
     const recentTransactions: Transaction[] = [];
     const keys: string[] = [];
     for (const transaction of transactions) {

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -18,7 +18,7 @@ import { GatewayComponentRequest } from 'src/common/gateway/entities/gateway.com
 import { TransactionActionService } from './transaction-action/transaction.action.service';
 import { TransactionDecodeDto } from './entities/dtos/transaction.decode.dto';
 import { TransactionStatus } from './entities/transaction.status';
-import { AddressUtils, BinaryUtils, Constants, PendingExecuter } from '@multiversx/sdk-nestjs-common';
+import { AddressUtils, BatchUtils, BinaryUtils, Constants, PendingExecuter } from '@multiversx/sdk-nestjs-common';
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import { TransactionUtils } from './transaction.utils';
@@ -47,6 +47,8 @@ import { TransactionActionCategory } from "./transaction-action/entities/transac
 
 @Injectable()
 export class TransactionService {
+  private readonly ACTION_BATCH_SIZE = 25;
+
   private readonly logger = new OriginLogger(TransactionService.name);
 
   constructor(
@@ -437,21 +439,69 @@ export class TransactionService {
       this.logger.error(error);
     }
 
-    for (const transaction of transactions) {
-      try {
-        transaction.action = await this.transactionActionService.getTransactionAction(transaction, options.withActionTransferValue);
+    await Promise.all([
+      this.applyTransactionActions(transactions, options.withActionTransferValue),
+      this.applyPendingResults(transactions),
+    ]);
 
-        transaction.pendingResults = await this.getPendingResults(transaction);
-        if (transaction.pendingResults === true) {
-          transaction.status = TransactionStatus.pending;
-        }
+    await this.applyAssets(transactions, { withUsernameAssets: options.withUsername });
+  }
+
+  private async applyTransactionActions(transactions: Transaction[], withActionTransferValue: boolean): Promise<void> {
+    const computeAction = async (transaction: Transaction) => {
+      try {
+        transaction.action = await this.transactionActionService.getTransactionAction(transaction, withActionTransferValue);
       } catch (error) {
         this.logger.error(`Unhandled error when processing transaction for transaction with hash '${transaction.txHash}'`);
         this.logger.error(error);
       }
+    };
+
+    const batches = BatchUtils.splitArrayIntoChunks(transactions, this.ACTION_BATCH_SIZE);
+
+    for (const batch of batches) {
+      await Promise.all(batch.map(transaction => computeAction(transaction)));
+    }
+  }
+
+  // resolves the pending results for the whole page with a single batched cache read, instead of
+  // one round-trip per transaction
+  private async applyPendingResults(transactions: Transaction[]): Promise<void> {
+    const twentyMinutes = Constants.oneMinute() * 20 * 1000;
+    const timestampLimit = (new Date().getTime() - twentyMinutes) / 1000;
+
+    // single pass: collect the recent transactions and their cache keys at the same time, instead
+    // of filtering and then mapping over the result
+    const recentTransactions: Transaction[] = [];
+    const keys: string[] = [];
+    for (const transaction of transactions) {
+      if (transaction.timestamp >= timestampLimit) {
+        recentTransactions.push(transaction);
+        keys.push(CacheInfo.TransactionPendingResults(transaction.txHash).key);
+      }
     }
 
-    await this.applyAssets(transactions, { withUsernameAssets: options.withUsername });
+    if (recentTransactions.length === 0) {
+      return;
+    }
+
+    let pendingResults: (boolean | undefined)[];
+    try {
+      pendingResults = await this.cachingService.getMany<boolean>(keys);
+    } catch (error) {
+      this.logger.error(`Unhandled error when fetching pending results for transactions with hashes '${recentTransactions.map(x => x.txHash).join(',')}'`);
+      this.logger.error(error);
+      return;
+    }
+
+    for (const [index, transaction] of recentTransactions.entries()) {
+      if (!pendingResults[index]) {
+        continue;
+      }
+
+      transaction.pendingResults = true;
+      transaction.status = TransactionStatus.pending;
+    }
   }
 
 
@@ -461,21 +511,6 @@ export class TransactionService {
         transaction.timestampMs = transaction.timestamp * 1000;
       }
     }
-  }
-
-  private async getPendingResults(transaction: Transaction): Promise<boolean | undefined> {
-    const twentyMinutes = Constants.oneMinute() * 20 * 1000;
-    const timestampLimit = (new Date().getTime() - twentyMinutes) / 1000;
-    if (transaction.timestamp < timestampLimit) {
-      return undefined;
-    }
-
-    const pendingResult = await this.cachingService.get(CacheInfo.TransactionPendingResults(transaction.txHash).key);
-    if (!pendingResult) {
-      return undefined;
-    }
-
-    return true;
   }
 
   async getExtraDetailsForTransactions(elasticTransactions: any[], transactions: Transaction[], queryOptions: TransactionQueryOptions): Promise<TransactionDetailed[]> {

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -471,19 +471,21 @@ export class TransactionService {
     const recentTransactions: Transaction[] = [];
     const keys: string[] = [];
     for (const transaction of transactions) {
-      if (transaction.timestamp >= timestampLimit) {
-        recentTransactions.push(transaction);
-        keys.push(CacheInfo.TransactionPendingResults(transaction.txHash).key);
+      if (transaction.timestamp < timestampLimit) {
+        continue;
       }
+
+      recentTransactions.push(transaction);
+      keys.push(CacheInfo.TransactionPendingResults(transaction.txHash).key);
     }
 
     if (recentTransactions.length === 0) {
       return;
     }
 
-    let pendingResults: (boolean | undefined)[];
+    let pendingResults: (string | undefined)[];
     try {
-      pendingResults = await this.cachingService.getMany<boolean>(keys);
+      pendingResults = await this.cachingService.getMany<string>(keys);
     } catch (error) {
       this.logger.error(`Unhandled error when fetching pending results for transactions with hashes '${recentTransactions.map(x => x.txHash).join(',')}'`);
       this.logger.error(error);

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -48,6 +48,7 @@ import { TransactionActionCategory } from "./transaction-action/entities/transac
 @Injectable()
 export class TransactionService {
   private readonly ACTION_BATCH_SIZE = 25;
+  private readonly PENDING_RESULTS_BATCH_SIZE = 100;
 
   private readonly logger = new OriginLogger(TransactionService.name);
 
@@ -469,36 +470,33 @@ export class TransactionService {
     const timestampLimit = (new Date().getTime() - twentyMinutes) / 1000;
 
     const recentTransactions: Transaction[] = [];
-    const keys: string[] = [];
     for (const transaction of transactions) {
       if (transaction.timestamp < timestampLimit) {
         continue;
       }
 
       recentTransactions.push(transaction);
-      keys.push(CacheInfo.TransactionPendingResults(transaction.txHash).key);
     }
 
     if (recentTransactions.length === 0) {
       return;
     }
 
-    let pendingResults: (string | undefined)[];
-    try {
-      pendingResults = await this.cachingService.getMany<string>(keys);
-    } catch (error) {
-      this.logger.error(`Unhandled error when fetching pending results for transactions with hashes '${recentTransactions.map(x => x.txHash).join(',')}'`);
-      this.logger.error(error);
-      return;
-    }
+    const batches = BatchUtils.splitArrayIntoChunks(recentTransactions, this.PENDING_RESULTS_BATCH_SIZE);
 
-    for (const [index, transaction] of recentTransactions.entries()) {
-      if (!pendingResults[index]) {
-        continue;
+    for (const batch of batches) {
+      const keys = batch.map(transaction => CacheInfo.TransactionPendingResults(transaction.txHash).key);
+
+      const pendingResults = await this.cachingService.getMany<string>(keys);
+
+      for (const [index, transaction] of batch.entries()) {
+        if (!pendingResults[index]) {
+          continue;
+        }
+
+        transaction.pendingResults = true;
+        transaction.status = TransactionStatus.pending;
       }
-
-      transaction.pendingResults = true;
-      transaction.status = TransactionStatus.pending;
     }
   }
 

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -225,6 +225,7 @@ describe('TransactionService', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValue({});
+      jest.spyOn(transactionActionService, 'getTransactionAction').mockResolvedValue(undefined);
     });
 
     it('should read the pending results of the whole page in a single batched call', async () => {

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -18,12 +18,16 @@ import { TransactionActionService } from "src/endpoints/transactions/transaction
 import { TransactionGetService } from "src/endpoints/transactions/transaction.get.service";
 import { TransactionPriceService } from "src/endpoints/transactions/transaction.price.service";
 import { TransactionService } from "src/endpoints/transactions/transaction.service";
+import { TransactionDetailed } from "src/endpoints/transactions/entities/transaction.detailed";
+import { TransactionStatus } from "src/endpoints/transactions/entities/transaction.status";
 import { UsernameService } from "src/endpoints/usernames/username.service";
 
 describe('TransactionService', () => {
   let service: TransactionService;
   let indexerService: IndexerService;
   let assetsService: AssetsService;
+  let cacheService: CacheService;
+  let transactionActionService: TransactionActionService;
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -67,6 +71,7 @@ describe('TransactionService', () => {
           provide: CacheService,
           useValue: {
             get: jest.fn(),
+            getMany: jest.fn().mockResolvedValue([]),
             getOrSet: jest.fn().mockImplementation(async (_key: string, getter: () => Promise<any>, _ttl: number) => {
               return await getter();
             }),
@@ -140,6 +145,8 @@ describe('TransactionService', () => {
     service = moduleRef.get<TransactionService>(TransactionService);
     indexerService = moduleRef.get<IndexerService>(IndexerService);
     assetsService = moduleRef.get<AssetsService>(AssetsService);
+    cacheService = moduleRef.get<CacheService>(CacheService);
+    transactionActionService = moduleRef.get<TransactionActionService>(TransactionActionService);
   });
 
   it('service should be defined', () => {
@@ -156,6 +163,110 @@ describe('TransactionService', () => {
       expect(result).toStrictEqual(200);
       expect(indexerService.getTransactionCountForAddress).toHaveBeenCalledWith(address);
       expect(indexerService.getTransactionCountForAddress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('processTransactions - action batching', () => {
+    const options = { withScamInfo: false, withUsername: false, withActionTransferValue: false };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValue({});
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([]);
+    });
+
+    it('should compute the action of every transaction, in batches', async () => {
+      const transactions = Array.from({ length: 60 }, (_, i) =>
+        Object.assign(new TransactionDetailed(), { txHash: `hash${i}`, timestamp: 1, value: '0', sender: 'erd1a', receiver: 'erd1b' }));
+
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      jest.spyOn(transactionActionService, 'getTransactionAction').mockImplementation(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise(resolve => setImmediate(resolve));
+        concurrent--;
+        return undefined;
+      });
+
+      await service.processTransactions(transactions, options);
+
+      expect(transactionActionService.getTransactionAction).toHaveBeenCalledTimes(60);
+      expect(maxConcurrent).toBeGreaterThan(1);
+      expect(maxConcurrent).toBeLessThanOrEqual(25);
+    });
+
+    it('should keep processing the page when the action of one transaction throws', async () => {
+      const transactions = [
+        Object.assign(new TransactionDetailed(), { txHash: 'hash1', timestamp: 1, value: '0', sender: 'erd1a', receiver: 'erd1b' }),
+        Object.assign(new TransactionDetailed(), { txHash: 'hash2', timestamp: 1, value: '0', sender: 'erd1a', receiver: 'erd1b' }),
+      ];
+
+      jest.spyOn(transactionActionService, 'getTransactionAction').mockImplementation((transaction: any) => {
+        if (transaction.txHash === 'hash1') {
+          return Promise.reject(new Error('boom'));
+        }
+        return Promise.resolve({ category: 'esdtNft' } as any);
+      });
+
+      await expect(service.processTransactions(transactions, options)).resolves.toBeUndefined();
+
+      expect(transactions[0].action).toBeUndefined();
+      expect(transactions[1].action).toBeDefined();
+    });
+  });
+
+  describe('processTransactions - pending results', () => {
+    const buildTransaction = (txHash: string, timestamp: number) =>
+      Object.assign(new TransactionDetailed(), { txHash, timestamp, value: '0', sender: 'erd1a', receiver: 'erd1b' });
+
+    const options = { withScamInfo: false, withUsername: false, withActionTransferValue: false };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(assetsService, 'getAllAccountAssets').mockResolvedValue({});
+    });
+
+    it('should read the pending results of the whole page in a single batched call', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const transactions = [buildTransaction('hash1', now), buildTransaction('hash2', now), buildTransaction('hash3', now)];
+
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([]);
+
+      await service.processTransactions(transactions, options);
+
+      expect(cacheService.getMany).toHaveBeenCalledTimes(1);
+      expect(cacheService.getMany).toHaveBeenCalledWith([
+        'transaction:pendingresults:hash1',
+        'transaction:pendingresults:hash2',
+        'transaction:pendingresults:hash3',
+      ]);
+    });
+
+    it('should mark only the transactions that have a cached pending result', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const transactions = [buildTransaction('hash1', now), buildTransaction('hash2', now)];
+
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([undefined, true]);
+
+      await service.processTransactions(transactions, options);
+
+      expect(transactions[0].pendingResults).toBeUndefined();
+      expect(transactions[0].status).not.toStrictEqual(TransactionStatus.pending);
+      expect(transactions[1].pendingResults).toStrictEqual(true);
+      expect(transactions[1].status).toStrictEqual(TransactionStatus.pending);
+    });
+
+    it('should skip transactions older than twenty minutes without querying the cache', async () => {
+      const old = Math.floor(Date.now() / 1000) - (25 * 60);
+      const transactions = [buildTransaction('hash1', old)];
+
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([]);
+
+      await service.processTransactions(transactions, options);
+
+      expect(cacheService.getMany).not.toHaveBeenCalled();
+      expect(transactions[0].pendingResults).toBeUndefined();
     });
   });
 

--- a/src/test/unit/services/transactions.spec.ts
+++ b/src/test/unit/services/transactions.spec.ts
@@ -217,8 +217,15 @@ describe('TransactionService', () => {
   });
 
   describe('processTransactions - pending results', () => {
+    const now = () => Math.floor(Date.now() / 1000);
+
     const buildTransaction = (txHash: string, timestamp: number) =>
       Object.assign(new TransactionDetailed(), { txHash, timestamp, value: '0', sender: 'erd1a', receiver: 'erd1b' });
+
+    const buildTransactions = (count: number) =>
+      Array.from({ length: count }, (_, index) => buildTransaction(`hash${index}`, now()));
+
+    const cacheMisses = (keys: string[]) => keys.map(() => null);
 
     const options = { withScamInfo: false, withUsername: false, withActionTransferValue: false };
 
@@ -229,10 +236,9 @@ describe('TransactionService', () => {
     });
 
     it('should read the pending results of the whole page in a single batched call', async () => {
-      const now = Math.floor(Date.now() / 1000);
-      const transactions = [buildTransaction('hash1', now), buildTransaction('hash2', now), buildTransaction('hash3', now)];
+      const transactions = [buildTransaction('hash1', now()), buildTransaction('hash2', now()), buildTransaction('hash3', now())];
 
-      jest.spyOn(cacheService, 'getMany').mockResolvedValue([]);
+      jest.spyOn(cacheService, 'getMany').mockImplementation((keys: string[]) => Promise.resolve(cacheMisses(keys)));
 
       await service.processTransactions(transactions, options);
 
@@ -245,10 +251,9 @@ describe('TransactionService', () => {
     });
 
     it('should mark only the transactions that have a cached pending result', async () => {
-      const now = Math.floor(Date.now() / 1000);
-      const transactions = [buildTransaction('hash1', now), buildTransaction('hash2', now)];
+      const transactions = [buildTransaction('hash1', now()), buildTransaction('hash2', now())];
 
-      jest.spyOn(cacheService, 'getMany').mockResolvedValue([undefined, true]);
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([null, 'hash2']);
 
       await service.processTransactions(transactions, options);
 
@@ -259,8 +264,7 @@ describe('TransactionService', () => {
     });
 
     it('should skip transactions older than twenty minutes without querying the cache', async () => {
-      const old = Math.floor(Date.now() / 1000) - (25 * 60);
-      const transactions = [buildTransaction('hash1', old)];
+      const transactions = [buildTransaction('hash1', now() - (25 * 60))];
 
       jest.spyOn(cacheService, 'getMany').mockResolvedValue([]);
 
@@ -269,6 +273,50 @@ describe('TransactionService', () => {
       expect(cacheService.getMany).not.toHaveBeenCalled();
       expect(transactions[0].pendingResults).toBeUndefined();
     });
+
+    it('should still look up transactions that do not have a timestamp yet', async () => {
+      // transactions served from the gateway are not in a block yet and carry no timestamp - they
+      // are exactly the pending ones, so the age check must let them through
+      const transaction = buildTransaction('hashPending', now());
+      (transaction as any).timestamp = undefined;
+
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue(['hashPending']);
+
+      await service.processTransactions([transaction], options);
+
+      expect(cacheService.getMany).toHaveBeenCalledWith(['transaction:pendingresults:hashPending']);
+      expect(transaction.pendingResults).toStrictEqual(true);
+      expect(transaction.status).toStrictEqual(TransactionStatus.pending);
+    });
+
+    it('should mark the right transactions on a page mixing recent and old ones', async () => {
+      const transactions = [
+        buildTransaction('old1', now() - (25 * 60)),
+        buildTransaction('recent1', now()),
+        buildTransaction('old2', now() - (25 * 60)),
+        buildTransaction('recent2', now()),
+      ];
+
+      jest.spyOn(cacheService, 'getMany').mockResolvedValue([null, 'recent2']);
+
+      await service.processTransactions(transactions, options);
+
+      expect(cacheService.getMany).toHaveBeenCalledWith([
+        'transaction:pendingresults:recent1',
+        'transaction:pendingresults:recent2',
+      ]);
+      expect(transactions.map(x => x.pendingResults)).toStrictEqual([undefined, undefined, undefined, true]);
+    });
+
+    it('should split a large page into batches of at most 100', async () => {
+      jest.spyOn(cacheService, 'getMany').mockImplementation((keys: string[]) => Promise.resolve(cacheMisses(keys)));
+
+      await service.processTransactions(buildTransactions(250), options);
+
+      const batchSizes = (cacheService.getMany as jest.Mock).mock.calls.map(call => call[0].length);
+      expect(batchSizes).toStrictEqual([100, 100, 50]);
+    });
+
   });
 
   describe('getTransactionCount', () => {


### PR DESCRIPTION
## Reasoning
- `processTransactions` issued one Redis `GET` per transaction to resolve pending results, so a single page meant N sequential round trips.
- Transaction actions were computed one at a time, serializing every cache / data-api call behind the previous transaction.
- Both are independent per transaction, so all of this page-level work was serialized for no reason.

## Proposed Changes
- Resolve pending results for the whole page with a single batched `getMany` call, keeping the existing 20-minute cutoff.
- Compute transaction actions in parallel batches of 25 (`BatchUtils.splitArrayIntoChunks`), preserving the per-transaction error handling so one failure cannot fail the page.
- Run the two independent stages concurrently, and build the recognizers list with a single atomic assignment so concurrent callers cannot observe a partial or duplicated list.

## How to test
- `npm run test:unit` — new tests cover the action batching, the batched pending-results lookup and the per-transaction error isolation.
- Diff responses before/after on `/transactions` and `/transfers` (including `withScResults`, `withOperations`, `withLogs`, `withUsername`, `withActionTransferValue`) — the payload must be identical.
- Check that recent pending transactions still report `pendingResults: true` / `status: pending`, and that MEX transactions still return their mex action rather than a generic `scCall`.
