### PR TITLE
Remove tokens response slice for identifiers filtering

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -126,7 +126,9 @@ export class TokenService {
 
     let tokens = await this.getFilteredTokens(filter);
 
-    tokens = tokens.slice(from, from + size);
+    if (!filter.identifiers) {
+      tokens = tokens.slice(from, from + size);
+    }
 
     for (const token of tokens) {
       this.applyTickerFromAssets(token);


### PR DESCRIPTION
## Reasoning
- when requested an array of identifiers on `/tokens` with more than 25 elements without a correspondent size, the elements over default 25 return size were excluded from the response 
  
## Proposed Changes
- do not slice the response if the request contains filtering by a specific array of token identifiers

## How to test
- `/tokens?identifiers=token1,token2,....,token30` should return an array of 30 tokens, without requesting a specific size of 30