### PR TITLE
handle token creation event

### DIFF
--- a/src/crons/transaction.processor/transaction.processor.module.ts
+++ b/src/crons/transaction.processor/transaction.processor.module.ts
@@ -10,6 +10,7 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionProcessorService } from './transaction.processor.service';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { PersistenceModule } from 'src/common/persistence/persistence.module';
+import { TokenModule } from 'src/endpoints/tokens/token.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { PersistenceModule } from 'src/common/persistence/persistence.module';
     NftModule,
     NftWorkerModule,
     ApiMetricsModule,
+    TokenModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -15,6 +15,7 @@ import { BinaryUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { PerformanceProfiler } from "@multiversx/sdk-nestjs-monitoring";
 import { StakeFunction } from "src/endpoints/transactions/transaction-action/recognizers/staking/entities/stake.function";
 import { ShardTransaction, TransactionProcessor } from "@multiversx/sdk-transaction-processor";
+import { TokenService } from "src/endpoints/tokens/token.service";
 
 @Injectable()
 export class TransactionProcessorService {
@@ -27,6 +28,7 @@ export class TransactionProcessorService {
     @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
     private readonly nodeService: NodeService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly tokenService: TokenService,
   ) { }
 
   @Cron('*/1 * * * * *')
@@ -46,6 +48,8 @@ export class TransactionProcessorService {
           const invalidatedOwnerKeys = await this.tryInvalidateOwner(transaction);
           const invalidatedCollectionPropertiesKeys = await this.tryInvalidateCollectionProperties(transaction);
           const invalidatedStakeTopUpKey = await this.tryInvalidateStakeTopup(transaction);
+
+          this.tryHandleTokenIssuance(transaction);
 
           allInvalidatedKeys.push(
             ...invalidatedTokenProperties,
@@ -151,5 +155,50 @@ export class TransactionProcessorService {
     await this.cachingService.deleteInCache(CacheInfo.StakeTopup(transaction.receiver).key);
 
     return [CacheInfo.StakeTopup(transaction.receiver).key];
+  }
+
+  async tryHandleTokenIssuance(transaction: ShardTransaction) {
+    if (transaction.status !== 'success' ||
+      !this.apiConfigService.getEsdtContractAddress().in(transaction.sender, transaction.receiver)) {
+      return;
+    }
+
+    const transactionFuncName = transaction.getDataFunctionName();
+    if (transactionFuncName === 'issue' && transaction.receiver === this.apiConfigService.getEsdtContractAddress()) {
+      this.cachingService.setLocal(
+        CacheInfo.TokenIssuancePendingRequestHash(transaction.hash).key,
+        transaction.hash,
+        CacheInfo.TokenIssuancePendingRequestHash(transaction.hash).ttl,
+      );
+    }
+    if (transactionFuncName === 'ESDTTransfer' &&
+      transaction.sender === this.apiConfigService.getEsdtContractAddress()) {
+      const txOriginalHash = transaction.originalTransactionHash;
+      if (txOriginalHash && this.cachingService.getLocal(CacheInfo.TokenIssuancePendingRequestHash(txOriginalHash).key)) {
+
+        let tokenIdentifier = undefined;
+        const dataArgs = transaction.getDataArgs();
+
+        if (dataArgs != null && dataArgs.length >= 0) {
+          tokenIdentifier = Buffer.from(dataArgs[0], 'hex').toString('utf-8');
+        }
+
+        if (tokenIdentifier) {
+          const token = await this.tokenService.getTokenRaw(tokenIdentifier);
+          if (token) {
+            this.logger.log(`Detected token issuance for token ${tokenIdentifier}`);
+            const tokens = await this.tokenService.getAllTokens();
+            const updatedTokens = [...tokens, token];
+            await this.cachingService.set(
+              CacheInfo.AllEsdtTokens.key,
+              updatedTokens.distinct(x => x.identifier),
+              CacheInfo.AllEsdtTokens.ttl
+            );
+
+            this.clientProxy.emit('deleteCacheKeys', [CacheInfo.AllEsdtTokens.key]);
+          }
+        }
+      }
+    }
   }
 }

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -49,7 +49,9 @@ export class TransactionProcessorService {
           const invalidatedCollectionPropertiesKeys = await this.tryInvalidateCollectionProperties(transaction);
           const invalidatedStakeTopUpKey = await this.tryInvalidateStakeTopup(transaction);
 
-          this.tryHandleTokenIssuance(transaction);
+          this.tryHandleTokenIssuance(transaction).catch((error) => {
+            this.logger.error(`Error handling token issuance for transaction ${transaction.hash}: ${error.message}`);
+          });
 
           allInvalidatedKeys.push(
             ...invalidatedTokenProperties,

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -44,6 +44,7 @@ import { MexPairService } from "../mex/mex.pair.service";
 import { MexPairState } from "../mex/entities/mex.pair.state";
 import { MexTokenType } from "../mex/entities/mex.token.type";
 import { NftSubType } from "../nfts/entities/nft.sub.type";
+import { NftCollection } from "../collections/entities/nft.collection";
 
 @Injectable()
 export class TokenService {
@@ -781,24 +782,104 @@ export class TokenService {
     const collections = await this.collectionService.getNftCollections(new QueryPagination({ from: 0, size: 10000 }), { type: [NftType.MetaESDT] });
 
     for (const collection of collections) {
-      tokens.push(new TokenDetailed({
-        type: TokenType.MetaESDT,
-        subType: collection.subType,
-        identifier: collection.collection,
-        name: collection.name,
-        timestamp: collection.timestamp,
-        owner: collection.owner,
-        decimals: collection.decimals,
-        canFreeze: collection.canFreeze,
-        canPause: collection.canPause,
-        canTransferNftCreateRole: collection.canTransferNftCreateRole,
-        canWipe: collection.canWipe,
-        canAddSpecialRoles: collection.canAddSpecialRoles,
-        canChangeOwner: collection.canChangeOwner,
-        canUpgrade: collection.canUpgrade,
-      }));
+      tokens.push(this.buildMetaEsdtToken(collection));
     }
 
+    await this.applyTokenDetails(tokens);
+
+    this.logger.log(`Sorting and finalizing ${tokens.length} tokens`);
+    tokens = tokens.sortedDescending(
+      token => token.assets ? 1 : 0,
+      token => token.marketCap ? 1 : 0,
+      token => token.isLowLiquidity || token.assets?.priceSource?.type === TokenAssetsPriceSourceType.customUrl ? 0 : (token.marketCap ?? 0),
+      token => token.transactions ?? 0,
+    );
+
+    tokens = [...tokens, await this.buildEgldToken()];
+
+    this.logger.log(`Total tokens processed: ${tokens.length}`);
+    return tokens;
+  }
+
+  async getTokenRaw(rawIdentifier: string): Promise<TokenDetailed | undefined> {
+    const identifier = this.normalizeIdentifierCase(rawIdentifier);
+
+    if (!TokenUtils.isToken(identifier)) {
+      return undefined;
+    }
+
+    if (identifier === this.egldIdentifierInMultiTransfer) {
+      return await this.buildEgldToken();
+    }
+
+    const token = await this.buildTokenFromProperties(identifier);
+    if (!token) {
+      return undefined;
+    }
+
+    await this.applyTokenDetails([token]);
+
+    return token;
+  }
+
+  private async buildTokenFromProperties(identifier: string): Promise<TokenDetailed | undefined> {
+    const properties = await this.esdtService.getEsdtTokenProperties(identifier);
+
+    if (properties?.type === EsdtType.FungibleESDT) {
+      const token = ApiUtils.mergeObjects(new TokenDetailed(), properties);
+      token.type = TokenType.FungibleESDT;
+
+      const assets = await this.assetsService.getTokenAssets(identifier);
+      if (assets && assets.name) {
+        token.name = assets.name;
+      }
+
+      return token;
+    }
+
+    const collection = await this.collectionService.getNftCollection(identifier);
+    if (collection && collection.type === NftType.MetaESDT) {
+      return this.buildMetaEsdtToken(collection);
+    }
+
+    return undefined;
+  }
+
+  private buildMetaEsdtToken(collection: NftCollection): TokenDetailed {
+    return new TokenDetailed({
+      type: TokenType.MetaESDT,
+      subType: collection.subType,
+      identifier: collection.collection,
+      name: collection.name,
+      timestamp: collection.timestamp,
+      owner: collection.owner,
+      decimals: collection.decimals,
+      canFreeze: collection.canFreeze,
+      canPause: collection.canPause,
+      canTransferNftCreateRole: collection.canTransferNftCreateRole,
+      canWipe: collection.canWipe,
+      canAddSpecialRoles: collection.canAddSpecialRoles,
+      canChangeOwner: collection.canChangeOwner,
+      canUpgrade: collection.canUpgrade,
+    });
+  }
+
+  private async buildEgldToken(): Promise<TokenDetailed> {
+    return new TokenDetailed({
+      identifier: this.egldIdentifierInMultiTransfer,
+      name: 'EGLD',
+      type: TokenType.FungibleESDT,
+      assets: await this.assetsService.getTokenAssets(this.egldIdentifierInMultiTransfer),
+      decimals: 18,
+      isLowLiquidity: false,
+      price: await this.dataApiService.getEgldPrice(),
+      supply: '0',
+      circulatingSupply: '0',
+      marketCap: 0,
+    });
+  }
+
+  private async applyTokenDetails(tokens: TokenDetailed[]): Promise<void> {
     await this.batchProcessTokens(tokens);
 
     const nonMetaEsdtTokens = tokens.filter(x => x.type !== TokenType.MetaESDT);
@@ -824,81 +905,58 @@ export class TokenService {
     this.logger.log(`Processing price sources and supply for ${tokens.length} tokens`);
     await ConcurrencyUtils.executeWithConcurrencyLimit(
       tokens,
-      async (token) => {
-        try {
-          const priceSourcetype = token.assets?.priceSource?.type;
-
-          if (priceSourcetype === TokenAssetsPriceSourceType.dataApi) {
-            const dataApiPrice = await this.dataApiService.getEsdtTokenPrice(token.identifier);
-            if (dataApiPrice) {
-              // keep DEX price if data api price is not available, otherwise override it
-              token.price = dataApiPrice;
-            }
-          } else if (priceSourcetype === TokenAssetsPriceSourceType.customUrl && token.assets?.priceSource?.url) {
-            const pathToPrice = token.assets?.priceSource?.path ?? "0.usdPrice";
-            const customHeaders = this.apiConfigService.getHeadersForCustomUrl(token.assets.priceSource.url);
-            const tokenData = await this.fetchTokenDataFromUrl(token.assets.priceSource.url, pathToPrice, customHeaders);
-
-            if (tokenData) {
-              token.price = tokenData;
-            }
-          }
-          if (!token.price && token.type === TokenType.FungibleESDT) {
-            try {
-              const dataApiPrice = await this.dataApiService.getEsdtTokenPrice(token.identifier);
-              if (dataApiPrice) {
-                token.price = dataApiPrice;
-                this.logger.log(`Applied dataAPI fallback for ${token.identifier} token with price ${dataApiPrice}`);
-              }
-            } catch (error) {
-              this.logger.error(`Error applying dataAPI fallback price for token ${token.identifier}: ${error}`);
-            }
-          }
-
-          const supply = await this.esdtService.getTokenSupply(token.identifier);
-          token.supply = supply.totalSupply;
-          token.circulatingSupply = supply.circulatingSupply;
-
-          if (token.price && token.circulatingSupply) {
-            token.marketCap = token.price * NumberUtils.denominateString(token.circulatingSupply, token.decimals);
-            // TODO: update this by checking the token's liquidity collateral
-            if (token.marketCap > this.thresholdFaultyMarketCap) {
-              this.logger.log(`Setting token market cap to 0 due to possibly faulty market cap. Token: ${token.identifier}. Circulating supply: ${token.circulatingSupply}. Price: ${token.price}. Market cap: ${token.marketCap}`);
-              token.marketCap = 0;
-            }
-          }
-        } catch (error) {
-          this.logger.error(`Error processing price/supply for token ${token.identifier}: ${error}`);
-        }
-      },
+      async (token) => await this.applyPriceAndSupply(token),
       50,
       'Token prices and supply calculation'
     );
+  }
 
-    this.logger.log(`Sorting and finalizing ${tokens.length} tokens`);
-    tokens = tokens.sortedDescending(
-      token => token.assets ? 1 : 0,
-      token => token.marketCap ? 1 : 0,
-      token => token.isLowLiquidity || token.assets?.priceSource?.type === TokenAssetsPriceSourceType.customUrl ? 0 : (token.marketCap ?? 0),
-      token => token.transactions ?? 0,
-    );
+  private async applyPriceAndSupply(token: TokenDetailed): Promise<void> {
+    try {
+      const priceSourcetype = token.assets?.priceSource?.type;
 
-    const egldToken = new TokenDetailed({
-      identifier: this.egldIdentifierInMultiTransfer,
-      name: 'EGLD',
-      type: TokenType.FungibleESDT,
-      assets: await this.assetsService.getTokenAssets(this.egldIdentifierInMultiTransfer),
-      decimals: 18,
-      isLowLiquidity: false,
-      price: await this.dataApiService.getEgldPrice(),
-      supply: '0',
-      circulatingSupply: '0',
-      marketCap: 0,
-    });
-    tokens = [...tokens, egldToken];
+      if (priceSourcetype === TokenAssetsPriceSourceType.dataApi) {
+        const dataApiPrice = await this.dataApiService.getEsdtTokenPrice(token.identifier);
+        if (dataApiPrice) {
+          // keep DEX price if data api price is not available, otherwise override it
+          token.price = dataApiPrice;
+        }
+      } else if (priceSourcetype === TokenAssetsPriceSourceType.customUrl && token.assets?.priceSource?.url) {
+        const pathToPrice = token.assets?.priceSource?.path ?? "0.usdPrice";
+        const customHeaders = this.apiConfigService.getHeadersForCustomUrl(token.assets.priceSource.url);
+        const tokenData = await this.fetchTokenDataFromUrl(token.assets.priceSource.url, pathToPrice, customHeaders);
 
-    this.logger.log(`Total tokens processed: ${tokens.length}`);
-    return tokens;
+        if (tokenData) {
+          token.price = tokenData;
+        }
+      }
+      if (!token.price && token.type === TokenType.FungibleESDT) {
+        try {
+          const dataApiPrice = await this.dataApiService.getEsdtTokenPrice(token.identifier);
+          if (dataApiPrice) {
+            token.price = dataApiPrice;
+            this.logger.log(`Applied dataAPI fallback for ${token.identifier} token with price ${dataApiPrice}`);
+          }
+        } catch (error) {
+          this.logger.error(`Error applying dataAPI fallback price for token ${token.identifier}: ${error}`);
+        }
+      }
+
+      const supply = await this.esdtService.getTokenSupply(token.identifier);
+      token.supply = supply.totalSupply;
+      token.circulatingSupply = supply.circulatingSupply;
+
+      if (token.price && token.circulatingSupply) {
+        token.marketCap = token.price * NumberUtils.denominateString(token.circulatingSupply, token.decimals);
+        // TODO: update this by checking the token's liquidity collateral
+        if (token.marketCap > this.thresholdFaultyMarketCap) {
+          this.logger.log(`Setting token market cap to 0 due to possibly faulty market cap. Token: ${token.identifier}. Circulating supply: ${token.circulatingSupply}. Price: ${token.price}. Market cap: ${token.marketCap}`);
+          token.marketCap = 0;
+        }
+      }
+    } catch (error) {
+      this.logger.error(`Error processing price/supply for token ${token.identifier}: ${error}`);
+    }
   }
 
   private extractData(data: any, path: string): any {

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -812,4 +812,11 @@ export class CacheInfo {
       ttl: Constants.oneMinute(),
     };
   }
+
+  static TokenIssuancePendingRequestHash(hash: string): CacheInfo {
+    return {
+      key: `tokenIssuancePendingRequestHash:${hash}`,
+      ttl: Constants.oneMinute(),
+    };
+  }
 }


### PR DESCRIPTION
## Reasoning
- Newly issued tokens only become visible in the API once the cache warmer rebuilds the entire ESDT token list, which runs every 2 minutes, so there is a noticeable delay after issuance.
- Rebuilding the whole list to pick up a single new token is expensive, and the enrichment logic lived inline in `getAllTokensRaw`, so it could not be reused for one token.

## Proposed Changes
- Extracted the per-token enrichment from `getAllTokensRaw` into reusable helpers: `applyTokenDetails`, `applyPriceAndSupply`, `buildMetaEsdtToken` and `buildEgldToken`. Behaviour of the bulk path is unchanged.
- Added `TokenService.getTokenRaw(identifier)`, which builds a single `TokenDetailed` (fungible from ESDT properties, MetaESDT from the collection) and runs it through the same pipeline as the bulk path.
- Added `tryHandleTokenIssuance` to the transaction processor: `issue` transactions sent to the ESDT contract are tracked in the local cache (`TokenIssuancePendingRequestHash`, 1 minute TTL), and when the matching `ESDTTransfer` callback comes back from the ESDT contract, the new token is fetched and appended to the cached `AllEsdtTokens` list, followed by a pubsub invalidation.
- Wired `TokenModule` into `TransactionProcessorModule` and added the new `CacheInfo.TokenIssuancePendingRequestHash` entry.

## How to test
- Issue a new token on devnet and query `GET /tokens/:identifier` and `GET /tokens?search=<ticker>` right after the issuance is confirmed — the token should be returned without waiting for the cache warmer cycle.
- Check the processor logs for `Detected token issuance for token <identifier>`.
- Compare `getTokenRaw` output for an existing fungible token and a MetaESDT token against the corresponding entry in the cached token list; they should match.
- Verify that `getTokenRaw` returns `undefined` for a malformed identifier and for an NFT/SFT collection identifier.
