### PR TITLE
Decrease WS broadcast interval mainnet

### DIFF
--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -10,7 +10,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 6000
+    broadcastIntervalMs: 600
   dataApi:
     enabled: false
     serviceUrl: 'https://data-api.multiversx.com'

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -25,7 +25,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 6000
+    broadcastIntervalMs: 600
   eventsNotifier:
     enabled: false
     port: 5674

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -25,7 +25,7 @@ features:
     port: 6002
     maxSubscriptionsPerInstance: 10000
     maxSubscriptionsPerClient: 10
-    broadcastIntervalMs: 6000
+    broadcastIntervalMs: 600
   eventsNotifier:
     enabled: false
     port: 5674


### PR DESCRIPTION
## Reasoning
- supernova will be activated on mainnet with 600 ms round time
  
## Proposed Changes
-  reduce WS subscriptions broadcast interval from 6s to 600ms

## How to test
- broadcast should happen 10x faster
