### PR TITLE
Token account dynamic meta esdt support

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -727,7 +727,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
   private buildTokenFilter(query: ElasticQuery, filter: TokenFilter): ElasticQuery {
     if (filter.includeMetaESDT === true) {
-      query = query.withMustMultiShouldCondition([TokenType.FungibleESDT, TokenType.MetaESDT], type => QueryType.Match('type', type));
+      query = query.withMustMultiShouldCondition([TokenType.FungibleESDT, TokenType.MetaESDT, TokenType.DynamicMetaESDT], type => QueryType.Match('type', type));
     } else {
       query = query.withMustNotCondition(QueryType.Exists('identifier'));
     }

--- a/src/common/indexer/entities/token.account.ts
+++ b/src/common/indexer/entities/token.account.ts
@@ -16,9 +16,16 @@ export interface TokenAccount extends ElasticSortable {
 
 export enum TokenType {
   FungibleESDT = 'FungibleESDT',
+
   NonFungibleESDT = 'NonFungibleESDT',
+  NonFungibleESDTv2 = 'NonFungibleESDTv2',
+  DynamicNonFungibleESDT = 'DynamicNonFungibleESDT',
+
   SemiFungibleESDT = 'SemiFungibleESDT',
+  DynamicSemiFungibleESDT = 'DynamicSemiFungibleESDT',
+
   MetaESDT = 'MetaESDT',
+  DynamicMetaESDT = 'DynamicMetaESDT',
 }
 
 registerEnumType(TokenType, {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -779,7 +779,7 @@ export class TokenService {
     }
 
     this.logger.log(`Starting to fetch all meta tokens`);
-    const collections = await this.collectionService.getNftCollections(new QueryPagination({ from: 0, size: 10000 }), { type: [NftType.MetaESDT] });
+    const collections = await this.collectionService.getNftCollections(new QueryPagination({ from: 0, size: 10000 }), { type: [NftType.MetaESDT], subType: [NftSubType.DynamicMetaESDT] });
 
     for (const collection of collections) {
       tokens.push(this.buildMetaEsdtToken(collection));

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -84,7 +84,7 @@ export class TokenService {
     const identifier = this.normalizeIdentifierCase(rawIdentifier);
     let token = tokens.find(x => x.identifier === identifier);
 
-    if (!TokenUtils.isToken(identifier) && !TokenUtils.isNft(identifier)) {
+    if (!TokenUtils.isToken(identifier)) {
       return undefined;
     }
 
@@ -258,6 +258,7 @@ export class TokenService {
 
   async getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     let tokens: TokenWithBalance[];
+
     if (AddressUtils.isSmartContractAddress(address)) {
       tokens = await this.getTokensForAddressFromElastic(address, queryPagination, filter);
     } else {
@@ -278,7 +279,7 @@ export class TokenService {
     const elasticTokens = await this.indexerService.getTokensForAddress(address, queryPagination, filter);
 
     const allTokens = await this.getAllTokens();
-
+    // console.log(allTokens)
     const allTokensIndexed = allTokens.toRecord<TokenDetailed>(token => token.identifier);
 
     const result: TokenWithBalance[] = [];
@@ -294,7 +295,7 @@ export class TokenService {
           attributes: elasticToken.data?.attributes,
           valueUsd: undefined,
         };
-
+        console.log(tokenWithBalance)
         this.applyValueUsd(tokenWithBalance);
 
         this.applyTickerFromAssets(tokenWithBalance);
@@ -314,6 +315,7 @@ export class TokenService {
 
   async getTokensForAddressFromGatewayWithElasticFallback(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     const isTrieTimeout = await this.cachingService.get<boolean>(CacheInfo.AddressEsdtTrieTimeout(address).key);
+
     if (isTrieTimeout) {
       return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
     }
@@ -1063,7 +1065,7 @@ export class TokenService {
 
   private async getAllTokensFromApi(): Promise<TokenDetailed[]> {
     try {
-      const { data } = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, { params: { size: 10000 } });
+      const { data } = await this.apiService.get(`${this.apiConfigService.getTokensFetchServiceUrl()}/tokens`, { params: { size: 10000, includeMetaESDT: true } });
 
       return data;
     } catch (error) {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -84,7 +84,7 @@ export class TokenService {
     const identifier = this.normalizeIdentifierCase(rawIdentifier);
     let token = tokens.find(x => x.identifier === identifier);
 
-    if (!TokenUtils.isToken(identifier)) {
+    if (!TokenUtils.isToken(identifier) && !TokenUtils.isNft(identifier)) {
       return undefined;
     }
 

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -779,7 +779,7 @@ export class TokenService {
     }
 
     this.logger.log(`Starting to fetch all meta tokens`);
-    const collections = await this.collectionService.getNftCollections(new QueryPagination({ from: 0, size: 10000 }), { type: [NftType.MetaESDT], subType: [NftSubType.DynamicMetaESDT] });
+    const collections = await this.collectionService.getNftCollections(new QueryPagination({ from: 0, size: 10000 }), { type: [NftType.MetaESDT] });
 
     for (const collection of collections) {
       tokens.push(this.buildMetaEsdtToken(collection));

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -258,7 +258,6 @@ export class TokenService {
 
   async getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     let tokens: TokenWithBalance[];
-
     if (AddressUtils.isSmartContractAddress(address)) {
       tokens = await this.getTokensForAddressFromElastic(address, queryPagination, filter);
     } else {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -279,7 +279,7 @@ export class TokenService {
     const elasticTokens = await this.indexerService.getTokensForAddress(address, queryPagination, filter);
 
     const allTokens = await this.getAllTokens();
-    // console.log(allTokens)
+
     const allTokensIndexed = allTokens.toRecord<TokenDetailed>(token => token.identifier);
 
     const result: TokenWithBalance[] = [];
@@ -295,7 +295,7 @@ export class TokenService {
           attributes: elasticToken.data?.attributes,
           valueUsd: undefined,
         };
-        console.log(tokenWithBalance)
+
         this.applyValueUsd(tokenWithBalance);
 
         this.applyTickerFromAssets(tokenWithBalance);
@@ -315,7 +315,6 @@ export class TokenService {
 
   async getTokensForAddressFromGatewayWithElasticFallback(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     const isTrieTimeout = await this.cachingService.get<boolean>(CacheInfo.AddressEsdtTrieTimeout(address).key);
-
     if (isTrieTimeout) {
       return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
     }

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -687,7 +687,7 @@ describe('Token Service', () => {
         const result = await tokenService.getAllTokens();
 
         expect(apiConfigService.isTokensFetchFeatureEnabled).toHaveBeenCalled();
-        expect(apiService.get).toHaveBeenCalledWith(`${url}/tokens`, { params: { size: 10000 } });
+        expect(apiService.get).toHaveBeenCalledWith(`${url}/tokens`, { params: { size: 10000, includeMetaESDT: true } });
         expect(result).toEqual(mockTokens);
       });
 


### PR DESCRIPTION
## Reasoning
- `GET /accounts/:address/tokens?includeMetaEsdt=true` returns an empty list for accounts holding dynamic meta tokens, while the gateway reports them correctly — e.g. `erd1qqqqqqqqqqqqqpgqz304m0s4684qj5fyh6rq8rqygywya4rzu7zsjy3crs` has 2 DynamicMetaESDT on `/address/:address/esdt` but none on the API.
- The indexer `TokenType` enum only knew the three legacy types, so the elastic filter behind `includeMetaESDT` matched `FungibleESDT` and `MetaESDT` only and dropped every dynamic token.

## Proposed Changes
- Added the dynamic ESDT variants (`NonFungibleESDTv2`, `DynamicNonFungibleESDT`, `DynamicSemiFungibleESDT`, `DynamicMetaESDT`) to the indexer `TokenType` enum.
- Included `DynamicMetaESDT` in the elastic token filter used when `includeMetaESDT` is set, so account token queries return them.
- Included dynamic meta collections when building the all-tokens list, and passed `includeMetaESDT=true` when tokens are fetched from the external tokens service.

## How to test
- `GET /accounts/erd1qqqqqqqqqqqqqpgqz304m0s4684qj5fyh6rq8rqygywya4rzu7zsjy3crs/tokens?includeMetaEsdt=true` returns the 2 DynamicMetaESDT tokens listed by `https://gateway.multiversx.com/address/erd1qqqqqqqqqqqqqpgqz304m0s4684qj5fyh6rq8rqygywya4rzu7zsjy3crs/esdt`.