### PR TITLE
Handle meta esdt collection creation

### DIFF
--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -198,7 +198,7 @@ export class TransactionProcessorService {
       return;
     }
 
-    await this.addTokenToCachedTokens(tokenIdentifier);
+    await this.addTokenToCachedTokens(tokenIdentifier, originalTxFuncName);
   }
 
   private getIssuedTokenIdentifier(transaction: ShardTransaction, originalTxFuncName: string): string | undefined {
@@ -220,13 +220,18 @@ export class TransactionProcessorService {
     return undefined;
   }
 
-  private async addTokenToCachedTokens(identifier: string) {
+  private async addTokenToCachedTokens(identifier: string, originalTxFuncName: string) {
     const token = await this.tokenService.getTokenRaw(identifier);
     if (!token) {
       return;
     }
+    if (originalTxFuncName === 'registerMetaESDT') {
+      this.logger.log(`Detected metaESDT collection creation ${identifier}`);
+    }
+    if (originalTxFuncName === 'issue') {
+      this.logger.log(`Detected ESDT token issuance ${identifier}`);
+    }
 
-    this.logger.log(`Detected token creation for token ${identifier}`);
 
     const tokens = await this.tokenService.getAllTokens();
     const updatedTokens = [...tokens, token];

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -160,47 +160,83 @@ export class TransactionProcessorService {
   }
 
   async tryHandleTokenIssuance(transaction: ShardTransaction) {
-    if (transaction.status !== 'success' ||
-      !this.apiConfigService.getEsdtContractAddress().in(transaction.sender, transaction.receiver)) {
+    const esdtContractAddress = this.apiConfigService.getEsdtContractAddress();
+
+    if (transaction.status !== 'success' || !esdtContractAddress.in(transaction.sender, transaction.receiver)) {
       return;
     }
 
     const transactionFuncName = transaction.getDataFunctionName();
-    if (transactionFuncName === 'issue' && transaction.receiver === this.apiConfigService.getEsdtContractAddress()) {
+
+    if (transaction.receiver === esdtContractAddress &&
+      transactionFuncName && ['issue', 'registerMetaESDT'].includes(transactionFuncName)) {
       this.cachingService.setLocal(
         CacheInfo.TokenIssuancePendingRequestHash(transaction.hash).key,
-        transaction.hash,
+        transactionFuncName,
         CacheInfo.TokenIssuancePendingRequestHash(transaction.hash).ttl,
       );
+
+      return;
     }
-    if (transactionFuncName === 'ESDTTransfer' &&
-      transaction.sender === this.apiConfigService.getEsdtContractAddress()) {
-      const txOriginalHash = transaction.originalTransactionHash;
-      if (txOriginalHash && this.cachingService.getLocal(CacheInfo.TokenIssuancePendingRequestHash(txOriginalHash).key)) {
 
-        let tokenIdentifier = undefined;
-        const dataArgs = transaction.getDataArgs();
-
-        if (dataArgs != null && dataArgs.length >= 0) {
-          tokenIdentifier = Buffer.from(dataArgs[0], 'hex').toString('utf-8');
-        }
-
-        if (tokenIdentifier) {
-          const token = await this.tokenService.getTokenRaw(tokenIdentifier);
-          if (token) {
-            this.logger.log(`Detected token issuance for token ${tokenIdentifier}`);
-            const tokens = await this.tokenService.getAllTokens();
-            const updatedTokens = [...tokens, token];
-            await this.cachingService.set(
-              CacheInfo.AllEsdtTokens.key,
-              updatedTokens.distinct(x => x.identifier),
-              CacheInfo.AllEsdtTokens.ttl
-            );
-
-            this.clientProxy.emit('deleteCacheKeys', [CacheInfo.AllEsdtTokens.key]);
-          }
-        }
-      }
+    if (transaction.sender !== esdtContractAddress) {
+      return;
     }
+
+    const txOriginalHash = transaction.originalTransactionHash;
+    if (!txOriginalHash) {
+      return;
+    }
+
+    const originalTxFuncName = this.cachingService.getLocal<string>(CacheInfo.TokenIssuancePendingRequestHash(txOriginalHash).key);
+    if (!originalTxFuncName) {
+      return;
+    }
+
+    const tokenIdentifier = this.getIssuedTokenIdentifier(transaction, originalTxFuncName);
+    if (!tokenIdentifier) {
+      return;
+    }
+
+    await this.addTokenToCachedTokens(tokenIdentifier);
+  }
+
+  private getIssuedTokenIdentifier(transaction: ShardTransaction, originalTxFuncName: string): string | undefined {
+    const dataArgs = transaction.getDataArgs();
+    if (!dataArgs || dataArgs.length === 0) {
+      return undefined;
+    }
+
+    // on 'issue', the esdt contract sends the issued supply back as 'ESDTTransfer@<identifier>@<amount>'
+    if (transaction.getDataFunctionName() === 'ESDTTransfer' && originalTxFuncName === 'issue') {
+      return BinaryUtils.hexToString(dataArgs[0]);
+    }
+
+    // on 'registerMetaESDT', the esdt contract answers with '@6f6b@<identifier>', where '6f6b' is 'ok'
+    if (dataArgs[0] === BinaryUtils.stringToHex('ok') && originalTxFuncName === 'registerMetaESDT') {
+      return BinaryUtils.hexToString(dataArgs[1]);
+    }
+
+    return undefined;
+  }
+
+  private async addTokenToCachedTokens(identifier: string) {
+    const token = await this.tokenService.getTokenRaw(identifier);
+    if (!token) {
+      return;
+    }
+
+    this.logger.log(`Detected token creation for token ${identifier}`);
+
+    const tokens = await this.tokenService.getAllTokens();
+    const updatedTokens = [...tokens, token];
+
+    await this.cachingService.set(
+      CacheInfo.AllEsdtTokens.key,
+      updatedTokens.distinct(x => x.identifier),
+      CacheInfo.AllEsdtTokens.ttl,
+    );
+
+    this.clientProxy.emit('deleteCacheKeys', [CacheInfo.AllEsdtTokens.key]);
   }
 }


### PR DESCRIPTION
## Reasoning
- MetaESDT collection properties are served from the cached all-tokens list, which is only rebuilt by the cache warmer every 2 minutes.
- When a meta ESDT is requested for an account, its collection is looked up in that list, and the token is skipped entirely if the collection is not there yet.
- As a result, a freshly created collection and its tokens stay invisible in the API for up to 2 minutes after the registration transaction is confirmed.

## Proposed Changes
- Track `registerMetaESDT` calls to the ESDT contract in the local pending cache, next to the existing `issue` flow, storing the originating function name.
- Match the smart contract result back to the original transaction: `ESDTTransfer@<identifier>@<amount>` for `issue`, `@6f6b@<identifier>` ("ok") for `registerMetaESDT`, and resolve the identifier accordingly.
- Extract the shared "fetch the token and append it to the cached token list" logic into a reusable method, with a distinct log line per flow.

## How to test
- Register a meta ESDT collection and a meta ESDT token, then immediately query `GET /accounts/:address/tokens?includeMetaEsdt=true` — the new token should be returned without waiting for the cache warmer.
- `GET /tokens/:identifier` resolves for the newly registered collection, and the processor logs `Detected metaESDT collection creation <identifier>`.
- Regression: issue a regular fungible token and confirm it still appears instantly, with the log `Detected ESDT token issuance <identifier>`.
