### PR TITLE
Upgrade sdk transaction processor to 0.1.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@multiversx/sdk-nestjs-monitoring": "^7.3.0",
         "@multiversx/sdk-nestjs-rabbitmq": "^7.3.0",
         "@multiversx/sdk-nestjs-redis": "^7.3.0",
-        "@multiversx/sdk-transaction-processor": "^0.1.35",
+        "@multiversx/sdk-transaction-processor": "^0.1.36",
         "@nestjs/apollo": "^13.3.0",
         "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
@@ -3722,9 +3722,9 @@
       "license": "MIT"
     },
     "node_modules/@multiversx/sdk-transaction-processor": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-transaction-processor/-/sdk-transaction-processor-0.1.35.tgz",
-      "integrity": "sha512-zbj4zNYhIxjlnxy7/p7so4IroOd+Z3QtIvFkKJEg8HMGSAuF6dObmrmc4dsx8nzG97rFpOLJ7iSyE8Xk9sCvrQ==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-transaction-processor/-/sdk-transaction-processor-0.1.36.tgz",
+      "integrity": "sha512-tIBoHJCEYuyPqxbtY+IXvr5CfnMS8uLpbSOdPkFivP8d+yhct25vyVmZVgLPQSXKoJZH6dgAqGSLdUztppWuGw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^1.7.4"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@multiversx/sdk-nestjs-monitoring": "^7.3.0",
     "@multiversx/sdk-nestjs-rabbitmq": "^7.3.0",
     "@multiversx/sdk-nestjs-redis": "^7.3.0",
-    "@multiversx/sdk-transaction-processor": "^0.1.35",
+    "@multiversx/sdk-transaction-processor": "^0.1.36",
     "@nestjs/apollo": "^13.3.0",
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",


### PR DESCRIPTION
## Reasoning
- a new version of sdk transaction processor is available
  
## Proposed Changes
- upgrade sdk transaction processor to the latest version

## How to test
- should work the same
