### PR TITLE
Check tokens created within all tokens processing time window

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -813,6 +813,7 @@ export class TokenService {
     // processing all tokens takes tens of seconds, so re-fetch the token list and
     // process only the tokens created in the meantime, instead of waiting for the next refresh
     try {
+      const startFetch = Date.now();
       const processedIdentifiers = new Set(tokens.map(token => token.identifier));
       const latestTokens = await this.fetchAllTokensWithoutDetails();
       const newTokens = latestTokens.filter(token => !processedIdentifiers.has(token.identifier));
@@ -821,10 +822,13 @@ export class TokenService {
         return;
       }
 
-      this.logger.log(`Processing ${newTokens.length} tokens created while processing all tokens`);
+      const startProcessing = Date.now();
       await this.applyTokenDetails(newTokens);
 
       tokens.push(...newTokens);
+
+      const endProcessing = Date.now();
+      this.logger.log(`Processed ${newTokens.length} tokens created while processing all tokens in ${endProcessing - startProcessing}ms (${endProcessing - startFetch}ms including re-fetch)`);
     } catch (error) {
       this.logger.error('Could not apply tokens created while processing all tokens');
       this.logger.error(error);

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -813,7 +813,7 @@ export class TokenService {
     // processing all tokens takes tens of seconds, so re-fetch the token list and
     // process only the tokens created in the meantime, instead of waiting for the next refresh
     try {
-      const startFetch = Date.now();
+      const startFetchAndProcess = Date.now();
       const processedIdentifiers = new Set(tokens.map(token => token.identifier));
       const latestTokens = await this.fetchAllTokensWithoutDetails();
       const newTokens = latestTokens.filter(token => !processedIdentifiers.has(token.identifier));
@@ -822,13 +822,12 @@ export class TokenService {
         return;
       }
 
-      const startProcessing = Date.now();
       await this.applyTokenDetails(newTokens);
 
       tokens.push(...newTokens);
 
-      const endProcessing = Date.now();
-      this.logger.log(`Processed ${newTokens.length} tokens created while processing all tokens in ${endProcessing - startProcessing}ms (${endProcessing - startFetch}ms including re-fetch)`);
+      const endFetchAndProcess = Date.now();
+      this.logger.log(`Processed ${newTokens.length} tokens created while processing all tokens in ${endFetchAndProcess - startFetchAndProcess}ms`);
     } catch (error) {
       this.logger.error('Could not apply tokens created while processing all tokens');
       this.logger.error(error);

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -761,9 +761,30 @@ export class TokenService {
     }
 
     this.logger.log(`Starting to fetch all tokens`);
+    let tokens = await this.fetchAllTokensWithoutDetails();
+
+    await this.applyTokenDetails(tokens);
+
+    await this.applyTokensCreatedDuringProcessing(tokens);
+
+    this.logger.log(`Sorting and finalizing ${tokens.length} tokens`);
+    tokens = tokens.sortedDescending(
+      token => token.assets ? 1 : 0,
+      token => token.marketCap ? 1 : 0,
+      token => token.isLowLiquidity || token.assets?.priceSource?.type === TokenAssetsPriceSourceType.customUrl ? 0 : (token.marketCap ?? 0),
+      token => token.transactions ?? 0,
+    );
+
+    tokens = [...tokens, await this.buildEgldToken()];
+
+    this.logger.log(`Total tokens processed: ${tokens.length}`);
+    return tokens;
+  }
+
+  private async fetchAllTokensWithoutDetails(): Promise<TokenDetailed[]> {
     const startFungible = Date.now();
     const tokensProperties = await this.esdtService.getAllFungibleTokenProperties();
-    let tokens = tokensProperties.map(properties => ApiUtils.mergeObjects(new TokenDetailed(), properties));
+    const tokens = tokensProperties.map(properties => ApiUtils.mergeObjects(new TokenDetailed(), properties));
     this.logger.log(`Fetched ${tokens.length} fungible tokens in ${Date.now() - startFungible}ms`);
 
     const allAssets = await this.assetsService.getAllTokenAssets();
@@ -785,20 +806,29 @@ export class TokenService {
       tokens.push(this.buildMetaEsdtToken(collection));
     }
 
-    await this.applyTokenDetails(tokens);
-
-    this.logger.log(`Sorting and finalizing ${tokens.length} tokens`);
-    tokens = tokens.sortedDescending(
-      token => token.assets ? 1 : 0,
-      token => token.marketCap ? 1 : 0,
-      token => token.isLowLiquidity || token.assets?.priceSource?.type === TokenAssetsPriceSourceType.customUrl ? 0 : (token.marketCap ?? 0),
-      token => token.transactions ?? 0,
-    );
-
-    tokens = [...tokens, await this.buildEgldToken()];
-
-    this.logger.log(`Total tokens processed: ${tokens.length}`);
     return tokens;
+  }
+
+  private async applyTokensCreatedDuringProcessing(tokens: TokenDetailed[]): Promise<void> {
+    // processing all tokens takes tens of seconds, so re-fetch the token list and
+    // process only the tokens created in the meantime, instead of waiting for the next refresh
+    try {
+      const processedIdentifiers = new Set(tokens.map(token => token.identifier));
+      const latestTokens = await this.fetchAllTokensWithoutDetails();
+      const newTokens = latestTokens.filter(token => !processedIdentifiers.has(token.identifier));
+
+      if (newTokens.length === 0) {
+        return;
+      }
+
+      this.logger.log(`Processing ${newTokens.length} tokens created while processing all tokens`);
+      await this.applyTokenDetails(newTokens);
+
+      tokens.push(...newTokens);
+    } catch (error) {
+      this.logger.error('Could not apply tokens created while processing all tokens');
+      this.logger.error(error);
+    }
   }
 
   async getTokenRaw(rawIdentifier: string): Promise<TokenDetailed | undefined> {

--- a/src/test/unit/services/tokens.spec.ts
+++ b/src/test/unit/services/tokens.spec.ts
@@ -723,7 +723,8 @@ describe('Token Service', () => {
         expect(apiConfigService.isTokensFetchFeatureEnabled).toHaveBeenCalled();
         expect(esdtService.getAllFungibleTokenProperties).toHaveBeenCalled();
 
-        expect(assetsService.getAllTokenAssets).toHaveBeenCalledTimes(1);
+        // the token list is fetched once for processing and once more to catch tokens created in the meantime
+        expect(assetsService.getAllTokenAssets).toHaveBeenCalledTimes(2);
 
         mockTokens.forEach(mockToken => {
           mockToken.name = mockTokenAssets.name;
@@ -796,6 +797,67 @@ describe('Token Service', () => {
         expect(egldToken?.price).toBe(100);
         expect(egldToken?.supply).toBe('0');
         expect(egldToken?.circulatingSupply).toBe('0');
+      });
+
+      describe('tokens created while processing all tokens', () => {
+        const mockTokenSupply: Partial<EsdtSupply> = { totalSupply: '1000', circulatingSupply: '1000' };
+
+        beforeEach(() => {
+          jest.spyOn(apiConfigService, 'isTokensFetchFeatureEnabled').mockReturnValue(false);
+          jest.spyOn(assetsService, 'getAllTokenAssets').mockResolvedValue({});
+          jest.spyOn(assetsService, 'getTokenAssets').mockResolvedValue(undefined);
+
+          jest.spyOn(tokenService as any, 'batchProcessTokens').mockImplementation(() => Promise.resolve());
+          jest.spyOn(tokenService as any, 'applyMexLiquidity').mockImplementation(() => Promise.resolve());
+          jest.spyOn(tokenService as any, 'applyMexPrices').mockImplementation(() => Promise.resolve());
+          jest.spyOn(tokenService as any, 'applyMexPairType').mockImplementation(() => Promise.resolve());
+          jest.spyOn(tokenService as any, 'applyMexPairTradesCount').mockImplementation(() => Promise.resolve());
+          jest.spyOn(cacheService as any, 'batchApplyAll').mockImplementation(() => Promise.resolve());
+          jest.spyOn(dataApiService, 'getEsdtTokenPrice').mockResolvedValue(undefined);
+          jest.spyOn(dataApiService, 'getEgldPrice').mockResolvedValue(100);
+          jest.spyOn(esdtService, 'getTokenSupply').mockResolvedValue(mockTokenSupply as EsdtSupply);
+        });
+
+        it('should process only the tokens created in the meantime and include them in the result', async () => {
+          jest.spyOn(esdtService, 'getAllFungibleTokenProperties')
+            .mockResolvedValueOnce([new TokenProperties({ identifier: 'OLD-111111' })])
+            .mockResolvedValueOnce([new TokenProperties({ identifier: 'OLD-111111' }), new TokenProperties({ identifier: 'NEW-222222' })]);
+          jest.spyOn(collectionService, 'getNftCollections')
+            .mockResolvedValueOnce([{ collection: 'OLDMETA-333333' } as NftCollection])
+            .mockResolvedValueOnce([{ collection: 'OLDMETA-333333' } as NftCollection, { collection: 'NEWMETA-444444' } as NftCollection]);
+
+          // snapshot the identifiers at call time, since the processed array is extended afterwards
+          const processedBatches: string[][] = [];
+          jest.spyOn(tokenService as any, 'batchProcessTokens').mockImplementation((tokens: any) => {
+            processedBatches.push(tokens.map((t: TokenDetailed) => t.identifier));
+            return Promise.resolve();
+          });
+
+          const result = await tokenService.getAllTokensRaw();
+
+          expect(processedBatches).toEqual([
+            ['OLD-111111', 'OLDMETA-333333'],
+            ['NEW-222222', 'NEWMETA-444444'],
+          ]);
+
+          expect(result.map(t => t.identifier).sort()).toEqual(['EGLD-000000', 'NEW-222222', 'NEWMETA-444444', 'OLD-111111', 'OLDMETA-333333']);
+
+          const newToken = result.find(t => t.identifier === 'NEW-222222');
+          expect(newToken?.type).toBe(TokenType.FungibleESDT);
+          expect(newToken?.supply).toBe(mockTokenSupply.totalSupply);
+        });
+
+        it('should keep the already processed tokens if fetching the latest tokens fails', async () => {
+          jest.spyOn(esdtService, 'getAllFungibleTokenProperties')
+            .mockResolvedValueOnce([new TokenProperties({ identifier: 'OLD-111111' })])
+            .mockRejectedValueOnce(new Error('elastic unavailable'));
+          jest.spyOn(collectionService, 'getNftCollections').mockResolvedValue([{ collection: 'OLDMETA-333333' } as NftCollection]);
+
+          const result = await tokenService.getAllTokensRaw();
+
+          expect((tokenService as any).batchProcessTokens).toHaveBeenCalledTimes(1);
+          expect(result.map(t => t.identifier).sort()).toEqual(['EGLD-000000', 'OLD-111111', 'OLDMETA-333333']);
+        });
       });
     });
 


### PR DESCRIPTION
## Reasoning
- `getAllTokensRaw`, run by the cache warmer every 2 minutes, takes tens of seconds: it fetches the token list once at the start and then processes every token. Any token created after that initial fetch is missing from the result until the next refresh.
- This also races with the token creation handler in the transaction processor. If warming starts at `t1`, a token is created at `t2` and appended to the cached list by the transaction processor, and warming finishes at `t3` (`t1 < t2 < t3`), the warmer overwrites the cache with a list that does not contain the new token. The token appears and then disappears until the next refresh.

## Proposed Changes
- After the full processing pass, re-fetch the fungible token properties and MetaESDT collections, and process only the tokens that were not in the initial list. They are merged in before sorting.
- This narrows the window for both issues from the whole processing time (tens of seconds) to the duration of the second, much smaller pass (a few seconds at most).
- If the second fetch fails, the error is logged and the already processed list is still returned, so a failure there cannot discard the full refresh.
- Extracted the list fetch into `fetchAllTokensWithoutDetails` so both passes share it.

## How to test
- Run `npx jest src/test/unit/services/tokens.spec.ts`. The new cases check that only tokens created in the meantime are processed in the second pass and that they are included in the result, and that a failing second fetch keeps the already processed tokens.
- On devnet, issue a token or register a MetaESDT collection while the `All Tokens invalidations` cron is running. The token should still be in `GET /tokens` after the warmer finishes, and the logs should show `Processing N tokens created while processing all tokens`.
- When no tokens are created during a refresh, `GET /tokens` returns the same count and order as before.
